### PR TITLE
Add SSL server support

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ Parameters are provided to configure the behavior of the bridge. These parameter
 
  * __port__: The TCP port to bind the WebSocket server to. Must be a valid TCP port number, or 0 to use a random port. Defaults to `8765`.
  * __address__: The host address to bind the WebSocket server to. Defaults to `0.0.0.0`, listening on all interfaces by default. Change this to `127.0.0.1` to only accept connections from the local machine.
+ * __tls__: If `true`, use Transport Layer Security (TLS) for encrypted communication. Defaults to `false`.
+ * __certfile__: Path to the certificate to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
+ * __keyfile__: Path to the private key to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `10`.

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
@@ -1,0 +1,16 @@
+#pragma once
+
+#include <websocketpp/config/asio.hpp>
+
+#include "./websocket_logging.hpp"
+
+namespace foxglove {
+
+struct WebSocketTls : public websocketpp::config::asio_tls {
+public:
+  // Replace default stream loggers with custom loggers
+  typedef CallbackLogger<concurrency_type, websocketpp::log::elevel> elog_type;
+  typedef CallbackLogger<concurrency_type, websocketpp::log::alevel> alog_type;
+};
+
+}  // namespace foxglove


### PR DESCRIPTION
**Public-Facing Changes**
Allows to start the server with SSL enabled


**Description**
This PR adds TLS support which can be enabled by setting the corresponding `tls` parameter.

Excerpt from README:

>  * __tls__: If `true`, use Transport Layer Security (TLS) for encrypted communication. Defaults to `false`.
>  * __certfile__: Path to the certificate to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
>  * __keyfile__: Path to the private key to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.

I could not get this working with a self signed certificate. Only made it work with a certificate generated with let's encrypt (added an entry in `/etc/hosts` to resolve the name to my local docker container)

Fixes #14
