### PR TITLE
Update tls ciphers, add comment about origin

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -664,16 +664,16 @@ inline void Server<WebSocketTls>::setupTlsHandler() {
       ctx->use_certificate_chain_file(_certfile);
       ctx->use_private_key_file(_keyfile, asio::ssl::context::pem);
 
+      // Ciphers are taken from the websocketpp example echo tls server:
+      // https://github.com/zaphoyd/websocketpp/blob/1b11fd301/examples/echo_server_tls/echo_server_tls.cpp#L119
       constexpr char ciphers[] =
         "ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:"
         "ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+"
         "AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-"
         "AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-"
         "ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-"
-        "AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:"
-        "AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:"
-        "!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-"
-        "CBC3-SHA";
+        "AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!3DES:"
+        "!MD5:!PSK";
 
       if (SSL_CTX_set_cipher_list(ctx->native_handle(), ciphers) != 1) {
         _server.get_elog().write(RECOVERABLE, "Error setting cipher list");


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Follow up of https://github.com/foxglove/ros-foxglove-bridge/pull/57#discussion_r1028429476
- Updates TLS ciphers to not include tlsv1 ciphers
- Adds a comment about the origin of the ciphers
