### PR TITLE
Add rosdep installation step to CI dockerfiles

### DIFF
--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -14,11 +14,22 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   libwebsocketpp-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Initialize rosdep
+RUN rosdep init && rosdep update
+
 # Add common files and ROS 1 source code
 COPY CMakeLists.txt /ros1_ws/src/ros-foxglove-bridge/CMakeLists.txt
 COPY package.xml /ros1_ws/src/ros-foxglove-bridge/package.xml
 COPY foxglove_bridge_base /ros1_ws/src/ros-foxglove-bridge/foxglove_bridge_base
 COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
+
+# Install rosdep dependencies
+RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
+    apt-get update && rosdep install -y \
+      --from-paths \
+        /ros1_ws/src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use the bash shell so we can use the source command
 SHELL [ "/bin/bash" , "-c" ]

--- a/Dockerfile.ros1bionic
+++ b/Dockerfile.ros1bionic
@@ -21,11 +21,22 @@ RUN cd /usr/src/gtest \
   && make \
   && cp ./*.a /usr/lib
 
+# Initialize rosdep
+RUN rosdep init && rosdep update
+
 # Add common files and ROS 1 source code
 COPY CMakeLists.txt /ros1_ws/src/ros-foxglove-bridge/CMakeLists.txt
 COPY package.xml /ros1_ws/src/ros-foxglove-bridge/package.xml
 COPY foxglove_bridge_base /ros1_ws/src/ros-foxglove-bridge/foxglove_bridge_base
 COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
+
+# Install rosdep dependencies
+RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
+    apt-get update && rosdep install -y \
+      --from-paths \
+        /ros1_ws/src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use the bash shell so we can use the source command
 SHELL [ "/bin/bash" , "-c" ]

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -6,17 +6,29 @@ ARG ROS_DISTRIBUTION=humble
 RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   python3-colcon-common-extensions \
+  python3-rosdep \
   nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \
   && rm -rf /var/lib/apt/lists/*
 
+# Initialize rosdep
+RUN rosdep init && rosdep update
+
 # Add common files and ROS 2 source code
 COPY CMakeLists.txt /ros2_ws/src/ros-foxglove-bridge/CMakeLists.txt
 COPY package.xml /ros2_ws/src/ros-foxglove-bridge/package.xml
 COPY foxglove_bridge_base /ros2_ws/src/ros-foxglove-bridge/foxglove_bridge_base
 COPY ros2_foxglove_bridge /ros2_ws/src/ros-foxglove-bridge/ros2_foxglove_bridge
+
+# Install rosdep dependencies
+RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
+    apt-get update && rosdep install -y \
+      --from-paths \
+        /ros2_ws/src \
+      --ignore-src \
+    && rm -rf /var/lib/apt/lists/*
 
 # Use the bash shell so we can use the source command
 SHELL [ "/bin/bash" , "-c" ]

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
     <depend condition="$ROS_VERSION == 1">rospack</depend>
     <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
     <depend condition="$ROS_VERSION == 2">rclcpp</depend>
+    <depend>libwebsocketpp-dev</depend>
 
     <!-- test dependencies -->
     <build_depend condition="$ROS_VERSION == 1">rostest</build_depend>
@@ -28,11 +29,9 @@
 
     <!-- common dependencies -->
     <build_depend>libssl-dev</build_depend>
-    <build_depend>libwebsocketpp-dev</build_depend>
     <build_depend>nlohmann-json-dev</build_depend>
 
     <exec_depend>openssl</exec_depend>
-    <exec_depend>websocketpp</exec_depend>
 
     <!-- The export tag contains other, unspecified, tags -->
     <export>


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Adds rosdep init & rosdep install steps to the Dockerfiles which are used for CI. This will automatically install new dependencies that are added to `package.xml` without having to manually add them to the list of installed packages.