### PR TITLE
Remove dependency on ros_type_introspection

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,13 +75,13 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     message(STATUS "Building with catkin")
     set(ROS_BUILD_TYPE "catkin")
 
-    find_package(catkin REQUIRED COMPONENTS nodelet ros_babel_fish ros_type_introspection roslib roscpp)
+    find_package(catkin REQUIRED COMPONENTS nodelet ros_babel_fish roslib roscpp)
     find_package(Boost REQUIRED)
 
     catkin_package(
       INCLUDE_DIRS foxglove_bridge_base/include
       LIBRARIES foxglove_bridge_base foxglove_bridge_nodelet
-      CATKIN_DEPENDS nodelet ros_babel_fish ros_type_introspection roslib roscpp
+      CATKIN_DEPENDS nodelet ros_babel_fish roslib roscpp
       DEPENDS Boost
     )
 

--- a/package.xml
+++ b/package.xml
@@ -14,7 +14,6 @@
     <!-- ROS 1 runtime dependencies -->
     <depend condition="$ROS_VERSION == 1">nodelet</depend>
     <depend condition="$ROS_VERSION == 1">ros_babel_fish</depend>
-    <depend condition="$ROS_VERSION == 1">ros_type_introspection</depend>
     <depend condition="$ROS_VERSION == 1">roscpp</depend>
     <depend condition="$ROS_VERSION == 1">roslib</depend>
 


### PR DESCRIPTION
**Public-Facing Changes**
Remove dependency on ros_type_introspection


**Description**
Removes dependency on `ros_type_introspection` by using the `ros_babel_fish` corresponding generic message class
