### PR TITLE
Advertise topics with unknown data type with empty schema

### DIFF
--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -229,26 +229,26 @@ private:
 
         try {
           newChannel.schema = _msgParser->get_message_schema(topicAndDatatype.second);
-          auto channel = foxglove::Channel{_server->addChannel(newChannel), newChannel};
-          ROS_DEBUG("Advertising channel %d for topic \"%s\" (%s)", channel.id,
-                    channel.topic.c_str(), channel.schemaName.c_str());
-
-          // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
-          // topic+datatype tuple
-          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
-          _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
         } catch (const foxglove_bridge::MsgNotFoundException& err) {
-          ROS_WARN("Could not find definition for topic \"%s\" (%s)",
-                   topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+          ROS_WARN("Could not find definition for type %s: %s", topicAndDatatype.second.c_str(),
+                   err.what());
 
-          // Add a mapping from the topic+datatype tuple to a dummy channel so we don't repeatedly
-          // try to load the message definition
-          auto channel = foxglove::Channel{0, newChannel};
-          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+          // We still advertise the channel, but with an emtpy schema
+          newChannel.schema = "";
         } catch (const std::exception& err) {
           ROS_WARN("Failed to add channel for topic \"%s\" (%s): %s",
                    topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str(), err.what());
+          continue;
         }
+
+        auto channel = foxglove::Channel{_server->addChannel(newChannel), newChannel};
+        ROS_DEBUG("Advertising channel %d for topic \"%s\" (%s)", channel.id, channel.topic.c_str(),
+                  channel.schemaName.c_str());
+
+        // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
+        // topic+datatype tuple
+        _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+        _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
       }
     }
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -231,23 +231,21 @@ public:
               break;
           }
 
-          auto channel = foxglove::Channel{_server.addChannel(newChannel), newChannel};
-          RCLCPP_DEBUG(this->get_logger(), "Advertising channel %d for topic \"%s\" (%s)",
-                       channel.id, channel.topic.c_str(), channel.schemaName.c_str());
-
-          // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
-          // topic+datatype tuple
-          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
-          _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
         } catch (const foxglove::DefinitionNotFoundError& err) {
-          RCLCPP_WARN(this->get_logger(), "Could not find definition for topic \"%s\" (%s)",
-                      topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
-
-          // Add a mapping from the topic+datatype tuple to a dummy channel so we don't repeatedly
-          // try to load the message definition
-          auto channel = foxglove::Channel{0, newChannel};
-          _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+          RCLCPP_WARN(this->get_logger(), "Could not find definition for type %s: %s",
+                      topicAndDatatype.second.c_str(), err.what());
+          // We still advertise the channel, but with an emtpy schema
+          newChannel.schema = "";
         }
+
+        auto channel = foxglove::Channel{_server.addChannel(newChannel), newChannel};
+        RCLCPP_DEBUG(this->get_logger(), "Advertising channel %d for topic \"%s\" (%s)", channel.id,
+                     channel.topic.c_str(), channel.schemaName.c_str());
+
+        // Add a mapping from the topic+datatype tuple to the channel, and channel ID to the
+        // topic+datatype tuple
+        _advertisedTopics.emplace(topicAndDatatype, std::move(channel));
+        _channelToTopicAndDatatype.emplace(channel.id, topicAndDatatype);
       }
     }
 


### PR DESCRIPTION
**Public-Facing Changes**
Advertise topics with unknown data type with empty schema


**Description**
Advertises topics with unknown data type with an empty schema. Before we were not advertising these topics hence the client did not know about it. This is similar to what rosbridge does.
