### PR TITLE
Fix ros2 node not receiving any ros messages

### DIFF
--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
@@ -35,6 +35,7 @@ int main(int argc, char* argv[]) {
   auto componentFactory = componentManager.create_component_factory(componentResources.front());
   auto node = componentFactory->create_node_instance(rclcpp::NodeOptions());
 
+  executor->add_node(node.get_node_base_interface());
   executor->spin();
   rclcpp::shutdown();
 


### PR DESCRIPTION
**Public-Facing Changes**
Fix ros2 node not receiving any ros messages


**Description**
Fixes a regression introduced in #63. The created node was not added to the executor and hence no ROS callbacks were executed.

We would have caught this regression with a proper smoke test in place (#20)


<!-- link relevant GitHub issues -->
