### PR TITLE
Switch foxglove_bridge_base back to a STATIC library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ if (ENDIAN)
 endif()
 
 # Build the foxglove_bridge_base library
-add_library(foxglove_bridge_base SHARED
+add_library(foxglove_bridge_base STATIC
   foxglove_bridge_base/src/foxglove_bridge.cpp
 )
 target_include_directories(foxglove_bridge_base


### PR DESCRIPTION
**Public-Facing Changes**

**Description**
It wasn't clear why this was switched from a STATIC to SHARED library, but I think it broke the ROS 2 node.
