### PR TITLE
Explicit template instantiation for common server configurations

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -686,4 +686,7 @@ inline void Server<WebSocketTls>::setupTlsHandler() {
   });
 }
 
+extern template class Server<WebSocketTls>;
+extern template class Server<WebSocketNoTls>;
+
 }  // namespace foxglove

--- a/foxglove_bridge_base/src/foxglove_bridge.cpp
+++ b/foxglove_bridge_base/src/foxglove_bridge.cpp
@@ -1,15 +1,18 @@
 #include "foxglove_bridge/foxglove_bridge.hpp"
 
 #define ASIO_STANDALONE
-#include <websocketpp/config/asio.hpp>
-#include <websocketpp/server.hpp>
+#include "foxglove_bridge/websocket_notls.hpp"
+#include "foxglove_bridge/websocket_server.hpp"
+#include "foxglove_bridge/websocket_tls.hpp"
 
-using Server = websocketpp::server<websocketpp::config::asio_tls>;
-using ConnectionHdl = websocketpp::connection_hdl;
-using SslContext = websocketpp::lib::asio::ssl::context;
-using websocketpp::lib::placeholders::_1;
-using websocketpp::lib::placeholders::_2;
+namespace foxglove {
 
-const char* foxglove::WebSocketUserAgent() {
+const char* WebSocketUserAgent() {
   return websocketpp::user_agent;
 }
+
+// Explicit template instantiation for common server configurations
+template class Server<WebSocketTls>;
+template class Server<WebSocketNoTls>;
+
+}  // namespace foxglove


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
We explicitly instantiate the server for the two configurations (TLS/NoTLS) so they are part of the `foxglove_bridge_base` library. This is a small compile time optimization as the server code is rarely modified.
