### PR TITLE
COPY nodelets.xml, add CMDs to Dockerfiles

### DIFF
--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -16,6 +16,7 @@ RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
 # Add common files and ROS 1 source code
 COPY CMakeLists.txt /ros1_ws/src/ros-foxglove-bridge/CMakeLists.txt
 COPY foxglove_bridge_base /ros1_ws/src/ros-foxglove-bridge/foxglove_bridge_base
+COPY nodelets.xml /ros1_ws/src/ros-foxglove-bridge/nodelets.xml
 COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
 
 # Build and install gtest.
@@ -32,3 +33,6 @@ RUN echo "source /ros1_ws/devel/setup.bash" >> ~/.bashrc
 
 # Set the working folder at startup
 WORKDIR /ros1_ws
+
+# Run foxglove_bridge
+CMD ["/bin/bash", "-c", "source /ros1_ws/devel/setup.bash && rosrun foxglove_bridge foxglove_bridge"]

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -41,3 +41,6 @@ RUN echo "source /ros2_ws/install/setup.bash" >> ~/.bashrc
 
 # Set the working folder at startup
 WORKDIR /ros2_ws
+
+# Run foxglove_bridge
+CMD ["/bin/bash", "-c", "source /ros2_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge"]


### PR DESCRIPTION
**Public-Facing Changes**
- Fixed a missing nodelets.xml in the ROS 1 node
- Docker containers run the foxglove_bridge node by default

**Description**
