### PR TITLE
Add support for latched topics (or topics published with transient local policy)

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -82,6 +82,7 @@ public:
   using ConnectionType = websocketpp::connection<ServerConfiguration>;
   using MessagePtr = typename ServerType::message_ptr;
   using Tcp = websocketpp::lib::asio::ip::tcp;
+  using SubscribeUnsubscribeHandler = std::function<void(ChannelId, ConnHandle)>;
 
   static const std::string SUPPORTED_SUBPROTOCOL;
 
@@ -100,10 +101,12 @@ public:
   void removeChannel(ChannelId chanId);
   void broadcastChannels();
 
-  void setSubscribeHandler(std::function<void(ChannelId)> handler);
-  void setUnsubscribeHandler(std::function<void(ChannelId)> handler);
+  void setSubscribeHandler(SubscribeUnsubscribeHandler handler);
+  void setUnsubscribeHandler(SubscribeUnsubscribeHandler handler);
 
   void sendMessage(ChannelId chanId, uint64_t timestamp, std::string_view data);
+  void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
+                   std::string_view data);
 
   std::optional<Tcp::endpoint> localEndpoint();
 
@@ -128,8 +131,8 @@ private:
   uint32_t _nextChannelId = 0;
   std::map<ConnHandle, ClientInfo, std::owner_less<>> _clients;
   std::unordered_map<ChannelId, Channel> _channels;
-  std::function<void(ChannelId)> _subscribeHandler;
-  std::function<void(ChannelId)> _unsubscribeHandler;
+  SubscribeUnsubscribeHandler _subscribeHandler;
+  SubscribeUnsubscribeHandler _unsubscribeHandler;
   std::shared_mutex _clientsChannelMutex;
 
   void socketInit(ConnHandle hdl);
@@ -141,8 +144,6 @@ private:
   void sendJson(ConnHandle hdl, json&& payload);
   void sendJsonRaw(ConnHandle hdl, const std::string& payload);
   void sendBinary(ConnHandle hdl, const std::vector<uint8_t>& payload);
-
-  bool anySubscribed(ChannelId chanId) const;
 };
 
 template <typename ServerConfiguration>
@@ -250,22 +251,19 @@ inline void Server<ServerConfiguration>::handleConnectionClosed(ConnHandle hdl) 
 
   if (_unsubscribeHandler) {
     for (const auto& [chanId, subs] : oldSubscriptionsByChannel) {
-      if (!anySubscribed(chanId)) {
-        _unsubscribeHandler(chanId);
-      }
+      _unsubscribeHandler(chanId, hdl);
     }
   }
 }
 
 template <typename ServerConfiguration>
-inline void Server<ServerConfiguration>::setSubscribeHandler(
-  std::function<void(ChannelId)> handler) {
+inline void Server<ServerConfiguration>::setSubscribeHandler(SubscribeUnsubscribeHandler handler) {
   _subscribeHandler = std::move(handler);
 }
 
 template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::setUnsubscribeHandler(
-  std::function<void(ChannelId)> handler) {
+  SubscribeUnsubscribeHandler handler) {
   _unsubscribeHandler = std::move(handler);
 }
 
@@ -462,10 +460,9 @@ inline void Server<ServerConfiguration>::handleMessage(ConnHandle hdl, MessagePt
                         });
           continue;
         }
-        bool firstSubscription = !anySubscribed(channelId);
         clientInfo.subscriptionsByChannel.emplace(channelId, subId);
-        if (firstSubscription && _subscribeHandler) {
-          _subscribeHandler(channelId);
+        if (_subscribeHandler) {
+          _subscribeHandler(channelId, hdl);
         }
       }
     } else if (op == "unsubscribe") {
@@ -483,8 +480,8 @@ inline void Server<ServerConfiguration>::handleMessage(ConnHandle hdl, MessagePt
         }
         ChannelId chanId = sub->first;
         clientInfo.subscriptionsByChannel.erase(sub);
-        if (!anySubscribed(chanId) && _unsubscribeHandler) {
-          _unsubscribeHandler(chanId);
+        if (_unsubscribeHandler) {
+          _unsubscribeHandler(chanId, hdl);
         }
       }
 
@@ -568,6 +565,30 @@ inline void Server<ServerConfiguration>::sendMessage(ChannelId chanId, uint64_t 
 }
 
 template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, ChannelId chanId,
+                                                     uint64_t timestamp, std::string_view data) {
+  std::shared_lock<std::shared_mutex> lock(_clientsChannelMutex);
+
+  const auto clientHandleAndInfoIt = _clients.find(clientHandle);
+  if (clientHandleAndInfoIt == _clients.end()) {
+    return;  // Client got removed in the meantime.
+  }
+
+  const auto& client = clientHandleAndInfoIt->second;
+  const auto& subs = client.subscriptionsByChannel.find(chanId);
+  if (subs == client.subscriptionsByChannel.end()) {
+    return;  // Client not subscribed to this channel.
+  }
+  const auto subId = subs->second;
+  std::vector<uint8_t> message(1 + 4 + 8 + data.size());
+  message[0] = uint8_t(BinaryOpcode::MESSAGE_DATA);
+  foxglove::WriteUint32LE(message.data() + 1, subId);
+  foxglove::WriteUint64LE(message.data() + 5, timestamp);
+  std::memcpy(message.data() + 1 + 4 + 8, data.data(), data.size());
+  sendBinary(clientHandle, message);
+}
+
+template <typename ServerConfiguration>
 inline std::optional<asio::ip::tcp::endpoint> Server<ServerConfiguration>::localEndpoint() {
   std::error_code ec;
   auto endpoint = _server.get_local_endpoint(ec);
@@ -575,16 +596,6 @@ inline std::optional<asio::ip::tcp::endpoint> Server<ServerConfiguration>::local
     return std::nullopt;
   }
   return endpoint;
-}
-
-template <typename ServerConfiguration>
-inline bool Server<ServerConfiguration>::anySubscribed(ChannelId chanId) const {
-  for (const auto& [hdl, client] : _clients) {
-    if (client.subscriptionsByChannel.find(chanId) != client.subscriptionsByChannel.end()) {
-      return true;
-    }
-  }
-  return false;
 }
 
 }  // namespace foxglove

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -17,23 +17,13 @@
 constexpr uint16_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
 constexpr int DEFAULT_NUM_THREADS = 0;
+constexpr size_t DEFAULT_MAX_QOS_DEPTH = 10;
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
 using LogLevel = foxglove::WebSocketLogLevel;
 using Subscription = std::pair<rclcpp::GenericSubscription::SharedPtr, rclcpp::SubscriptionOptions>;
 using SubscriptionsByClient = std::map<foxglove::ConnHandle, Subscription, std::owner_less<>>;
-
-constexpr char DEFAULT_SUBSCRIPTION_QOS_PRESET[] = "sensor_data";
-static const std::unordered_map<std::string, rmw_qos_profile_t> QOS_PRESETS = {
-  {"sensor_data", rmw_qos_profile_sensor_data},
-  {"parameters", rmw_qos_profile_parameters},
-  {"default", rmw_qos_profile_default},
-  {"services_default", rmw_qos_profile_services_default},
-  {"parameter_events", rmw_qos_profile_parameter_events},
-  {"system_default", rmw_qos_profile_system_default},
-  {"unknown", rmw_qos_profile_unknown},
-};
 
 class FoxgloveBridge : public rclcpp::Node {
 public:
@@ -78,19 +68,18 @@ public:
     numThreadsDescription.integer_range[0].step = 1;
     this->declare_parameter("num_threads", DEFAULT_NUM_THREADS, numThreadsDescription);
 
-    auto subscriptionQosPresetDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    subscriptionQosPresetDescription.name = "subscription_qos_preset";
-    subscriptionQosPresetDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
-    subscriptionQosPresetDescription.description = "QOS preset used for subscriptions.";
-    subscriptionQosPresetDescription.read_only = true;
-    subscriptionQosPresetDescription.additional_constraints = "Must be one of [";
-    for (const auto& [name, qosProfile] : QOS_PRESETS) {
-      (void)qosProfile;
-      subscriptionQosPresetDescription.additional_constraints += name + ", ";
-    }
-    subscriptionQosPresetDescription.additional_constraints += "]";
-    this->declare_parameter("subscription_qos_preset", DEFAULT_SUBSCRIPTION_QOS_PRESET,
-                            subscriptionQosPresetDescription);
+    auto maxQosDepthDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    maxQosDepthDescription.name = "max_qos_depth";
+    maxQosDepthDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+    maxQosDepthDescription.description = "Maximum depth used for the QoS profile of subscriptions.";
+    maxQosDepthDescription.read_only = true;
+    maxQosDepthDescription.additional_constraints = "Must be a non-negative integer";
+    maxQosDepthDescription.integer_range.resize(1);
+    maxQosDepthDescription.integer_range[0].from_value = 0;
+    maxQosDepthDescription.integer_range[0].to_value = INT32_MAX;
+    maxQosDepthDescription.integer_range[0].step = 1;
+    this->declare_parameter("max_qos_depth", static_cast<int>(DEFAULT_MAX_QOS_DEPTH),
+                            maxQosDepthDescription);
 
     _server.setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));
     _server.setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2));
@@ -111,15 +100,7 @@ public:
     _rosgraphPollThread =
       std::make_unique<std::thread>(std::bind(&FoxgloveBridge::rosgraphPollThread, this));
 
-    const auto subscriptionQosPresetName =
-      this->get_parameter("subscription_qos_preset").as_string();
-    try {
-      _defaultSubscriptionQos = QOS_PRESETS.at(subscriptionQosPresetName);
-    } catch (const std::out_of_range&) {
-      RCLCPP_ERROR(this->get_logger(), "QOS preset '%s' not found. Using default preset '%s'",
-                   subscriptionQosPresetName.c_str(), DEFAULT_SUBSCRIPTION_QOS_PRESET);
-      _defaultSubscriptionQos = QOS_PRESETS.at(DEFAULT_SUBSCRIPTION_QOS_PRESET);
-    }
+    _maxQosDepth = this->get_parameter("max_qos_depth").as_int();
   }
 
   ~FoxgloveBridge() {
@@ -290,7 +271,7 @@ private:
   std::unordered_map<foxglove::ChannelId, SubscriptionsByClient> _subscriptions;
   std::mutex _subscriptionsMutex;
   std::unique_ptr<std::thread> _rosgraphPollThread;
-  rmw_qos_profile_t _defaultSubscriptionQos;
+  size_t _maxQosDepth = DEFAULT_MAX_QOS_DEPTH;
   std::shared_ptr<rclcpp::Subscription<rosgraph_msgs::msg::Clock>> _clockSubscription;
   std::atomic<uint64_t> _simTimeNs = 0;
   std::atomic<bool> _useSimTime = false;
@@ -339,26 +320,23 @@ private:
     // Select an appropriate subscription QOS profile. This is similar to how ros2 topic echo
     // does it:
     // https://github.com/ros2/ros2cli/blob/619b3d1c9/ros2topic/ros2topic/verb/echo.py#L137-L194
-    size_t depth = 1;
+    size_t depth = 0;
     size_t reliabilityReliableEndpointsCount = 0;
     size_t durabilityTransientLocalEndpointsCount = 0;
 
     const auto publisherInfo = this->get_publishers_info_by_topic(topic);
     for (const auto& publisher : publisherInfo) {
       const auto& qos = publisher.qos_profile();
-
       if (qos.reliability() == rclcpp::ReliabilityPolicy::Reliable) {
         ++reliabilityReliableEndpointsCount;
       }
       if (qos.durability() == rclcpp::DurabilityPolicy::TransientLocal) {
         ++durabilityTransientLocalEndpointsCount;
       }
-
-      constexpr size_t MAX_QUEUE_DEPTH = 10;
-      depth = std::min(MAX_QUEUE_DEPTH, depth + qos.depth());
+      depth = std::min(_maxQosDepth, depth + qos.depth());
     }
 
-    rclcpp::QoS qos{rclcpp::KeepLast(depth), _defaultSubscriptionQos};
+    rclcpp::QoS qos{rclcpp::KeepLast(std::max(depth, 1lu))};
 
     // If all endpoints are reliable, ask for reliable
     if (reliabilityReliableEndpointsCount == publisherInfo.size()) {


### PR DESCRIPTION
**Public-Facing Changes**
Add support for topics that are latched (ROS1) or published with transient local durability policy (ROS2)

**Description**
Instead of having only a single subscriber instance per topic, we now create a subscriber for every client that subscribes to the topic. This way we do not have to re-implement the latching logic and we instead rely on ROS to correctly send latched messages to new subscriber instances.

Update:
- Mirrors subscription qos profile selection of `ros2 topic echo` ([source](https://github.com/ros2/ros2cli/blob/619b3d1c9b38f49bfd2a9286b1086d8eed1ecb94/ros2topic/ros2topic/verb/echo.py#L137-L194))
- Allows setting a max QoS depth via ROS2 parameter

Fixes #30 
Fixes #31 
