### PR TITLE
Refactor ROS 2 node as a component

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,13 +111,27 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
 
     find_package(ament_cmake REQUIRED)
     find_package(rclcpp REQUIRED)
+    find_package(rclcpp_components REQUIRED)
 
-    add_executable(foxglove_bridge
+    add_library(foxglove_bridge_component SHARED
       ros2_foxglove_bridge/src/message_definition_cache.cpp
       ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
     )
+    target_include_directories(foxglove_bridge_component
+      PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros2_foxglove_bridge/include>
+        $<INSTALL_INTERFACE:include>
+    )
+    ament_target_dependencies(foxglove_bridge_component rclcpp rclcpp_components)
+    target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
+    rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")
+
+    add_executable(foxglove_bridge
+      ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+    )
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${rclcpp_INCLUDE_DIRS})
-    target_link_libraries(foxglove_bridge foxglove_bridge_base ${rclcpp_LIBRARIES})
+    ament_target_dependencies(foxglove_bridge rclcpp rclcpp_components)
   else()
     message(FATAL_ERROR "Could not find ament_cmake")
   endif()
@@ -177,11 +191,11 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     install(TARGETS foxglove_bridge
       DESTINATION lib/${PROJECT_NAME}
     )
-    install(TARGETS foxglove_bridge_base
+    install(TARGETS foxglove_bridge_base foxglove_bridge_component
       ARCHIVE DESTINATION lib
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
     )
-    ament_export_libraries(foxglove_bridge_base)
+    ament_export_libraries(foxglove_bridge_base foxglove_bridge_component)
     ament_package()
 endif()

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
     <!-- ROS 2 runtime dependencies -->
     <depend condition="$ROS_VERSION == 2">ament_index_cpp</depend>
     <depend condition="$ROS_VERSION == 2">rclcpp</depend>
+    <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
 
     <!-- Test dependencies -->
     <build_depend condition="$ROS_VERSION == 1">rostest</build_depend>

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
@@ -1,0 +1,42 @@
+#include <rclcpp_components/component_manager.hpp>
+
+int main(int argc, char* argv[]) {
+  rclcpp::init(argc, argv);
+
+  auto dummyNode = std::make_shared<rclcpp::Node>("dummy");
+  auto numThreadsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  numThreadsDescription.name = "num_threads";
+  numThreadsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  numThreadsDescription.description =
+    "The number of threads to use for the ROS node executor. 0 means one thread per CPU core.";
+  numThreadsDescription.read_only = true;
+  numThreadsDescription.additional_constraints = "Must be a non-negative integer";
+  numThreadsDescription.integer_range.resize(1);
+  numThreadsDescription.integer_range[0].from_value = 0;
+  numThreadsDescription.integer_range[0].to_value = INT32_MAX;
+  numThreadsDescription.integer_range[0].step = 1;
+  constexpr int DEFAULT_NUM_THREADS = 0;
+  dummyNode->declare_parameter("num_threads", DEFAULT_NUM_THREADS, numThreadsDescription);
+
+  const auto numThreads = dummyNode->get_parameter("num_threads").as_int();
+
+  auto executor =
+    rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
+
+  rclcpp_components::ComponentManager componentManager(executor, "ComponentManager");
+  const auto componentResources = componentManager.get_component_resources("foxglove_bridge");
+  RCLCPP_INFO(componentManager.get_logger(), std::to_string(numThreads).c_str());
+
+  if (componentResources.empty()) {
+    RCLCPP_INFO(componentManager.get_logger(), "No loadable resources found");
+    return EXIT_FAILURE;
+  }
+
+  auto componentFactory = componentManager.create_component_factory(componentResources.front());
+  auto node = componentFactory->create_node_instance(rclcpp::NodeOptions());
+
+  executor->spin();
+  rclcpp::shutdown();
+
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
**Public-Facing Changes**
Refactor ROS 2 node as a component


**Description**
Allows to run the ROS2 version both as standalone node or as a component.

For the standalone version we simply create a `ComponentManager` and load the foxglove bridge component. I'm not sure if this is best practice, but it has the advantage that it does not additional header files to be included which would require an additional refactoring.


Fixes #28
