### PR TITLE
Add C++ library to get full message definition for ros1 types.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,23 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     message(STATUS "Building with catkin")
     set(ROS_BUILD_TYPE "catkin")
 
-    find_package(catkin REQUIRED COMPONENTS roslib roscpp)
+    find_package(catkin REQUIRED COMPONENTS roslib roscpp rospack)
+    find_package(Boost REQUIRED)
 
     catkin_package(
-      INCLUDE_DIRS foxglove_bridge_base/include
-      LIBRARIES foxglove_bridge_base
-      CATKIN_DEPENDS roslib roscpp
+      INCLUDE_DIRS foxglove_bridge_base/include ros1_foxglove_bridge/include
+      LIBRARIES foxglove_bridge_base message_parser
+      CATKIN_DEPENDS roslib roscpp rospack
+      DEPENDS Boost
     )
+
+    add_library(message_parser ros1_foxglove_bridge/src/msg_parser.cpp)
+    target_include_directories(message_parser SYSTEM PRIVATE ${Boost_INCLUDE_DIRS} ${catkin_INCLUDE_DIRS} ros1_foxglove_bridge/include)
+    target_link_libraries(message_parser ${catkin_LIBRARIES})
+
+    add_executable(get_full_message_definition ros1_foxglove_bridge/src/msg_parser_cli.cpp)
+    target_include_directories(get_full_message_definition SYSTEM PRIVATE ros1_foxglove_bridge/include)
+    target_link_libraries(get_full_message_definition message_parser)
 
     add_executable(foxglove_bridge ros1_foxglove_bridge/src/ros1_foxglove_bridge.cpp)
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
@@ -124,6 +134,10 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
     target_link_libraries(version_test foxglove_bridge_base GTest::GTest GTest::Main)
 
     add_rostest(ros1_foxglove_bridge/tests/smoke.test)
+
+    catkin_add_gtest(message_parser_test ros1_foxglove_bridge/tests/msg_parser_test.cpp)
+    target_include_directories(message_parser_test SYSTEM PRIVATE ros1_foxglove_bridge/include)
+    target_link_libraries(message_parser_test message_parser GTest::GTest GTest::Main)
   endif()
 elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
   if(BUILD_TESTING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,8 +155,16 @@ endif()
 #### INSTALL ###################################################################
 
 if(ROS_BUILD_TYPE STREQUAL "catkin")
-    install(TARGETS foxglove_bridge
+    install(TARGETS foxglove_bridge get_full_message_definition
       RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+    )
+    install(TARGETS message_parser
+      ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+      RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
+    )
+    install(DIRECTORY ros1_foxglove_bridge/include/foxglove_bridge
+      DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
     )
 elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     install(TARGETS foxglove_bridge

--- a/package.xml
+++ b/package.xml
@@ -16,12 +16,14 @@
 
     <depend condition="$ROS_VERSION == 1">roslib</depend>
     <depend condition="$ROS_VERSION == 1">roscpp</depend>
+    <depend condition="$ROS_VERSION == 1">rospack</depend>
     <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
     <depend condition="$ROS_VERSION == 2">rclcpp</depend>
 
     <!-- test dependencies -->
     <build_depend condition="$ROS_VERSION == 1">rostest</build_depend>
     <test_depend condition="$ROS_VERSION == 1">rosunit</test_depend>
+    <test_depend condition="$ROS_VERSION == 1">geometry_msgs</test_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
 
     <!-- common dependencies -->

--- a/ros1_foxglove_bridge/include/foxglove_bridge/msg_parser.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/msg_parser.hpp
@@ -1,9 +1,9 @@
 #pragma once
 
-#include <map>
 #include <memory>
 #include <stdexcept>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace rospack {
@@ -43,7 +43,7 @@ private:
   std::string get_msg_file_path(const std::string& package_name, const std::string& message_name);
   MsgSpec parse_msg_file(const std::string& package_name, const std::string& file_path);
   std::shared_ptr<rospack::Rosstackage> rospack_;
-  std::map<std::string, MsgSpec> msg_spec_cache_;
+  std::unordered_map<std::string, MsgSpec> msg_spec_cache_;
 };
 
 }  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/include/foxglove_bridge/msg_parser.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/msg_parser.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <map>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace rospack {
+class Rosstackage;
+}
+
+namespace foxglove_bridge {
+
+struct MsgSpecException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+struct MsgNotFoundException : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+struct InvalidMessageType : public std::runtime_error {
+  using std::runtime_error::runtime_error;
+};
+
+struct MsgSpec {
+  /// @brief Raw message definition.
+  std::string full_text;
+  /// @brief Field types.
+  std::vector<std::string> types;
+};
+
+class MsgParser {
+public:
+  explicit MsgParser(std::shared_ptr<rospack::Rosstackage> rospack = nullptr);
+
+  /// @brief Get the full message definition including definitions of all subtypes.
+  /// The output is equal to what `rosrun roslib gendeps -c <msg_file>` generates.
+  /// @param message_type Message type in the format <package_name>/<message_name>
+  /// @return String with the message schema and concatenated schemas of submessages.
+  std::string get_message_schema(const std::string& message_type);
+
+private:
+  std::string get_msg_file_path(const std::string& package_name, const std::string& message_name);
+  MsgSpec parse_msg_file(const std::string& package_name, const std::string& file_path);
+  std::shared_ptr<rospack::Rosstackage> rospack_;
+  std::map<std::string, MsgSpec> msg_spec_cache_;
+};
+
+}  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/msg_parser.cpp
+++ b/ros1_foxglove_bridge/src/msg_parser.cpp
@@ -1,0 +1,153 @@
+#include <filesystem>
+#include <fstream>
+
+#include <boost/algorithm/string.hpp>
+#include <rospack/rospack.h>
+
+#include <foxglove_bridge/msg_parser.hpp>
+
+namespace foxglove_bridge {
+
+constexpr char EXT[] = ".msg";
+constexpr char SUB_PATH[] = "msg";
+constexpr std::array PRIMITIVE_TYPES = {
+  "int8",    "uint8",   "int16",  "uint16", "int32", "uint32",   "int64", "uint64",
+  "float32", "float64", "string", "bool",   "time",  "duration", "char",  "byte"};
+constexpr char HEADER[] = "std_msgs/Header";
+constexpr std::array HEADER_TYPES = {"Header", "std_msgs/Header", "roslib/Header"};
+
+static bool is_builtin_type(const std::string& type_name) {
+  for (std::size_t i = 0; i < std::size(PRIMITIVE_TYPES); ++i) {
+    if (type_name == PRIMITIVE_TYPES[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static bool is_header_type(const std::string& type_name) {
+  for (std::size_t i = 0; i < std::size(HEADER_TYPES); ++i) {
+    if (type_name == HEADER_TYPES[i]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+static std::pair<std::string, std::string> get_package_and_message_name(
+  const std::string& message_type) {
+  std::vector<std::string> split_str;
+  boost::algorithm::split(split_str, message_type, boost::algorithm::is_any_of("/"));
+  if (split_str.size() != 2) {
+    throw InvalidMessageType("Invalid message type " + message_type);
+  }
+
+  const std::string& package_name = split_str[0];
+  const std::string& message_name = split_str[1];
+  return {package_name, message_name};
+}
+
+MsgParser::MsgParser(std::shared_ptr<rospack::Rosstackage> rospack)
+    : rospack_(rospack ? rospack : std::make_shared<rospack::Rospack>()) {
+  if (!rospack) {
+    // Perform a crawl if rospack was not passed in as argument.
+    std::vector<std::string> search_path;
+    if (rospack_->getSearchPathFromEnv(search_path)) {
+      const bool force_crawl = true;
+      rospack_->crawl(search_path, force_crawl);
+    }
+  }
+}
+
+std::string MsgParser::get_msg_file_path(const std::string& package_name,
+                                         const std::string& message_name) {
+  std::string package_path;
+  if (rospack_->find(package_name, package_path)) {
+    const auto msg_path = std::filesystem::path(package_path) / SUB_PATH / (message_name + EXT);
+    if (std::filesystem::exists(msg_path)) {
+      return msg_path.string();
+    }
+  }
+
+  throw MsgNotFoundException("Unable to find message definition " + message_name + " in package " +
+                             package_name);
+}
+
+MsgSpec MsgParser::parse_msg_file(const std::string& package_name, const std::string& file_path) {
+  MsgSpec spec;
+  std::ifstream infile(file_path);
+  std::string line;
+  while (std::getline(infile, line)) {
+    spec.full_text += line + "\n";
+    line = line.substr(0, line.find("#"));     // Remove comments.
+    line = boost::algorithm::trim_copy(line);  // Trim
+
+    if (line.empty()) {
+      // Ignore empty lines.
+      continue;
+    } else if (line.find("=") != std::string::npos) {
+      // Ignore constants.
+      continue;
+    } else {
+      // Field declaration.
+      std::vector<std::string> split_str;
+      boost::algorithm::split(split_str, line, boost::algorithm::is_any_of(" "));
+      if (split_str.size() < 2) {
+        throw MsgSpecException("Invalid declaration: " + line);
+      }
+
+      std::string field_type = split_str.front();
+      // We don't care if it is an array type.
+      field_type = field_type.substr(0, field_type.find("["));
+
+      if (is_builtin_type(field_type)) {
+        continue;
+      } else if (is_header_type(field_type)) {
+        spec.types.push_back(HEADER);
+      } else if (field_type.find("/") == std::string::npos) {
+        // Message type specifier without package_name. References messages in same package.
+        spec.types.push_back(package_name + "/" + field_type);
+      } else {
+        // Explicity type specifier: <package_name>/<message_name>.
+        spec.types.push_back(field_type);
+      }
+    }
+  }
+  return spec;
+}
+
+std::string MsgParser::get_message_schema(const std::string& message_type) {
+  std::vector<std::string> subtypes;
+  std::list<std::string> type_list = {message_type};
+
+  while (!type_list.empty()) {
+    const auto type = type_list.front();
+
+    const auto [package_name, message_name] = get_package_and_message_name(type);
+    if (msg_spec_cache_.find(type) == msg_spec_cache_.end()) {
+      msg_spec_cache_.insert(
+        {type, parse_msg_file(package_name, get_msg_file_path(package_name, message_name))});
+    }
+
+    const auto spec = msg_spec_cache_.at(type);
+    for (const auto& subtype : spec.types) {
+      if (std::find(subtypes.begin(), subtypes.end(), subtype) == subtypes.end()) {
+        subtypes.push_back(subtype);
+      }
+      type_list.push_back(subtype);
+    };
+    type_list.pop_front();
+  }
+
+  // Construct string of concatenated message definitions.
+  std::string ret_string = msg_spec_cache_[message_type].full_text;
+  for (const auto& type : subtypes) {
+    ret_string += "\n" + std::string(80, '=') + "\n";
+    ret_string += "MSG: " + type + "\n";
+    ret_string += msg_spec_cache_[type].full_text;
+  }
+
+  return ret_string;
+}
+
+}  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/msg_parser.cpp
+++ b/ros1_foxglove_bridge/src/msg_parser.cpp
@@ -1,7 +1,7 @@
-#include <filesystem>
 #include <fstream>
 
 #include <boost/algorithm/string.hpp>
+#include <boost/filesystem.hpp>
 #include <rospack/rospack.h>
 
 #include <foxglove_bridge/msg_parser.hpp>
@@ -63,8 +63,8 @@ std::string MsgParser::get_msg_file_path(const std::string& package_name,
                                          const std::string& message_name) {
   std::string package_path;
   if (rospack_->find(package_name, package_path)) {
-    const auto msg_path = std::filesystem::path(package_path) / SUB_PATH / (message_name + EXT);
-    if (std::filesystem::exists(msg_path)) {
+    const auto msg_path = boost::filesystem::path(package_path) / SUB_PATH / (message_name + EXT);
+    if (boost::filesystem::exists(msg_path)) {
       return msg_path.string();
     }
   }

--- a/ros1_foxglove_bridge/src/msg_parser.cpp
+++ b/ros1_foxglove_bridge/src/msg_parser.cpp
@@ -108,7 +108,7 @@ MsgSpec MsgParser::parse_msg_file(const std::string& package_name, const std::st
         // Message type specifier without package_name. References messages in same package.
         spec.types.push_back(package_name + "/" + field_type);
       } else {
-        // Explicity type specifier: <package_name>/<message_name>.
+        // Explicit type specifier: <package_name>/<message_name>.
         spec.types.push_back(field_type);
       }
     }

--- a/ros1_foxglove_bridge/src/msg_parser_cli.cpp
+++ b/ros1_foxglove_bridge/src/msg_parser_cli.cpp
@@ -1,0 +1,20 @@
+#include <iostream>
+
+#include <foxglove_bridge/msg_parser.hpp>
+
+int main(int argc, char const* argv[]) {
+  if (argc != 2) {
+    std::cerr << "Usage: " << argv[0] << " <msg_type>" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  foxglove_bridge::MsgParser msg_parser;
+
+  try {
+    std::cout << msg_parser.get_message_schema(argv[1]) << std::endl;
+  } catch (const std::exception& ex) {
+    std::cerr << ex.what() << std::endl;
+    return EXIT_FAILURE;
+  }
+  return EXIT_SUCCESS;
+}

--- a/ros1_foxglove_bridge/tests/msg_parser_test.cpp
+++ b/ros1_foxglove_bridge/tests/msg_parser_test.cpp
@@ -1,0 +1,50 @@
+#include <gtest/gtest.h>
+
+#include <foxglove_bridge/msg_parser.hpp>
+
+constexpr char GENDEPS_POSE_MSG[] =
+  "# A representation of pose in free space, composed of position and orientation. \n"
+  "Point position\n"
+  "Quaternion orientation\n"
+  "\n"
+  "================================================================================\n"
+  "MSG: geometry_msgs/Point\n"
+  "# This contains the position of a point in free space\n"
+  "float64 x\n"
+  "float64 y\n"
+  "float64 z\n"
+  "\n"
+  "================================================================================\n"
+  "MSG: geometry_msgs/Quaternion\n"
+  "# This represents an orientation in free space in quaternion form.\n"
+  "\n"
+  "float64 x\n"
+  "float64 y\n"
+  "float64 z\n"
+  "float64 w\n";
+
+TEST(message_parser, msg_not_found) {
+  foxglove_bridge::MsgParser msg_parser;
+  EXPECT_THROW((void)msg_parser.get_message_schema("foo/bar"),
+               foxglove_bridge::MsgNotFoundException);
+  EXPECT_TRUE(true);
+}
+
+TEST(message_parser, invalid_msg_type) {
+  foxglove_bridge::MsgParser msg_parser;
+  EXPECT_THROW((void)msg_parser.get_message_schema("foo/bar/baz"),
+               foxglove_bridge::InvalidMessageType);
+  EXPECT_TRUE(true);
+}
+
+TEST(message_parser, msg_schema) {
+  foxglove_bridge::MsgParser msg_parser;
+  EXPECT_EQ(GENDEPS_POSE_MSG, msg_parser.get_message_schema("geometry_msgs/Pose"));
+  EXPECT_TRUE(true);
+}
+
+// Run all the tests that were declared with TEST()
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
For ROS1, the full ros message definition of a topic is only available when subscribing to the topic. In order to avoid that, a simple library was added that allows to generate the full message schema without having to subscribe to the topic. The library works similar to `roslib`'s `gendeps` tool in that it parses `.msg` file on the disk to generate a schema where all types are concatenated.

This library will be used to get the message schemas for published topics. These will then be advertised as available channels.
