### PR TITLE
Handle other exceptions when getting ros2 message definitions

### DIFF
--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -236,6 +236,10 @@ public:
                       topicAndDatatype.second.c_str(), err.what());
           // We still advertise the channel, but with an emtpy schema
           newChannel.schema = "";
+        } catch (const std::exception& err) {
+          RCLCPP_WARN(this->get_logger(), "Failed to add channel for topic \"%s\" (%s): %s",
+                      topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str(), err.what());
+          continue;
         }
 
         auto channel = foxglove::Channel{_server.addChannel(newChannel), newChannel};


### PR DESCRIPTION
**Public-Facing Changes**
Improve error handling when retrieving message definitions (ros2)


**Description**
The presence of action topics causes the bridge to crash:

```
terminate called after throwing an instance of 'std::invalid_argument'
  what():  Invalid package resource name: turtlesim/action/RotateAbsolute_FeedbackMessage
```

The reason why the exception is thrown, is because we assume that message files are located in the `msg` folder:
https://github.com/foxglove/ros-foxglove-bridge/blob/08ff9e522065a2c9998b0fbf2030d9e8fa363637/ros2_foxglove_bridge/src/message_definition_cache.cpp#L19

This PR for now only adds an additional exception handler that will simply log a warning. Proper action support will be implemented later on.


Fixes #60
