### PR TITLE
Add GitHub action to publish Docker containers to GHCR

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   lldb \
   lsb-release \
   nlohmann-json3-dev \
+  openssh-client \
   python3-colcon-common-extensions \
   python3-pip \
   python3-rosdep \

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,53 @@
+name: Publish
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  docker:
+    strategy:
+      matrix:
+        ros: ["melodic", "noetic", "foxy", "galactic", "humble", "rolling"]
+
+    name: Publish ROS ${{ matrix.ros }} container to GHCR
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: satackey/action-docker-layer-caching@v0.0.11
+        continue-on-error: true
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate Docker tags
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            latest
+
+      - name: Configure QEMU
+        uses: docker/setup-qemu-action@v2
+
+      - name: Configure Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and push
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: ./Dockerfile.ros${{ fromJSON('["2", "1"]')[contains(fromJson('["melodic", "noetic"]'), matrix.ros)] }}
+          build-args: |
+            ROS_DISTRIBUTION=${{ matrix.ros }}
+          push: true
+          platforms: linux/amd64,linux/arm64,linux/arm/v7
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -30,7 +30,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ghcr.io/${{ github.repository }}
+          images: ghcr.io/foxglove/foxglove_bridge-${{ matrix.ros }}
           tags: |
             latest
 


### PR DESCRIPTION
**Public-Facing Changes**
- Docker containers are published for six ROS versions and three architectures

**Description**
This only publishes the "latest" tag on merge to `main` since we don't have a versioned release process yet.
