### PR TITLE
Add address parameter

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -93,7 +93,7 @@ public:
   Server& operator=(const Server&) = delete;
   Server& operator=(Server&&) = delete;
 
-  void start(uint16_t port);
+  void start(const std::string& host, uint16_t port);
   void stop();
 
   ChannelId addChannel(ChannelWithoutId channel);
@@ -347,14 +347,14 @@ inline void Server<ServerConfiguration>::stop() {
 }
 
 template <typename ServerConfiguration>
-inline void Server<ServerConfiguration>::start(uint16_t port) {
+inline void Server<ServerConfiguration>::start(const std::string& host, uint16_t port) {
   if (_serverThread) {
     throw std::runtime_error("Server already started");
   }
 
   std::error_code ec;
 
-  _server.listen(port, ec);
+  _server.listen(host, std::to_string(port), ec);
   if (ec) {
     throw std::runtime_error("Failed to listen on port " + std::to_string(port) + ": " +
                              ec.message());

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_node.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_node.cpp
@@ -7,7 +7,10 @@ int main(int argc, char** argv) {
   nodelet::M_string remap(ros::names::getRemappings());
   nodelet::V_string nargv;
   std::string nodelet_name = ros::this_node::getName();
-  nodelet.load(nodelet_name, "foxglove_bridge/foxglove_bridge_nodelet", remap, nargv);
-  ros::spin();
-  return 0;
+  if (nodelet.load(nodelet_name, "foxglove_bridge/foxglove_bridge_nodelet", remap, nargv)) {
+    ros::spin();
+    return EXIT_SUCCESS;
+  } else {
+    return EXIT_FAILURE;
+  }
 }

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -55,6 +55,8 @@ public:
                                                    &FoxgloveBridge::updateAdvertisedTopics, this);
     } catch (const std::exception& err) {
       ROS_ERROR("Failed to start websocket server: %s", err.what());
+      // Rethrow exception such that the nodelet is unloaded.
+      throw err;
     }
   };
   virtual ~FoxgloveBridge() {

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -19,7 +19,7 @@
 namespace foxglove_bridge {
 
 constexpr int DEFAULT_PORT = 8765;
-constexpr char DEFAULT_HOST[] = "0.0.0.0";
+constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
 constexpr int DEFAULT_MAX_UPDATE_MS = 5000;
 constexpr char ROS1_CHANNEL_ENCODING[] = "ros1";
 constexpr uint32_t SUBSCRIPTION_QUEUE_LENGTH = 10;
@@ -33,7 +33,7 @@ public:
   FoxgloveBridge() = default;
   virtual void onInit() {
     auto& nhp = getPrivateNodeHandle();
-    const auto host = nhp.param<std::string>("host", DEFAULT_HOST);
+    const auto address = nhp.param<std::string>("address", DEFAULT_ADDRESS);
     const int port = nhp.param<int>("port", DEFAULT_PORT);
     const int max_update_ms = nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS);
 
@@ -48,7 +48,7 @@ public:
         std::bind(&FoxgloveBridge::subscribeHandler, this, std::placeholders::_1));
       _server->setUnsubscribeHandler(
         std::bind(&FoxgloveBridge::unsubscribeHandler, this, std::placeholders::_1));
-      _server->start(host, static_cast<uint16_t>(port));
+      _server->start(address, static_cast<uint16_t>(port));
 
       _msgParser = std::make_unique<foxglove_bridge::MsgParser>();
       _updateTimer = getMTNodeHandle().createTimer(ros::Duration(max_update_ms / 1e3),

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -14,6 +14,7 @@
 #include <foxglove_bridge/websocket_server.hpp>
 
 constexpr uint16_t DEFAULT_PORT = 8765;
+constexpr char DEFAULT_HOST[] = "0.0.0.0";
 constexpr int DEFAULT_MAX_UPDATE_MS = 5000;
 constexpr int DEFAULT_NUM_THREADS = 0;
 
@@ -45,6 +46,13 @@ public:
     portDescription.integer_range[0].step = 1;
     this->declare_parameter("port", DEFAULT_PORT, portDescription);
 
+    auto hostDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    hostDescription.name = "host";
+    hostDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+    hostDescription.description = "The host address to bind the WebSocket server to";
+    hostDescription.read_only = true;
+    this->declare_parameter("host", DEFAULT_HOST, hostDescription);
+
     auto maxUpdateDescription = rcl_interfaces::msg::ParameterDescriptor{};
     maxUpdateDescription.name = "max_update_ms";
     maxUpdateDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
@@ -75,8 +83,9 @@ public:
     _server.setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1));
     _server.setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1));
 
+    auto host = this->get_parameter("host").as_string();
     uint16_t port = uint16_t(this->get_parameter("port").as_int());
-    _server.start(port);
+    _server.start(host, port);
 
     // Get the actual port we bound to
     uint16_t listeningPort = _server.localEndpoint()->port();

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -14,7 +14,7 @@
 #include <foxglove_bridge/websocket_server.hpp>
 
 constexpr uint16_t DEFAULT_PORT = 8765;
-constexpr char DEFAULT_HOST[] = "0.0.0.0";
+constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
 constexpr int DEFAULT_MAX_UPDATE_MS = 5000;
 constexpr int DEFAULT_NUM_THREADS = 0;
 
@@ -46,12 +46,12 @@ public:
     portDescription.integer_range[0].step = 1;
     this->declare_parameter("port", DEFAULT_PORT, portDescription);
 
-    auto hostDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    hostDescription.name = "host";
-    hostDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    hostDescription.description = "The host address to bind the WebSocket server to";
-    hostDescription.read_only = true;
-    this->declare_parameter("host", DEFAULT_HOST, hostDescription);
+    auto addressDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    addressDescription.name = "address";
+    addressDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+    addressDescription.description = "The host address to bind the WebSocket server to";
+    addressDescription.read_only = true;
+    this->declare_parameter("address", DEFAULT_ADDRESS, addressDescription);
 
     auto maxUpdateDescription = rcl_interfaces::msg::ParameterDescriptor{};
     maxUpdateDescription.name = "max_update_ms";
@@ -83,9 +83,9 @@ public:
     _server.setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1));
     _server.setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1));
 
-    auto host = this->get_parameter("host").as_string();
+    auto address = this->get_parameter("address").as_string();
     uint16_t port = uint16_t(this->get_parameter("port").as_int());
-    _server.start(host, port);
+    _server.start(address, port);
 
     // Get the actual port we bound to
     uint16_t listeningPort = _server.localEndpoint()->port();


### PR DESCRIPTION
**Public-Facing Changes**
Add `address` parameter


**Description**

Adds the `address` parameter which is forwarded to [websocketpp::transport::asio::endpoint<config>::listen](https://docs.websocketpp.org/classwebsocketpp_1_1transport_1_1asio_1_1endpoint.html#a85606665cc9c948194076c2377cb61c0) `host` parameter:

> host | A string identifying a location. May be a descriptive name or a numeric address string.
> -- | --






Fixes #36