### PR TITLE
ws-protocol server, ROS2 msgdef lookup, ROS2 foxglove_bridge implementation

### DIFF
--- a/.devcontainer/Dockerfile.ros1
+++ b/.devcontainer/Dockerfile.ros1
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-rosinstall-generator \
   python3-wstool \
   build-essential \
+  nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \

--- a/.devcontainer/Dockerfile.ros2
+++ b/.devcontainer/Dockerfile.ros2
@@ -4,6 +4,7 @@ FROM ros:humble-ros-core
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   python3-colcon-common-extensions \
+  nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \

--- a/.devcontainer/Dockerfile.ros2
+++ b/.devcontainer/Dockerfile.ros2
@@ -15,5 +15,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Create a ROS 2 workspace
 RUN mkdir -p /ros2_ws/src/ros-foxglove-bridge
 
+SHELL ["/bin/bash", "-c"]
+
+# Add aliases to .bashrc
+RUN echo $'\
+alias build_debug="colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n\
+alias build_release="colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release"\n\
+alias foxglove_bridge="source /ros2_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge --ros-args --log-level debug"\n\
+' >> ~/.bashrc
+
 # Source the ROS environment in .bashrc
 RUN echo "source /opt/ros/humble/setup.bash" >> /root/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,3 +1,4 @@
+// -*- jsonc -*-
 {
   // ROS 2 dev environment
   "name": "ROS 2",

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
   // Shared configuration between ROS 1 and ROS 2 environments
   "context": "..",
   "forwardPorts": [
-    8080
+    8765
   ],
   "customizations": {
     "vscode": {

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,6 @@ jobs:
         include:
           - ros_distribution: melodic
           - ros_distribution: noetic
-          - ros_distribution: foxy
           - ros_distribution: galactic
           - ros_distribution: humble
           - ros_distribution: rolling

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,3 +1,4 @@
+// -*- jsonc -*-
 {
   "configurations": [
     {

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -14,7 +14,7 @@
           "/usr/include"
         ]
       },
-      "defines": [],
+      "defines": ["ASIO_STANDALONE"],
       "cppStandard": "c++17"
     }
   ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,3 +1,4 @@
+// -*- jsonc -*-
 {
   // Use IntelliSense to learn about possible attributes.
   // Hover to view descriptions of existing attributes.

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,18 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [{
+    "name": "C++ Debug",
+    "type": "cppdbg",
+    "request": "launch",
+    "program": "${workspaceFolder}/build/foxglove_bridge/foxglove_bridge",
+    "args": [],
+    "stopAtEntry": false,
+    "cwd": "${workspaceFolder}",
+    "environment": [],
+    "externalConsole": false,
+    "MIMode": "gdb",
+  }]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,4 @@
+// -*- jsonc -*-
 {
   "C_Cpp.autoAddFileAssociations": false,
   "editor.defaultFormatter": "xaver.clang-format",

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,15 @@
 cmake_minimum_required(VERSION 3.10.2)
 
-PROJECT(foxglove_bridge LANGUAGES CXX VERSION 0.0.1)
+project(foxglove_bridge LANGUAGES CXX VERSION 0.0.1)
 
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 
-find_package(Threads REQUIRED)
+find_package(nlohmann_json REQUIRED)
 find_package(OpenSSL REQUIRED)
+find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
 
 if(NOT CMAKE_BUILD_TYPE)
@@ -20,10 +21,6 @@ if(CMAKE_BUILD_TYPE STREQUAL "Debug")
   if(NOT MSVC)
     set(OPTIMIZATION_FLAGS "${OPTIMIZATION_FLAGS} -O0")
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -fno-omit-frame-pointer")
-
-    ## Set gcov flags
-    set(CMAKE_CXX_FLAGS "-fprofile-arcs -ftest-coverage")
-    set(CMAKE_EXE_LINKER_FLAGS "-lgcov")
   endif()
   message("-- Configuring debug build")
 else()
@@ -34,7 +31,7 @@ endif()
 if(MSVC)
   set(DESIRED_WARNINGS "-WX")
 else()
-  set(DESIRED_WARNINGS "-Wall -Wextra -Wconversion -Wunreachable-code -Wuninitialized -pedantic-errors -Wold-style-cast -Wno-error=unused-variable -Wshadow -Wfloat-equal")
+  set(DESIRED_WARNINGS "-Wall -Wextra -Wconversion -Wunreachable-code -Wuninitialized -pedantic-errors -Wold-style-cast -Wno-error=unused-variable -Wfloat-equal")
   if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
     set(DESIRED_WARNINGS "${DESIRED_WARNINGS} -Wmost")
   endif()
@@ -48,6 +45,13 @@ IF(NOT WIN32 AND ENABLE_ASAN)
   set(CMAKE_LINKER_FLAGS "${CMAKE_LINKER_FLAGS} -fno-omit-frame-pointer -fsanitize=address")
 endif()
 
+# Detect big-endian architectures
+include(TestBigEndian)
+TEST_BIG_ENDIAN(ENDIAN)
+if (ENDIAN)
+  add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
+endif()
+
 # Build the foxglove_bridge_base library
 add_library(foxglove_bridge_base STATIC
   foxglove_bridge_base/src/foxglove_bridge.cpp
@@ -57,7 +61,13 @@ target_include_directories(foxglove_bridge_base
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>
     $<INSTALL_INTERFACE:include>
 )
-target_link_libraries(foxglove_bridge_base OpenSSL::Crypto OpenSSL::SSL ${CMAKE_THREAD_LIBS_INIT})
+target_link_libraries(foxglove_bridge_base
+  nlohmann_json::nlohmann_json
+  OpenSSL::Crypto
+  OpenSSL::SSL
+  websocketpp::websocketpp
+  ${CMAKE_THREAD_LIBS_INIT}
+)
 
 message(STATUS "ROS_VERSION: " $ENV{ROS_VERSION})
 if("$ENV{ROS_VERSION}" STREQUAL "1")
@@ -89,7 +99,10 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     find_package(ament_cmake REQUIRED)
     find_package(rclcpp REQUIRED)
 
-    add_executable(foxglove_bridge ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp)
+    add_executable(foxglove_bridge
+      ros2_foxglove_bridge/src/message_definition_cache.cpp
+      ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+    )
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${rclcpp_INCLUDE_DIRS})
     target_link_libraries(foxglove_bridge foxglove_bridge_base ${rclcpp_LIBRARIES})
   else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json REQUIRED CONFIG PATHS "/usr/lib/cmake/")
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -62,10 +62,9 @@ target_include_directories(foxglove_bridge_base
     $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(foxglove_bridge_base
-  nlohmann_json::nlohmann_json
+  nlohmann_json
   OpenSSL::Crypto
   OpenSSL::SSL
-  websocketpp::websocketpp
   ${CMAKE_THREAD_LIBS_INIT}
 )
 

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python3-rosdep \
   python3-wstool \
   build-essential \
+  nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \

--- a/Dockerfile.ros1bionic
+++ b/Dockerfile.ros1bionic
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   python-rosdep \
   python-wstool \
   build-essential \
+  nlohmann-json-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -6,6 +6,7 @@ ARG ROS_DISTRIBUTION=humble
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   python3-colcon-common-extensions \
+  nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \

--- a/Makefile
+++ b/Makefile
@@ -16,10 +16,6 @@ melodic:
 noetic:
 	docker build -t foxglove_bridge_noetic -f Dockerfile.ros1 --build-arg ROS_DISTRIBUTION=noetic .
 
-.PHONY: foxy
-foxy:
-	docker build -t foxglove_bridge_foxy -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=foxy .
-
 .PHONY: galactic
 galactic:
 	docker build -t foxglove_bridge_galactic -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=galactic .
@@ -41,7 +37,6 @@ clean:
 	docker rmi -f foxglove_bridge_ros2
 	docker rmi -f foxglove_bridge_melodic
 	docker rmi -f foxglove_bridge_noetic
-	docker rmi -f foxglove_bridge_foxy
 	docker rmi -f foxglove_bridge_galactic
 	docker rmi -f foxglove_bridge_humble
 	docker rmi -f foxglove_bridge_rolling
@@ -54,10 +49,6 @@ melodic-test: melodic
 .PHONY: noetic-test
 noetic-test: noetic
 	docker run -t --rm foxglove_bridge_noetic catkin_make run_tests
-
-.PHONY: foxy-test
-foxy-test: foxy
-	docker run -t --rm foxglove_bridge_foxy colcon test --event-handlers console_cohesion+
 
 .PHONY: galactic-test
 galactic-test: galactic

--- a/foxglove_bridge_base/include/foxglove_bridge/message_definition_cache.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/message_definition_cache.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <set>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+
+namespace foxglove {
+
+enum struct MessageDefinitionFormat {
+  IDL,
+  MSG,
+};
+
+struct MessageSpec {
+  MessageSpec(MessageDefinitionFormat format, std::string text, const std::string& package_context);
+  const std::set<std::string> dependencies;
+  const std::string text;
+  MessageDefinitionFormat format;
+};
+
+struct DefinitionIdentifier {
+  MessageDefinitionFormat format;
+  std::string package_resource_name;
+
+  bool operator==(const DefinitionIdentifier& di) const {
+    return (format == di.format) && (package_resource_name == di.package_resource_name);
+  }
+};
+
+class DefinitionNotFoundError : public std::exception {
+private:
+  std::string name_;
+
+public:
+  explicit DefinitionNotFoundError(std::string name)
+      : name_(std::move(name)) {}
+
+  const char* what() const noexcept override {
+    return name_.c_str();
+  }
+};
+
+class MessageDefinitionCache final {
+public:
+  /**
+   * Concatenate the message definition with its dependencies into a self-contained schema.
+   * The format is different for MSG and IDL definitions, and is described fully here:
+   * [MSG](https://mcap.dev/specification/appendix.html#ros2msg-data-format)
+   * [IDL](https://mcap.dev/specification/appendix.html#ros2idl-data-format)
+   * Throws DefinitionNotFoundError if one or more definition files are missing for the given
+   * package resource name.
+   */
+  std::pair<MessageDefinitionFormat, std::string> get_full_text(
+    const std::string& package_resource_name);
+
+private:
+  struct DefinitionIdentifierHash {
+    std::size_t operator()(const DefinitionIdentifier& di) const {
+      std::size_t h1 = std::hash<MessageDefinitionFormat>()(di.format);
+      std::size_t h2 = std::hash<std::string>()(di.package_resource_name);
+      return h1 ^ h2;
+    }
+  };
+  /**
+   * Load and parse the message file referenced by the given datatype, or return it from
+   * msg_specs_by_datatype
+   */
+  const MessageSpec& load_message_spec(const DefinitionIdentifier& definition_identifier);
+
+  std::unordered_map<DefinitionIdentifier, MessageSpec, DefinitionIdentifierHash>
+    msg_specs_by_definition_identifier_;
+};
+
+std::set<std::string> parse_dependencies(MessageDefinitionFormat format, const std::string& text,
+                                         const std::string& package_context);
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -1,0 +1,33 @@
+#pragma once
+
+#include <stdint.h>
+
+namespace foxglove {
+
+inline void WriteUint64LE(uint8_t* buf, uint64_t val) {
+#ifdef ARCH_IS_BIG_ENDIAN
+  buf[0] = val & 0xff;
+  buf[1] = (val >> 8) & 0xff;
+  buf[2] = (val >> 16) & 0xff;
+  buf[3] = (val >> 24) & 0xff;
+  buf[4] = (val >> 32) & 0xff;
+  buf[5] = (val >> 40) & 0xff;
+  buf[6] = (val >> 48) & 0xff;
+  buf[7] = (val >> 56) & 0xff;
+#else
+  reinterpret_cast<uint64_t*>(buf)[0] = val;
+#endif
+}
+
+inline void WriteUint32LE(uint8_t* buf, uint32_t val) {
+#ifdef ARCH_IS_BIG_ENDIAN
+  buf[0] = val & 0xff;
+  buf[1] = (val >> 8) & 0xff;
+  buf[2] = (val >> 16) & 0xff;
+  buf[3] = (val >> 24) & 0xff;
+#else
+  reinterpret_cast<uint32_t*>(buf)[0] = val;
+#endif
+}
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
@@ -24,7 +24,7 @@ inline std::string IPAddressToString(const asio::ip::address& addr) {
   return addr.to_string();
 }
 
-inline void NoOpLogCallback(WebSocketLogLevel, char const*){};
+inline void NoOpLogCallback(WebSocketLogLevel, char const*) {}
 
 template <typename concurrency, typename names>
 class CallbackLogger : public websocketpp::log::basic<concurrency, names> {

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <functional>
+
+#include <asio/ip/address.hpp>
+#include <websocketpp/logger/basic.hpp>
+
+namespace foxglove {
+
+enum class WebSocketLogLevel {
+  Debug,
+  Info,
+  Warn,
+  Error,
+  Critical,
+};
+
+using LogCallback = std::function<void(WebSocketLogLevel, char const*)>;
+
+inline std::string IPAddressToString(const asio::ip::address& addr) {
+  if (addr.is_v6()) {
+    return "[" + addr.to_string() + "]";
+  }
+  return addr.to_string();
+}
+
+inline void NoOpLogCallback(WebSocketLogLevel, char const*){};
+
+template <typename concurrency, typename names>
+class CallbackLogger : public websocketpp::log::basic<concurrency, names> {
+public:
+  using channel_type_hint = websocketpp::log::channel_type_hint;
+
+  CallbackLogger(channel_type_hint::value hint = channel_type_hint::access)
+      : websocketpp::log::basic<concurrency, names>(hint)
+      , _channelTypeHint(hint)
+      , _callback(NoOpLogCallback) {}
+
+  CallbackLogger(websocketpp::log::level channels,
+                 channel_type_hint::value hint = channel_type_hint::access)
+      : websocketpp::log::basic<concurrency, names>(channels, hint)
+      , _channelTypeHint(hint)
+      , _callback(NoOpLogCallback) {}
+
+  void set_callback(LogCallback callback) {
+    _callback = callback;
+  }
+
+  void write(websocketpp::log::level channel, std::string const& msg) {
+    write(channel, msg.c_str());
+  }
+
+  void write(websocketpp::log::level channel, char const* msg) {
+    if (!this->dynamic_test(channel)) {
+      return;
+    }
+
+    if (_channelTypeHint == channel_type_hint::access) {
+      _callback(WebSocketLogLevel::Info, msg);
+    } else {
+      if (channel == websocketpp::log::elevel::devel) {
+        _callback(WebSocketLogLevel::Debug, msg);
+      } else if (channel == websocketpp::log::elevel::library) {
+        _callback(WebSocketLogLevel::Debug, msg);
+      } else if (channel == websocketpp::log::elevel::info) {
+        _callback(WebSocketLogLevel::Info, msg);
+      } else if (channel == websocketpp::log::elevel::warn) {
+        _callback(WebSocketLogLevel::Warn, msg);
+      } else if (channel == websocketpp::log::elevel::rerror) {
+        _callback(WebSocketLogLevel::Error, msg);
+      } else if (channel == websocketpp::log::elevel::fatal) {
+        _callback(WebSocketLogLevel::Critical, msg);
+      }
+    }
+  }
+
+private:
+  channel_type_hint::value _channelTypeHint;
+  LogCallback _callback;
+};
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/server.hpp>
+
+#include "./websocket_logging.hpp"
+
+namespace foxglove {
+
+struct WebSocketNoTls : public websocketpp::config::asio {
+public:
+  // Replace default stream loggers with custom loggers
+  typedef CallbackLogger<concurrency_type, websocketpp::log::elevel> elog_type;
+  typedef CallbackLogger<concurrency_type, websocketpp::log::alevel> alog_type;
+};
+
+using WebSocketNoTlsServer = websocketpp::server<WebSocketNoTls>;
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
@@ -14,6 +14,4 @@ public:
   typedef CallbackLogger<concurrency_type, websocketpp::log::alevel> alog_type;
 };
 
-using WebSocketNoTlsServer = websocketpp::server<WebSocketNoTls>;
-
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1,0 +1,541 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <functional>
+#include <map>
+#include <memory>
+#include <optional>
+#include <shared_mutex>
+#include <string_view>
+#include <thread>
+#include <unordered_map>
+#include <vector>
+
+#include <nlohmann/json.hpp>
+
+#include "serialization.hpp"
+#include "websocket_logging.hpp"
+#include "websocket_notls.hpp"
+
+namespace foxglove {
+
+using json = nlohmann::json;
+using namespace std::placeholders;
+
+using ConnHandle = websocketpp::connection_hdl;
+using MessagePtr = WebSocketNoTlsServer::message_ptr;
+using OpCode = websocketpp::frame::opcode::value;
+
+using ChannelId = uint32_t;
+using SubscriptionId = uint32_t;
+
+static const websocketpp::log::level APP = websocketpp::log::alevel::app;
+static const websocketpp::log::level RECOVERABLE = websocketpp::log::elevel::rerror;
+
+struct ChannelWithoutId {
+  std::string topic;
+  std::string encoding;
+  std::string schemaName;
+  std::string schema;
+
+  bool operator==(const ChannelWithoutId& other) const {
+    return topic == other.topic && encoding == other.encoding && schemaName == other.schemaName &&
+           schema == other.schema;
+  }
+};
+
+struct Channel : ChannelWithoutId {
+  ChannelId id;
+
+  explicit Channel(ChannelId id, ChannelWithoutId ch)
+      : ChannelWithoutId(std::move(ch))
+      , id(id) {}
+
+  friend void to_json(json& j, const Channel& channel) {
+    j = {
+      {"id", channel.id},
+      {"topic", channel.topic},
+      {"encoding", channel.encoding},
+      {"schemaName", channel.schemaName},
+      {"schema", channel.schema},
+    };
+  }
+
+  bool operator==(const Channel& other) const {
+    return id == other.id && ChannelWithoutId::operator==(other);
+  }
+};
+
+enum class BinaryOpcode : uint8_t {
+  MESSAGE_DATA = 1,
+};
+
+enum class StatusLevel : uint8_t {
+  INFO = 0,
+  WARNING = 1,
+  ERROR = 2,
+};
+
+class Server final {
+public:
+  static const std::string SUPPORTED_SUBPROTOCOL;
+
+  explicit Server(std::string name, LogCallback logger);
+  ~Server();
+
+  Server(const Server&) = delete;
+  Server(Server&&) = delete;
+  Server& operator=(const Server&) = delete;
+  Server& operator=(Server&&) = delete;
+
+  void start(uint16_t port);
+  void stop();
+
+  ChannelId addChannel(ChannelWithoutId channel);
+  void removeChannel(ChannelId chanId);
+  void broadcastChannels();
+
+  void setSubscribeHandler(std::function<void(ChannelId)> handler);
+  void setUnsubscribeHandler(std::function<void(ChannelId)> handler);
+
+  void sendMessage(ChannelId chanId, uint64_t timestamp, std::string_view data);
+
+  std::optional<asio::ip::tcp::endpoint> localEndpoint();
+
+private:
+  struct ClientInfo {
+    std::string name;
+    ConnHandle handle;
+    std::unordered_map<ChannelId, SubscriptionId> subscriptionsByChannel;
+
+    ClientInfo(const ClientInfo&) = delete;
+    ClientInfo& operator=(const ClientInfo&) = delete;
+
+    ClientInfo(ClientInfo&&) = default;
+    ClientInfo& operator=(ClientInfo&&) = default;
+  };
+
+  std::string _name;
+  LogCallback _logger;
+  WebSocketNoTlsServer _server;
+  std::unique_ptr<std::thread> _serverThread;
+
+  uint32_t _nextChannelId = 0;
+  std::map<ConnHandle, ClientInfo, std::owner_less<>> _clients;
+  std::unordered_map<ChannelId, Channel> _channels;
+  std::function<void(ChannelId)> _subscribeHandler;
+  std::function<void(ChannelId)> _unsubscribeHandler;
+  std::shared_mutex _clientsChannelMutex;
+
+  bool validateConnection(ConnHandle hdl);
+  void handleConnectionOpened(ConnHandle hdl);
+  void handleConnectionClosed(ConnHandle hdl);
+  void handleMessage(ConnHandle hdl, MessagePtr msg);
+
+  void sendJson(ConnHandle hdl, json&& payload);
+  void sendJsonRaw(ConnHandle hdl, const std::string& payload);
+  void sendBinary(ConnHandle hdl, const std::vector<uint8_t>& payload);
+
+  bool anySubscribed(ChannelId chanId) const;
+};
+
+inline const std::string Server::SUPPORTED_SUBPROTOCOL = "foxglove.websocket.v1";
+
+inline Server::Server(std::string name, LogCallback logger)
+    : _name(std::move(name))
+    , _logger(logger) {
+  // Redirect logging
+  _server.get_alog().set_callback(_logger);
+  _server.get_elog().set_callback(_logger);
+
+  std::error_code ec;
+  _server.init_asio(ec);
+  if (ec) {
+    throw std::runtime_error("Failed to initialize websocket server: " + ec.message());
+  }
+
+  _server.clear_access_channels(websocketpp::log::alevel::all);
+  _server.set_access_channels(APP);
+  _server.set_validate_handler(std::bind(&Server::validateConnection, this, _1));
+  _server.set_open_handler(std::bind(&Server::handleConnectionOpened, this, _1));
+  _server.set_close_handler(std::bind(&Server::handleConnectionClosed, this, _1));
+  _server.set_message_handler(std::bind(&Server::handleMessage, this, _1, _2));
+  _server.set_reuse_addr(true);
+  _server.set_listen_backlog(128);
+}
+
+inline Server::~Server() {}
+
+inline bool Server::validateConnection(ConnHandle hdl) {
+  auto con = _server.get_con_from_hdl(hdl);
+
+  const auto& subprotocols = con->get_requested_subprotocols();
+  if (std::find(subprotocols.begin(), subprotocols.end(), SUPPORTED_SUBPROTOCOL) !=
+      subprotocols.end()) {
+    con->select_subprotocol(SUPPORTED_SUBPROTOCOL);
+    return true;
+  }
+  _server.get_alog().write(APP, "Rejecting client " + con->get_remote_endpoint() +
+                                  " which did not declare support for subprotocol " +
+                                  SUPPORTED_SUBPROTOCOL);
+  return false;
+}
+
+inline void Server::handleConnectionOpened(ConnHandle hdl) {
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  auto con = _server.get_con_from_hdl(hdl);
+  _server.get_alog().write(
+    APP, "Client " + con->get_remote_endpoint() + " connected via " + con->get_resource());
+  _clients.emplace(hdl, ClientInfo{con->get_remote_endpoint(), hdl, {}});
+
+  con->send(json({
+                   {"op", "serverInfo"},
+                   {"name", _name},
+                   {"capabilities", json::array()},
+                 })
+              .dump());
+
+  json channels;
+  for (const auto& [id, channel] : _channels) {
+    channels.push_back(channel);
+  }
+  sendJson(hdl, {
+                  {"op", "advertise"},
+                  {"channels", std::move(channels)},
+                });
+}
+
+inline void Server::handleConnectionClosed(ConnHandle hdl) {
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  const auto& client = _clients.find(hdl);
+  if (client == _clients.end()) {
+    _server.get_elog().write(RECOVERABLE, "Client " +
+                                            _server.get_con_from_hdl(hdl)->get_remote_endpoint() +
+                                            " disconnected but not found in _clients");
+    return;
+  }
+
+  _server.get_alog().write(APP, "Client " + client->second.name + " disconnected");
+
+  const auto oldSubscriptionsByChannel = std::move(client->second.subscriptionsByChannel);
+  _clients.erase(client);
+  for (const auto& [chanId, subs] : oldSubscriptionsByChannel) {
+    if (!anySubscribed(chanId) && _unsubscribeHandler) {
+      _unsubscribeHandler(chanId);
+    }
+  }
+}
+
+inline void Server::setSubscribeHandler(std::function<void(ChannelId)> handler) {
+  _subscribeHandler = std::move(handler);
+}
+inline void Server::setUnsubscribeHandler(std::function<void(ChannelId)> handler) {
+  _unsubscribeHandler = std::move(handler);
+}
+
+inline void Server::stop() {
+  if (_server.stopped()) {
+    return;
+  }
+
+  _server.get_alog().write(APP, "Stopping WebSocket server");
+  std::error_code ec;
+
+  _server.stop_perpetual();
+
+  if (_server.is_listening()) {
+    _server.stop_listening(ec);
+    if (ec) {
+      _server.get_elog().write(RECOVERABLE, "Failed to stop listening: " + ec.message());
+    }
+  }
+
+  std::vector<websocketpp::connection_hdl> connections;
+  {
+    std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+    connections.reserve(_clients.size());
+    for (const auto& [hdl, client] : _clients) {
+      connections.push_back(hdl);
+    }
+  }
+
+  if (!connections.empty()) {
+    _server.get_alog().write(
+      APP, "Closing " + std::to_string(connections.size()) + " client connection(s)");
+
+    // Iterate over all client connections and start the close connection handshake
+    for (const auto& hdl : connections) {
+      if (auto con = _server.get_con_from_hdl(hdl, ec)) {
+        con->close(websocketpp::close::status::going_away, "server shutdown", ec);
+        if (ec) {
+          _server.get_elog().write(RECOVERABLE, "Failed to close connection: " + ec.message());
+        }
+      }
+    }
+
+    // Wait for all connections to close
+    constexpr size_t MAX_SHUTDOWN_MS = 1000;
+    constexpr size_t SLEEP_MS = 10;
+    size_t durationMs = 0;
+    while (!_server.stopped() && durationMs < MAX_SHUTDOWN_MS) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(SLEEP_MS));
+      _server.poll_one();
+      durationMs += SLEEP_MS;
+    }
+
+    if (!_server.stopped()) {
+      _server.get_elog().write(RECOVERABLE, "Failed to close all connections, forcefully stopping");
+      for (const auto& hdl : connections) {
+        if (auto con = _server.get_con_from_hdl(hdl, ec)) {
+          _server.get_elog().write(RECOVERABLE,
+                                   "Terminating connection to " + con->get_remote_endpoint());
+          con->terminate(ec);
+        }
+      }
+      _server.stop();
+    }
+  }
+
+  _server.get_alog().write(APP, "All WebSocket connections closed");
+
+  if (_serverThread) {
+    _server.get_alog().write(APP, "Waiting for WebSocket server run loop to terminate");
+    _serverThread->join();
+    _serverThread.reset();
+    _server.get_alog().write(APP, "WebSocket server run loop terminated");
+  }
+
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  _clients.clear();
+}
+
+inline void Server::start(uint16_t port) {
+  if (_serverThread) {
+    throw std::runtime_error("Server already started");
+  }
+
+  std::error_code ec;
+
+  _server.listen(port, ec);
+  if (ec) {
+    throw std::runtime_error("Failed to listen on port " + std::to_string(port) + ": " +
+                             ec.message());
+  }
+
+  _server.start_accept(ec);
+  if (ec) {
+    throw std::runtime_error("Failed to start accepting connections: " + ec.message());
+  }
+
+  _serverThread = std::make_unique<std::thread>([this]() {
+    _server.get_alog().write(APP, "WebSocket server run loop started");
+    _server.run();
+    _server.get_alog().write(APP, "WebSocket server run loop stopped");
+  });
+
+  if (!_server.is_listening()) {
+    throw std::runtime_error("WebSocket server failed to listen on port " + std::to_string(port));
+  }
+
+  auto endpoint = _server.get_local_endpoint(ec);
+  if (ec) {
+    throw std::runtime_error("Failed to resolve the local endpoint: " + ec.message());
+  }
+
+  auto address = endpoint.address();
+  _server.get_alog().write(APP, "WebSocket server listening at ws://" + IPAddressToString(address) +
+                                  ":" + std::to_string(endpoint.port()));
+}
+
+inline void Server::sendJson(ConnHandle hdl, json&& payload) {
+  try {
+    _server.send(hdl, std::move(payload).dump(), OpCode::TEXT);
+  } catch (std::exception const& e) {
+    _server.get_elog().write(RECOVERABLE, e.what());
+  }
+}
+
+inline void Server::sendJsonRaw(ConnHandle hdl, const std::string& payload) {
+  try {
+    _server.send(hdl, payload, OpCode::TEXT);
+  } catch (std::exception const& e) {
+    _server.get_elog().write(RECOVERABLE, e.what());
+  }
+}
+
+inline void Server::sendBinary(ConnHandle hdl, const std::vector<uint8_t>& payload) {
+  try {
+    _server.send(hdl, payload.data(), payload.size(), OpCode::BINARY);
+  } catch (std::exception const& e) {
+    _server.get_elog().write(RECOVERABLE, e.what());
+  }
+}
+
+inline void Server::handleMessage(ConnHandle hdl, MessagePtr msg) {
+  std::error_code ec;
+  auto con = _server.get_con_from_hdl(hdl, ec);
+  if (!con) {
+    _server.get_elog().write(RECOVERABLE, "get_con_from_hdl failed in handleMessage");
+    return;
+  }
+
+  const std::string remoteEndpoint = con->get_remote_endpoint();
+
+  try {
+    std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+    auto& clientInfo = _clients.at(hdl);
+
+    const auto findSubscriptionBySubId = [&clientInfo](SubscriptionId subId) {
+      return std::find_if(clientInfo.subscriptionsByChannel.begin(),
+                          clientInfo.subscriptionsByChannel.end(), [&subId](const auto& mo) {
+                            return mo.second == subId;
+                          });
+    };
+
+    const auto& payloadStr = msg->get_payload();
+    const json payload = json::parse(payloadStr);
+    const std::string& op = payload.at("op").get<std::string>();
+
+    if (op == "subscribe") {
+      for (const auto& sub : payload.at("subscriptions")) {
+        SubscriptionId subId = sub.at("id");
+        ChannelId channelId = sub.at("channelId");
+        if (findSubscriptionBySubId(subId) != clientInfo.subscriptionsByChannel.end()) {
+          sendJson(hdl, json{
+                          {"op", "status"},
+                          {"level", static_cast<uint8_t>(StatusLevel::ERROR)},
+                          {"message", "Client subscription id " + std::to_string(subId) +
+                                        " was already used; ignoring subscription"},
+                        });
+          continue;
+        }
+        const auto& channelIt = _channels.find(channelId);
+        if (channelIt == _channels.end()) {
+          sendJson(hdl, json{
+                          {"op", "status"},
+                          {"level", static_cast<uint8_t>(StatusLevel::WARNING)},
+                          {"message", "Channel " + std::to_string(channelId) +
+                                        " is not available; ignoring subscription"},
+                        });
+          continue;
+        }
+        bool firstSubscription = !anySubscribed(channelId);
+        clientInfo.subscriptionsByChannel.emplace(channelId, subId);
+        if (firstSubscription && _subscribeHandler) {
+          _subscribeHandler(channelId);
+        }
+      }
+    } else if (op == "unsubscribe") {
+      for (const auto& subIdJson : payload.at("subscriptionIds")) {
+        SubscriptionId subId = subIdJson;
+        const auto& sub = findSubscriptionBySubId(subId);
+        if (sub == clientInfo.subscriptionsByChannel.end()) {
+          sendJson(hdl, json{
+                          {"op", "status"},
+                          {"level", static_cast<uint8_t>(StatusLevel::WARNING)},
+                          {"message", "Client subscription id " + std::to_string(subId) +
+                                        " did not exist; ignoring unsubscription"},
+                        });
+          continue;
+        }
+        ChannelId chanId = sub->second;
+        clientInfo.subscriptionsByChannel.erase(sub);
+        if (!anySubscribed(chanId) && _unsubscribeHandler) {
+          _unsubscribeHandler(chanId);
+        }
+      }
+
+    } else {
+      _server.get_elog().write(RECOVERABLE, "Unrecognized client opcode: " + op);
+      sendJson(hdl, {
+                      {"op", "status"},
+                      {"level", static_cast<uint8_t>(StatusLevel::ERROR)},
+                      {"message", "Unrecognized opcode " + op},
+                    });
+    }
+  } catch (std::exception const& ex) {
+    _server.get_elog().write(RECOVERABLE,
+                             "Error parsing message from " + remoteEndpoint + ": " + ex.what());
+    return;
+  }
+}
+
+inline ChannelId Server::addChannel(ChannelWithoutId channel) {
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  const auto newId = ++_nextChannelId;
+  Channel newChannel{newId, std::move(channel)};
+  _channels.emplace(newId, std::move(newChannel));
+  return newId;
+}
+
+inline void Server::removeChannel(ChannelId chanId) {
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  _channels.erase(chanId);
+  for (auto& [hdl, clientInfo] : _clients) {
+    if (const auto it = clientInfo.subscriptionsByChannel.find(chanId);
+        it != clientInfo.subscriptionsByChannel.end()) {
+      clientInfo.subscriptionsByChannel.erase(it);
+    }
+    sendJson(hdl, {{"op", "unadvertise"}, {"channelIds", {chanId}}});
+  }
+}
+
+inline void Server::broadcastChannels() {
+  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+
+  if (_clients.empty()) {
+    return;
+  }
+
+  json channels;
+  for (const auto& [id, channel] : _channels) {
+    channels.push_back(channel);
+  }
+  std::string msg = json{{"op", "advertise"}, {"channels", std::move(channels)}}.dump();
+
+  for (const auto& [hdl, clientInfo] : _clients) {
+    sendJsonRaw(hdl, msg);
+  }
+}
+
+inline void Server::sendMessage(ChannelId chanId, uint64_t timestamp, std::string_view data) {
+  std::shared_lock<std::shared_mutex> lock(_clientsChannelMutex);
+  std::vector<uint8_t> message;
+  for (const auto& [hdl, client] : _clients) {
+    const auto& subs = client.subscriptionsByChannel.find(chanId);
+    if (subs == client.subscriptionsByChannel.end()) {
+      continue;
+    }
+    const auto subId = subs->second;
+    if (message.empty()) {
+      message.resize(1 + 4 + 8 + data.size());
+      message[0] = uint8_t(BinaryOpcode::MESSAGE_DATA);
+      // message[1..4] is the subscription id, which we'll fill in per-recipient below
+      foxglove::WriteUint64LE(message.data() + 5, timestamp);
+      std::memcpy(message.data() + 1 + 4 + 8, data.data(), data.size());
+    }
+    foxglove::WriteUint32LE(message.data() + 1, subId);
+    sendBinary(hdl, message);
+  }
+}
+
+inline std::optional<asio::ip::tcp::endpoint> Server::localEndpoint() {
+  std::error_code ec;
+  auto endpoint = _server.get_local_endpoint(ec);
+  if (ec) {
+    return std::nullopt;
+  }
+  return endpoint;
+}
+
+inline bool Server::anySubscribed(ChannelId chanId) const {
+  for (const auto& [hdl, client] : _clients) {
+    if (client.subscriptionsByChannel.find(chanId) != client.subscriptionsByChannel.end()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace foxglove

--- a/package.xml
+++ b/package.xml
@@ -27,6 +27,7 @@
     <!-- common dependencies -->
     <build_depend>libssl-dev</build_depend>
     <build_depend>libwebsocketpp-dev</build_depend>
+    <build_depend>nlohmann-json-dev</build_depend>
 
     <exec_depend>openssl</exec_depend>
     <exec_depend>websocketpp</exec_depend>

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge.cpp
@@ -1,16 +1,8 @@
 #define ASIO_STANDALONE
 
 #include <ros/ros.h>
-#include <websocketpp/config/asio.hpp>
-#include <websocketpp/server.hpp>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
-
-using Server = websocketpp::server<websocketpp::config::asio_tls>;
-using ConnectionHdl = websocketpp::connection_hdl;
-using SslContext = websocketpp::lib::asio::ssl::context;
-using websocketpp::lib::placeholders::_1;
-using websocketpp::lib::placeholders::_2;
 
 class FoxgloveBridge {
 public:

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -1,0 +1,175 @@
+#include "foxglove_bridge/message_definition_cache.hpp"
+
+#include <fstream>
+#include <optional>
+#include <regex>
+#include <set>
+#include <string>
+#include <unordered_set>
+#include <utility>
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <ament_index_cpp/get_resource.hpp>
+#include <ament_index_cpp/get_resources.hpp>
+#include <rcutils/logging_macros.h>
+
+namespace foxglove {
+
+// Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
+static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/)?([a-zA-Z0-9_]+)$)"};
+
+// Match field types from .msg definitions ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
+static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
+
+// match field types from `.idl` definitions ("foo_msgs/msg/bar" in #include <foo_msgs/msg/Bar.idl>)
+static const std::regex IDL_FIELD_TYPE_REGEX{
+  R"((?:^|\n)#include\s+(?:"|<)([a-zA-Z0-9_/]+)\.idl(?:"|>))"};
+
+static const std::unordered_set<std::string> PRIMITIVE_TYPES{
+  "bool",  "byte",   "char",  "float32", "float64", "int8",   "uint8",
+  "int16", "uint16", "int32", "uint32",  "int64",   "uint64", "string"};
+
+static std::set<std::string> parse_msg_dependencies(const std::string& text,
+                                                    const std::string& package_context) {
+  std::set<std::string> dependencies;
+
+  for (std::sregex_iterator iter(text.begin(), text.end(), MSG_FIELD_TYPE_REGEX);
+       iter != std::sregex_iterator(); ++iter) {
+    std::string type = (*iter)[1];
+    if (PRIMITIVE_TYPES.find(type) != PRIMITIVE_TYPES.end()) {
+      continue;
+    }
+    if (type.find('/') == std::string::npos) {
+      dependencies.insert(package_context + '/' + std::move(type));
+    } else {
+      dependencies.insert(std::move(type));
+    }
+  }
+  return dependencies;
+}
+
+static std::set<std::string> parse_idl_dependencies(const std::string& text) {
+  std::set<std::string> dependencies;
+
+  for (std::sregex_iterator iter(text.begin(), text.end(), IDL_FIELD_TYPE_REGEX);
+       iter != std::sregex_iterator(); ++iter) {
+    dependencies.insert((*iter)[1]);
+  }
+  return dependencies;
+}
+
+std::set<std::string> parse_dependencies(MessageDefinitionFormat format, const std::string& text,
+                                         const std::string& package_context) {
+  switch (format) {
+    case MessageDefinitionFormat::MSG:
+      return parse_msg_dependencies(text, package_context);
+    case MessageDefinitionFormat::IDL:
+      return parse_idl_dependencies(text);
+    default:
+      throw std::runtime_error("switch is not exhaustive");
+  }
+}
+
+static const char* extension_for_format(MessageDefinitionFormat format) {
+  switch (format) {
+    case MessageDefinitionFormat::MSG:
+      return ".msg";
+    case MessageDefinitionFormat::IDL:
+      return ".idl";
+    default:
+      throw std::runtime_error("switch is not exhaustive");
+  }
+}
+
+static std::string delimiter(const DefinitionIdentifier& definition_identifier) {
+  std::string result =
+    "================================================================================\n";
+  switch (definition_identifier.format) {
+    case MessageDefinitionFormat::MSG:
+      result += "MSG: ";
+      break;
+    case MessageDefinitionFormat::IDL:
+      result += "IDL: ";
+      break;
+    default:
+      throw std::runtime_error("switch is not exhaustive");
+  }
+  result += definition_identifier.package_resource_name;
+  result += "\n";
+  return result;
+}
+
+MessageSpec::MessageSpec(MessageDefinitionFormat format, std::string text,
+                         const std::string& package_context)
+    : dependencies(parse_dependencies(format, text, package_context))
+    , text(std::move(text))
+    , format(format) {}
+
+const MessageSpec& MessageDefinitionCache::load_message_spec(
+  const DefinitionIdentifier& definition_identifier) {
+  if (auto it = msg_specs_by_definition_identifier_.find(definition_identifier);
+      it != msg_specs_by_definition_identifier_.end()) {
+    return it->second;
+  }
+  std::smatch match;
+  if (!std::regex_match(definition_identifier.package_resource_name, match,
+                        PACKAGE_TYPENAME_REGEX)) {
+    throw std::invalid_argument("Invalid package resource name: " +
+                                definition_identifier.package_resource_name);
+  }
+  std::string package = match[1];
+  std::string share_dir = ament_index_cpp::get_package_share_directory(package);
+  std::ifstream file{share_dir + "/msg/" + match[2].str() +
+                     extension_for_format(definition_identifier.format)};
+  if (!file.good()) {
+    throw DefinitionNotFoundError(definition_identifier.package_resource_name);
+  }
+
+  std::string contents{std::istreambuf_iterator(file), {}};
+  const MessageSpec& spec =
+    msg_specs_by_definition_identifier_
+      .emplace(definition_identifier,
+               MessageSpec(definition_identifier.format, std::move(contents), package))
+      .first->second;
+
+  // "References and pointers to data stored in the container are only invalidated by erasing that
+  // element, even when the corresponding iterator is invalidated."
+  return spec;
+}
+
+std::pair<MessageDefinitionFormat, std::string> MessageDefinitionCache::get_full_text(
+  const std::string& root_package_resource_name) {
+  std::unordered_set<DefinitionIdentifier, DefinitionIdentifierHash> seen_deps;
+
+  std::function<std::string(const DefinitionIdentifier&)> append_recursive =
+    [&](const DefinitionIdentifier& definition_identifier) {
+      const MessageSpec& spec = load_message_spec(definition_identifier);
+      std::string result = spec.text;
+      for (const auto& dep_name : spec.dependencies) {
+        DefinitionIdentifier dep{definition_identifier.format, dep_name};
+        bool inserted = seen_deps.insert(dep).second;
+        if (inserted) {
+          result += "\n";
+          result += delimiter(dep);
+          result += append_recursive(dep);
+        }
+      }
+      return result;
+    };
+
+  std::string result;
+  auto format = MessageDefinitionFormat::MSG;
+  try {
+    result = append_recursive(DefinitionIdentifier{format, root_package_resource_name});
+  } catch (const DefinitionNotFoundError& err) {
+    // log that we've fallen back
+    RCUTILS_LOG_WARN_NAMED("rosbag2_storage_mcap", "no .msg definition for %s, falling back to IDL",
+                           err.what());
+    format = MessageDefinitionFormat::IDL;
+    DefinitionIdentifier root_definition_identifier{format, root_package_resource_name};
+    result = delimiter(root_definition_identifier) + append_recursive(root_definition_identifier);
+  }
+  return std::make_pair(format, result);
+}
+
+}  // namespace foxglove

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -209,7 +209,7 @@ public:
       _server.broadcastChannels();
     }
 
-    // Schedule the next update
+    // Schedule the next update using truncated exponential backoff, up to `_maxUpdateMs`
     _updateCount++;
     auto nextUpdateMs =
       std::chrono::milliseconds(std::min(size_t(1) << _updateCount, _maxUpdateMs));

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -1,24 +1,343 @@
 #include <chrono>
 #include <memory>
+#include <unordered_set>
 
 #include <rclcpp/rclcpp.hpp>
 
+#define ASIO_STANDALONE
+
 #include <foxglove_bridge/foxglove_bridge.hpp>
+#include <foxglove_bridge/message_definition_cache.hpp>
+#include <foxglove_bridge/websocket_server.hpp>
+
+constexpr uint16_t DEFAULT_PORT = 8765;
+constexpr size_t DEFAULT_MAX_UPDATE_MS = 5000;
+
+using namespace std::chrono_literals;
+using namespace std::placeholders;
+using LogLevel = foxglove::WebSocketLogLevel;
 
 class FoxgloveBridge : public rclcpp::Node {
 public:
-  FoxgloveBridge()
-      : Node("foxglove_bridge") {
+  using TopicAndDatatype = std::pair<std::string, std::string>;
+
+  FoxgloveBridge(const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
+      : Node("foxglove_bridge", options)
+      , _server("foxglove_bridge", std::bind(&FoxgloveBridge::logHandler, this, _1, _2)) {
     RCLCPP_INFO(this->get_logger(), "Starting %s with %s", this->get_name(),
                 foxglove::WebSocketUserAgent());
+
+    auto portDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    portDescription.name = "port";
+    portDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+    portDescription.description = "The TCP port to bind the WebSocket server to";
+    portDescription.read_only = true;
+    portDescription.additional_constraints =
+      "Must be a valid TCP port number, or 0 to use a random port";
+    portDescription.integer_range.resize(1);
+    portDescription.integer_range[0].from_value = 0;
+    portDescription.integer_range[0].to_value = 65535;
+    portDescription.integer_range[0].step = 1;
+    this->declare_parameter("port", DEFAULT_PORT, portDescription);
+
+    auto maxUpdateDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    maxUpdateDescription.name = "max_update_ms";
+    maxUpdateDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+    maxUpdateDescription.description =
+      "The maximum time in milliseconds between refreshing the list of known topics, services, "
+      "actions, and parameters";
+    maxUpdateDescription.read_only = false;
+    maxUpdateDescription.additional_constraints = "Must be a positive integer";
+    maxUpdateDescription.integer_range.resize(1);
+    maxUpdateDescription.integer_range[0].from_value = 1;
+    maxUpdateDescription.integer_range[0].to_value = INT32_MAX;
+    maxUpdateDescription.integer_range[0].step = 1;
+    this->declare_parameter("max_update_ms", int(DEFAULT_MAX_UPDATE_MS), maxUpdateDescription);
+
+    _server.setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1));
+    _server.setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1));
+
+    uint16_t port = uint16_t(this->get_parameter("port").as_int());
+    _server.start(port);
+
+    // Get the actual port we bound to
+    uint16_t listeningPort = _server.localEndpoint()->port();
+    if (port != listeningPort) {
+      RCLCPP_DEBUG(this->get_logger(), "Reassigning \"port\" parameter from %d to %d", port,
+                   listeningPort);
+      this->set_parameter(rclcpp::Parameter{"port", listeningPort});
+    }
+
+    _maxUpdateMs = size_t(this->get_parameter("max_update_ms").as_int());
+
+    // Listen for parameter updates
+    _parametersUpdateHandle = this->add_on_set_parameters_callback(
+      std::bind(&FoxgloveBridge::parametersHandler, this, std::placeholders::_1));
+
+    _updateTimer =
+      this->create_wall_timer(1ms, std::bind(&FoxgloveBridge::updateAdvertisedTopics, this));
+  }
+
+  ~FoxgloveBridge() {
+    RCLCPP_INFO(this->get_logger(), "Shutting down %s", this->get_name());
+    if (_updateTimer) {
+      _updateTimer.reset();
+    }
+    _server.stop();
+    RCLCPP_INFO(this->get_logger(), "Shutdown complete");
+  }
+
+  void updateAdvertisedTopics() {
+    _updateTimer.reset();
+    if (!rclcpp::ok()) {
+      return;
+    }
+
+    // Get the current list of visible topics and datatypes from the ROS graph
+    // rclcpp::spin_some(this->get_node_base_interface());
+    auto topicNamesAndTypes = this->get_node_graph_interface()->get_topic_names_and_types();
+    std::unordered_set<TopicAndDatatype, PairHash> latestTopics;
+    latestTopics.reserve(topicNamesAndTypes.size());
+    for (const auto& topicNameAndType : topicNamesAndTypes) {
+      for (const auto& datatype : topicNameAndType.second) {
+        latestTopics.emplace(topicNameAndType.first, datatype);
+      }
+    }
+
+    // Create a list of topics that are new to us
+    std::vector<TopicAndDatatype> newTopics;
+    for (const auto& topic : latestTopics) {
+      if (_advertisedTopics.find(topic) == _advertisedTopics.end()) {
+        newTopics.push_back(topic);
+      }
+    }
+
+    // Create a list of topics that have been removed
+    std::vector<TopicAndDatatype> removedTopics;
+    for (const auto& [topic, channel] : _advertisedTopics) {
+      if (latestTopics.find(topic) == latestTopics.end()) {
+        removedTopics.push_back(topic);
+      }
+    }
+
+    // Remove advertisements for topics that have been removed
+    {
+      std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+      for (const auto& topicAndDatatype : removedTopics) {
+        auto& channel = _advertisedTopics.at(topicAndDatatype);
+
+        // Stop tracking this channel in the WebSocket server
+        _server.removeChannel(channel.id);
+
+        // Remove this topic+datatype tuple
+        _advertisedTopics.erase(topicAndDatatype);
+        _channelToTopicAndDatatype.erase(channel.id);
+
+        // Remove the subscription for this topic, if any
+        _subscriptions.erase(channel.id);
+
+        RCLCPP_DEBUG(this->get_logger(), "Removed channel %d for topic \"%s\" (%s)", channel.id,
+                     channel.topic.c_str(), channel.schemaName.c_str());
+      }
+
+      // Advertise new topics
+      for (const auto& topicAndDatatype : newTopics) {
+        foxglove::ChannelWithoutId newChannel{};
+        newChannel.topic = topicAndDatatype.first;
+        newChannel.schemaName = topicAndDatatype.second;
+
+        try {
+          auto [format, schema] = _messageDefinitionCache.get_full_text(topicAndDatatype.second);
+          switch (format) {
+            case foxglove::MessageDefinitionFormat::MSG:
+              newChannel.encoding = "cdr";
+              newChannel.schema = schema;
+              break;
+            case foxglove::MessageDefinitionFormat::IDL:
+              RCLCPP_WARN(this->get_logger(),
+                          "IDL message definition format cannot be communicated over ws-protocol. "
+                          "Topic \"%s\" (%s) may not decode correctly in clients",
+                          topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+              newChannel.encoding = "cdr";
+              newChannel.schema = schema;
+              break;
+          }
+
+          auto channel = foxglove::Channel{_server.addChannel(newChannel), newChannel};
+          RCLCPP_DEBUG(this->get_logger(), "Advertising channel %d for topic \"%s\" (%s)",
+                       channel.id, channel.topic.c_str(), channel.schemaName.c_str());
+
+          // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
+          // topic+datatype tuple
+          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+          _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
+        } catch (foxglove::DefinitionNotFoundError& err) {
+          RCLCPP_WARN(this->get_logger(), "Could not find definition for topic \"%s\" (%s)",
+                      topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+
+          // Add a mapping from the topic+datatype tuple to a dummy channel so we don't repeatedly
+          // try to load the message definition
+          auto channel = foxglove::Channel{0, newChannel};
+          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+        }
+      }
+    }
+
+    if (newTopics.size() > 0) {
+      _server.broadcastChannels();
+    }
+
+    // Schedule the next update
+    _updateCount++;
+    auto nextUpdateMs =
+      std::chrono::milliseconds(std::min(size_t(1) << _updateCount, _maxUpdateMs));
+    _updateTimer = this->create_wall_timer(
+      nextUpdateMs, std::bind(&FoxgloveBridge::updateAdvertisedTopics, this));
   }
 
 private:
+  struct PairHash {
+    template <class T1, class T2>
+    std::size_t operator()(const std::pair<T1, T2>& pair) const {
+      return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+    }
+  };
+
+  foxglove::Server _server;
+  foxglove::MessageDefinitionCache _messageDefinitionCache;
+  std::unordered_map<TopicAndDatatype, foxglove::Channel, PairHash> _advertisedTopics;
+  std::unordered_map<foxglove::ChannelId, TopicAndDatatype> _channelToTopicAndDatatype;
+  std::unordered_map<foxglove::ChannelId, std::shared_ptr<rclcpp::GenericSubscription>>
+    _subscriptions;
+  std::mutex _subscriptionsMutex;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr _parametersUpdateHandle;
+  rclcpp::TimerBase::SharedPtr _updateTimer;
+  size_t _maxUpdateMs = DEFAULT_MAX_UPDATE_MS;
+  size_t _updateCount = 0;
+
+  rcl_interfaces::msg::SetParametersResult parametersHandler(
+    const std::vector<rclcpp::Parameter>& parameters) {
+    for (const auto& parameter : parameters) {
+      if (parameter.get_name() == "max_update_ms") {
+        _maxUpdateMs = size_t(parameter.as_int());
+      }
+    }
+
+    rcl_interfaces::msg::SetParametersResult result;
+    result.successful = true;
+    result.reason = "success";
+    return result;
+  }
+
+  void subscribeHandler(foxglove::ChannelId channelId) {
+    std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+    if (_subscriptions.find(channelId) != _subscriptions.end()) {
+      // Subscription already exists
+      RCLCPP_DEBUG(this->get_logger(), "Subscription already exists for channel %d", channelId);
+      return;
+    }
+
+    auto it = _channelToTopicAndDatatype.find(channelId);
+    if (it == _channelToTopicAndDatatype.end()) {
+      RCLCPP_WARN(this->get_logger(), "Received subscribe request for unknown channel %d",
+                  channelId);
+      return;
+    }
+    auto& topicAndDatatype = it->second;
+    auto topic = topicAndDatatype.first;
+    auto datatype = topicAndDatatype.second;
+    auto it2 = _advertisedTopics.find(topicAndDatatype);
+    if (it2 == _advertisedTopics.end()) {
+      RCLCPP_ERROR(this->get_logger(), "Channel %d for topic \"%s\" (%s) is not advertised",
+                   channelId, topic.c_str(), datatype.c_str());
+      return;
+    }
+    auto& channel = it2->second;
+
+    rclcpp::SubscriptionEventCallbacks eventCallbacks;
+    eventCallbacks.incompatible_qos_callback = [&](const rclcpp::QOSRequestedIncompatibleQoSInfo&) {
+      RCLCPP_ERROR(this->get_logger(), "Incompatible subscriber QoS settings for topic \"%s\" (%s)",
+                   topic.c_str(), datatype.c_str());
+    };
+
+    rclcpp::SubscriptionOptions subscriptionOptions;
+    subscriptionOptions.event_callbacks = eventCallbacks;
+
+    constexpr size_t QUEUE_LENGTH = 10;
+    try {
+      auto subscriber = this->create_generic_subscription(
+        topic, datatype, QUEUE_LENGTH,
+        [&](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+          rosMessageHandler(channel, msg);
+        },
+        subscriptionOptions);
+      _subscriptions.emplace(channelId, std::move(subscriber));
+      RCLCPP_INFO(this->get_logger(), "Subscribed to topic \"%s\" (%s)", topic.c_str(),
+                  datatype.c_str());
+    } catch (const std::exception& ex) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to subscribe to topic \"%s\" (%s): %s",
+                   topic.c_str(), datatype.c_str(), ex.what());
+    }
+  }
+
+  void unsubscribeHandler(foxglove::ChannelId channelId) {
+    std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+
+    auto it = _channelToTopicAndDatatype.find(channelId);
+    TopicAndDatatype topicAndDatatype =
+      it != _channelToTopicAndDatatype.end()
+        ? it->second
+        : std::make_pair<std::string, std::string>("[Unknown]", "[Unknown]");
+
+    auto it2 = _subscriptions.find(channelId);
+    if (it2 == _subscriptions.end()) {
+      RCLCPP_WARN(this->get_logger(), "Received unsubscribe request for unknown channel %d",
+                  channelId);
+      return;
+    }
+
+    RCLCPP_INFO(this->get_logger(), "Unsubscribing from topic \"%s\" (%s)",
+                topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+    _subscriptions.erase(it2);
+  }
+
+  void logHandler(LogLevel level, char const* msg) {
+    switch (level) {
+      case LogLevel::Debug:
+        RCLCPP_DEBUG(this->get_logger(), "[WS] %s", msg);
+        break;
+      case LogLevel::Info:
+        RCLCPP_INFO(this->get_logger(), "[WS] %s", msg);
+        break;
+      case LogLevel::Warn:
+        RCLCPP_WARN(this->get_logger(), "[WS] %s", msg);
+        break;
+      case LogLevel::Error:
+        RCLCPP_ERROR(this->get_logger(), "[WS] %s", msg);
+        break;
+      case LogLevel::Critical:
+        RCLCPP_FATAL(this->get_logger(), "[WS] %s", msg);
+        break;
+    }
+  }
+
+  void rosMessageHandler(const foxglove::Channel& channel,
+                         std::shared_ptr<rclcpp::SerializedMessage> msg) {
+    // NOTE: Do not call any RCLCPP_* logging functions from this function. Otherwise, subscribing
+    // to `/rosout` will cause a feedback loop
+    auto timestamp = this->now().nanoseconds();
+    auto payload =
+      std::string_view{reinterpret_cast<const char*>(msg->get_rcl_serialized_message().buffer),
+                       msg->get_rcl_serialized_message().buffer_length};
+    _server.sendMessage(channel.id, timestamp, payload);
+  }
 };
 
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
-  rclcpp::spin(std::make_shared<FoxgloveBridge>());
+  auto bridgeNode = std::make_shared<FoxgloveBridge>();
+  rclcpp::spin(bridgeNode);
+  bridgeNode.reset();
   rclcpp::shutdown();
   return 0;
 }

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -193,7 +193,7 @@ public:
           // topic+datatype tuple
           _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
           _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
-        } catch (foxglove::DefinitionNotFoundError& err) {
+        } catch (const foxglove::DefinitionNotFoundError& err) {
           RCLCPP_WARN(this->get_logger(), "Could not find definition for topic \"%s\" (%s)",
                       topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
 


### PR DESCRIPTION
**Public-Facing Changes**
- ROS 2 node starts a WebSocket server speaking `ws-protocol`

**Description**
This brings the ROS 2 side of things closer to "feature complete" for read-only topic subscriptions for `.msg`-backed files. Not supported:

- All QoS profiles
- IDL message definitions
- Parameters
- Services
- Actions
- Publishing
- Non-CDR serializations
- ROS 1 node
