### PR TITLE
Client advertisements and message publishing

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -321,7 +321,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
   con->send(json({
                    {"op", "serverInfo"},
                    {"name", _name},
-                   {"capabilities", json::array()},
+                   {"capabilities", json::array({"clientPublish"})},
                  })
               .dump());
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -651,7 +651,7 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
         }
         ClientAdvertisement advertisement{};
         advertisement.channelId = channelId;
-        advertisement.topic = chan.at("channelId").get<std::string>();
+        advertisement.topic = chan.at("topic").get<std::string>();
         advertisement.encoding = chan.at("encoding").get<std::string>();
         advertisement.schemaName = chan.at("schemaName").get<std::string>();
         _clientChannels.emplace(channelId, std::move(advertisement));

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -654,7 +654,7 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
         advertisement.topic = chan.at("topic").get<std::string>();
         advertisement.encoding = chan.at("encoding").get<std::string>();
         advertisement.schemaName = chan.at("schemaName").get<std::string>();
-        _clientChannels.emplace(channelId, std::move(advertisement));
+        _clientChannels.emplace(channelId, advertisement);
         clientInfo.advertisedChannels.emplace(channelId);
         if (_clientAdvertiseHandler) {
           _clientAdvertiseHandler(advertisement, hdl);

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -96,6 +96,15 @@ struct ClientMessage {
       , advertisement(advertisement)
       , dataLength(dataLength)
       , data(data) {}
+
+  static const size_t MSG_PAYLOAD_OFFSET = 5;
+
+  const uint8_t* getData() const {
+    return data + MSG_PAYLOAD_OFFSET;
+  }
+  std::size_t getLength() const {
+    return dataLength - MSG_PAYLOAD_OFFSET;
+  }
 };
 
 enum class BinaryOpcode : uint8_t {
@@ -736,8 +745,8 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
       if (_clientMessageHandler) {
         const auto& advertisement = channelIt->second;
         const uint32_t sequence = 0;
-        const ClientMessage clientMessage{timestamp,     timestamp,  sequence,
-                                          advertisement, length - 5, msg + 5};
+        const ClientMessage clientMessage{timestamp,     timestamp, sequence,
+                                          advertisement, length,    msg};
         _clientMessageHandler(clientMessage, hdl);
       }
     } break;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -10,6 +10,7 @@
 #include <string_view>
 #include <thread>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include <nlohmann/json.hpp>

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -713,8 +713,8 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
       if (_clientMessageHandler) {
         const auto& advertisement = channelIt->second;
         const uint32_t sequence = 0;
-        const ClientMessage clientMessage{timestamp,     timestamp, sequence,
-                                          advertisement, length - 5,    msg + 5};
+        const ClientMessage clientMessage{timestamp,     timestamp,  sequence,
+                                          advertisement, length - 5, msg + 5};
         _clientMessageHandler(clientMessage, hdl);
       }
     } break;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -714,7 +714,7 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
         const auto& advertisement = channelIt->second;
         const uint32_t sequence = 0;
         const ClientMessage clientMessage{timestamp,     timestamp, sequence,
-                                          advertisement, length,    msg};
+                                          advertisement, length - 5,    msg + 5};
         _clientMessageHandler(clientMessage, hdl);
       }
     } break;

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -561,8 +561,9 @@ private:
 
     // Copy the message payload into a SerializedMessage object
     rclcpp::SerializedMessage serializedMessage{message.getLength()};
-    std::memcpy(serializedMessage.get_rcl_serialized_message().buffer, message.getData(),
-                message.getLength());
+    auto& rclSerializedMsg = serializedMessage.get_rcl_serialized_message();
+    std::memcpy(rclSerializedMsg.buffer, message.getData(), message.getLength());
+    rclSerializedMsg.buffer_length = message.getLength();
 
     // Publish the message
     publisher->publish(serializedMessage);

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -561,9 +561,9 @@ private:
     }
 
     // Copy the message payload into a SerializedMessage object
-    rclcpp::SerializedMessage serializedMessage{message.dataLength};
-    std::memcpy(serializedMessage.get_rcl_serialized_message().buffer, message.data,
-                message.dataLength);
+    rclcpp::SerializedMessage serializedMessage{message.getLength()};
+    std::memcpy(serializedMessage.get_rcl_serialized_message().buffer, message.getData(),
+                message.getLength());
 
     // Publish the message
     publisher->publish(serializedMessage);


### PR DESCRIPTION
**Public-Facing Changes**
- WebSocket clients can advertise topics and publish messages to their advertised topics

**Description**
This supports the `clientPublish` capability, including advertising/unadvertising/publishing for ROS 1 and ROS 2.