### PR TITLE
Add ROS1 subscription support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,13 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     message(STATUS "Building with catkin")
     set(ROS_BUILD_TYPE "catkin")
 
-    find_package(catkin REQUIRED COMPONENTS nodelet roslib roscpp rospack)
+    find_package(catkin REQUIRED COMPONENTS nodelet ros_type_introspection roslib roscpp rospack)
     find_package(Boost REQUIRED)
 
     catkin_package(
       INCLUDE_DIRS foxglove_bridge_base/include ros1_foxglove_bridge/include
       LIBRARIES foxglove_bridge_base foxglove_bridge_nodelet message_parser
-      CATKIN_DEPENDS nodelet roslib roscpp rospack
+      CATKIN_DEPENDS nodelet ros_type_introspection roslib roscpp rospack
       DEPENDS Boost
     )
 
@@ -94,8 +94,8 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     target_link_libraries(get_full_message_definition message_parser)
 
     add_library(foxglove_bridge_nodelet ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp)
-    target_include_directories(foxglove_bridge_nodelet SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
-    target_link_libraries(foxglove_bridge_nodelet foxglove_bridge_base ${catkin_LIBRARIES})
+    target_include_directories(foxglove_bridge_nodelet SYSTEM PRIVATE ${catkin_INCLUDE_DIRS} ros1_foxglove_bridge/include)
+    target_link_libraries(foxglove_bridge_nodelet foxglove_bridge_base message_parser ${catkin_LIBRARIES})
 
     add_executable(foxglove_bridge ros1_foxglove_bridge/src/ros1_foxglove_bridge_node.cpp)
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -21,7 +21,6 @@
 namespace foxglove {
 
 using json = nlohmann::json;
-using namespace std::placeholders;
 
 using ConnHandle = websocketpp::connection_hdl;
 using OpCode = websocketpp::frame::opcode::value;
@@ -166,11 +165,13 @@ inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger)
 
   _server.clear_access_channels(websocketpp::log::alevel::all);
   _server.set_access_channels(APP);
-  _server.set_tcp_pre_init_handler(std::bind(&Server::socketInit, this, _1));
-  _server.set_validate_handler(std::bind(&Server::validateConnection, this, _1));
-  _server.set_open_handler(std::bind(&Server::handleConnectionOpened, this, _1));
-  _server.set_close_handler(std::bind(&Server::handleConnectionClosed, this, _1));
-  _server.set_message_handler(std::bind(&Server::handleMessage, this, _1, _2));
+  _server.set_tcp_pre_init_handler(std::bind(&Server::socketInit, this, std::placeholders::_1));
+  _server.set_validate_handler(std::bind(&Server::validateConnection, this, std::placeholders::_1));
+  _server.set_open_handler(std::bind(&Server::handleConnectionOpened, this, std::placeholders::_1));
+  _server.set_close_handler(
+    std::bind(&Server::handleConnectionClosed, this, std::placeholders::_1));
+  _server.set_message_handler(
+    std::bind(&Server::handleMessage, this, std::placeholders::_1, std::placeholders::_2));
   _server.set_reuse_addr(true);
   _server.set_listen_backlog(128);
 }

--- a/package.xml
+++ b/package.xml
@@ -13,6 +13,7 @@
 
     <!-- ROS 1 runtime dependencies -->
     <depend condition="$ROS_VERSION == 1">nodelet</depend>
+    <depend condition="$ROS_VERSION == 1">ros_type_introspection</depend>
     <depend condition="$ROS_VERSION == 1">roscpp</depend>
     <depend condition="$ROS_VERSION == 1">roslib</depend>
     <depend condition="$ROS_VERSION == 1">rospack</depend>

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -1,21 +1,264 @@
 #define ASIO_STANDALONE
 
+#include <functional>
+#include <memory>
+#include <mutex>
+#include <string>
+
 #include <nodelet/nodelet.h>
 #include <pluginlib/class_list_macros.h>
+#include <ros/message_event.h>
 #include <ros/ros.h>
+#include <ros_type_introspection/utils/shape_shifter.hpp>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
+#include <foxglove_bridge/msg_parser.hpp>
+#include <foxglove_bridge/websocket_notls.hpp>
+#include <foxglove_bridge/websocket_server.hpp>
 
 namespace foxglove_bridge {
 
+constexpr int DEFAULT_PORT = 8765;
+constexpr int DEFAULT_MAX_UPDATE_MS = 5000;
+constexpr char ROS1_CHANNEL_ENCODING[] = "ros1";
+constexpr uint32_t SUBSCRIPTION_QUEUE_LENGTH = 10;
+
+using ServerType = foxglove::Server<foxglove::WebSocketNoTls>;
+using TopicAndDatatype = std::pair<std::string, std::string>;
+using Subscription = ros::Subscriber;
+
 class FoxgloveBridge : public nodelet::Nodelet {
 public:
-  FoxgloveBridge(){};
-  virtual ~FoxgloveBridge() {}
+  FoxgloveBridge() = default;
   virtual void onInit() {
+    auto& nhp = getPrivateNodeHandle();
+    const int port = nhp.param<int>("port", DEFAULT_PORT);
+    const int max_update_ms = nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS);
+
     ROS_INFO("Starting %s with %s", ros::this_node::getName().c_str(),
              foxglove::WebSocketUserAgent());
+
+    _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
+      "foxglove_bridge",
+      std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2));
+    _server->setSubscribeHandler(
+      std::bind(&FoxgloveBridge::subscribeHandler, this, std::placeholders::_1));
+    _server->setUnsubscribeHandler(
+      std::bind(&FoxgloveBridge::unsubscribeHandler, this, std::placeholders::_1));
+    _server->start(static_cast<uint16_t>(port));
+
+    _msgParser = std::make_unique<foxglove_bridge::MsgParser>();
+    _updateTimer = getMTNodeHandle().createTimer(ros::Duration(max_update_ms / 1e3),
+                                                 &FoxgloveBridge::updateAdvertisedTopics, this);
   };
+  virtual ~FoxgloveBridge() {
+    if (_server) {
+      _server->stop();
+    }
+  }
+
+private:
+  struct PairHash {
+    template <class T1, class T2>
+    std::size_t operator()(const std::pair<T1, T2>& pair) const {
+      return std::hash<T1>()(pair.first) ^ std::hash<T2>()(pair.second);
+    }
+  };
+
+  void subscribeHandler(foxglove::ChannelId channelId) {
+    std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+    if (_subscriptions.find(channelId) != _subscriptions.end()) {
+      // Subscription already exists
+      ROS_WARN("Subscription already exists for channel %d", channelId);
+      return;
+    }
+
+    auto it = _channelToTopicAndDatatype.find(channelId);
+    if (it == _channelToTopicAndDatatype.end()) {
+      ROS_WARN("Received subscribe request for unknown channel %d", channelId);
+      return;
+    }
+    auto& topicAndDatatype = it->second;
+    auto topic = topicAndDatatype.first;
+    auto datatype = topicAndDatatype.second;
+    auto it2 = _advertisedTopics.find(topicAndDatatype);
+    if (it2 == _advertisedTopics.end()) {
+      ROS_ERROR("Channel %d for topic \"%s\" (%s) is not advertised", channelId, topic.c_str(),
+                datatype.c_str());
+      return;
+    }
+    auto& channel = it2->second;
+
+    try {
+      _subscriptions.emplace(channelId, getMTNodeHandle().subscribe<RosIntrospection::ShapeShifter>(
+                                          topic, SUBSCRIPTION_QUEUE_LENGTH,
+                                          std::bind(&FoxgloveBridge::rosMessageHandler, this,
+                                                    channel, std::placeholders::_1))
+
+      );
+      ROS_INFO("Subscribed to topic \"%s\" (%s) on channel %d", topic.c_str(), datatype.c_str(),
+               channelId);
+    } catch (const std::exception& ex) {
+      ROS_ERROR("Failed to subscribe to topic \"%s\" (%s): %s", topic.c_str(), datatype.c_str(),
+                ex.what());
+    }
+  }
+
+  void unsubscribeHandler(foxglove::ChannelId channelId) {
+    std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+
+    auto it = _channelToTopicAndDatatype.find(channelId);
+    TopicAndDatatype topicAndDatatype =
+      it != _channelToTopicAndDatatype.end()
+        ? it->second
+        : std::make_pair<std::string, std::string>("[Unknown]", "[Unknown]");
+
+    auto it2 = _subscriptions.find(channelId);
+    if (it2 == _subscriptions.end()) {
+      ROS_WARN("Received unsubscribe request for unknown channel %d", channelId);
+      return;
+    }
+
+    ROS_INFO("Unsubscribing from topic \"%s\" (%s) on channel %d", topicAndDatatype.first.c_str(),
+             topicAndDatatype.second.c_str(), channelId);
+    _subscriptions.erase(it2);
+  }
+
+  void updateAdvertisedTopics(const ros::TimerEvent&) {
+    _updateTimer.stop();
+    if (!ros::ok()) {
+      return;
+    }
+
+    // Get the current list of visible topics and datatypes from the ROS graph
+    std::vector<ros::master::TopicInfo> topicNamesAndTypes;
+    if (!ros::master::getTopics(topicNamesAndTypes)) {
+      ROS_WARN("Failed to retrieve published topics from ROS master.");
+      return;
+    }
+
+    std::unordered_set<TopicAndDatatype, PairHash> latestTopics;
+    latestTopics.reserve(topicNamesAndTypes.size());
+    for (const auto& topicNameAndType : topicNamesAndTypes) {
+      latestTopics.emplace(topicNameAndType.name, topicNameAndType.datatype);
+    }
+
+    // Create a list of topics that are new to us
+    std::vector<TopicAndDatatype> newTopics;
+    for (const auto& topic : latestTopics) {
+      if (_advertisedTopics.find(topic) == _advertisedTopics.end()) {
+        newTopics.push_back(topic);
+      }
+    }
+
+    // Create a list of topics that have been removed
+    std::vector<TopicAndDatatype> removedTopics;
+    for (const auto& [topic, channel] : _advertisedTopics) {
+      if (latestTopics.find(topic) == latestTopics.end()) {
+        removedTopics.push_back(topic);
+      }
+    }
+
+    // Remove advertisements for topics that have been removed
+    {
+      std::lock_guard<std::mutex> lock(_subscriptionsMutex);
+      for (const auto& topicAndDatatype : removedTopics) {
+        auto& channel = _advertisedTopics.at(topicAndDatatype);
+
+        // Stop tracking this channel in the WebSocket server
+        _server->removeChannel(channel.id);
+
+        // Remove the subscription for this topic, if any
+        _subscriptions.erase(channel.id);
+
+        // Remove this topic+datatype tuple
+        _channelToTopicAndDatatype.erase(channel.id);
+        _advertisedTopics.erase(topicAndDatatype);
+
+        ROS_DEBUG("Removed channel %d for topic \"%s\" (%s)", channel.id,
+                  topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+      }
+
+      // Advertise new topics
+      for (const auto& topicAndDatatype : newTopics) {
+        foxglove::ChannelWithoutId newChannel{};
+        newChannel.topic = topicAndDatatype.first;
+        newChannel.schemaName = topicAndDatatype.second;
+        newChannel.encoding = ROS1_CHANNEL_ENCODING;
+
+        try {
+          newChannel.schema = _msgParser->get_message_schema(topicAndDatatype.second);
+          auto channel = foxglove::Channel{_server->addChannel(newChannel), newChannel};
+          ROS_DEBUG("Advertising channel %d for topic \"%s\" (%s)", channel.id,
+                    channel.topic.c_str(), channel.schemaName.c_str());
+
+          // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
+          // topic+datatype tuple
+          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+          _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
+        } catch (const foxglove_bridge::MsgNotFoundException& err) {
+          ROS_WARN("Could not find definition for topic \"%s\" (%s)",
+                   topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+
+          // Add a mapping from the topic+datatype tuple to a dummy channel so we don't repeatedly
+          // try to load the message definition
+          auto channel = foxglove::Channel{0, newChannel};
+          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+        } catch (const std::exception& err) {
+          ROS_WARN("Failed to add channel for topic \"%s\" (%s): %s",
+                   topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str(), err.what());
+        }
+      }
+    }
+
+    if (newTopics.size() > 0) {
+      _server->broadcastChannels();
+    }
+
+    // Schedule the next update using truncated exponential backoff, up to `_maxUpdateMs`
+    _updateCount++;
+    auto nextUpdateMs = static_cast<double>(std::min(size_t(1) << _updateCount, _maxUpdateMs));
+    _updateTimer = getMTNodeHandle().createTimer(ros::Duration(nextUpdateMs / 1e3),
+                                                 &FoxgloveBridge::updateAdvertisedTopics, this);
+  }
+
+  void logHandler(foxglove::WebSocketLogLevel level, char const* msg) {
+    switch (level) {
+      case foxglove::WebSocketLogLevel::Debug:
+        ROS_DEBUG("[WS] %s", msg);
+        break;
+      case foxglove::WebSocketLogLevel::Info:
+        ROS_INFO("[WS] %s", msg);
+        break;
+      case foxglove::WebSocketLogLevel::Warn:
+        ROS_WARN("[WS] %s", msg);
+        break;
+      case foxglove::WebSocketLogLevel::Error:
+        ROS_ERROR("[WS] %s", msg);
+        break;
+      case foxglove::WebSocketLogLevel::Critical:
+        ROS_FATAL("[WS] %s", msg);
+        break;
+    }
+  }
+
+  void rosMessageHandler(const foxglove::Channel& channel,
+                         const ros::MessageEvent<RosIntrospection::ShapeShifter const>& msgEvent) {
+    const auto& msg = msgEvent.getConstMessage();
+    _server->sendMessage(
+      channel.id, msgEvent.getReceiptTime().toNSec(),
+      std::string_view(reinterpret_cast<const char*>(msg->raw_data()), msg->size()));
+  }
+
+  std::unique_ptr<ServerType> _server;
+  std::unique_ptr<foxglove_bridge::MsgParser> _msgParser;
+  std::unordered_map<TopicAndDatatype, foxglove::Channel, PairHash> _advertisedTopics;
+  std::unordered_map<foxglove::ChannelId, TopicAndDatatype> _channelToTopicAndDatatype;
+  std::unordered_map<foxglove::ChannelId, Subscription> _subscriptions;
+  std::mutex _subscriptionsMutex;
+  ros::Timer _updateTimer;
+  size_t _maxUpdateMs = size_t(DEFAULT_MAX_UPDATE_MS);
+  size_t _updateCount = 0;
 };
 
 }  // namespace foxglove_bridge


### PR DESCRIPTION
**Public-Facing Changes**
Advertises ROS1 topics as channels and allows to subscribe to them e.g. from Foxglove Studio.

**Description**
Implementation is mainly based on https://github.com/achim-k/foxglove_websocket_server

One mayor problem that I noticed, is that the message schema parsing approach (parsing .msg files from the disk) does not work if topics are published from a bag file. We will have to think about what to do here, maybe the solution is then to fallback and subscribe to the topic once to get the message definition from the connection header.