### PR TITLE
Fix missing install rule.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -177,5 +177,11 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     install(TARGETS foxglove_bridge
       DESTINATION lib/${PROJECT_NAME}
     )
+    install(TARGETS foxglove_bridge_base
+      ARCHIVE DESTINATION lib
+      LIBRARY DESTINATION lib
+      RUNTIME DESTINATION bin
+    )
+    ament_export_libraries(foxglove_bridge_base)
     ament_package()
 endif()


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Fixes a missing ros2 install rule for the `foxglove_bridge_base` library

