### PR TITLE
Add client implementation

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -1,0 +1,31 @@
+#pragma once
+
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace foxglove {
+
+constexpr char SUPPORTED_SUBPROTOCOL[] = "foxglove.websocket.v1";
+
+using ChannelId = uint32_t;
+using ClientChannelId = uint32_t;
+using SubscriptionId = uint32_t;
+
+enum class BinaryOpcode : uint8_t {
+  MESSAGE_DATA = 1,
+};
+
+enum class ClientBinaryOpcode : uint8_t {
+  MESSAGE_DATA = 1,
+};
+
+struct ClientAdvertisement {
+  ClientChannelId channelId;
+  std::string topic;
+  std::string encoding;
+  std::string schemaName;
+  std::vector<uint8_t> schema;
+};
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -46,21 +46,21 @@ public:
   using ConnectionPtr = typename ClientType::connection_ptr;
 
   Client() {
-    m_endpoint.clear_access_channels(websocketpp::log::alevel::all);
-    m_endpoint.clear_error_channels(websocketpp::log::elevel::all);
+    _endpoint.clear_access_channels(websocketpp::log::alevel::all);
+    _endpoint.clear_error_channels(websocketpp::log::elevel::all);
 
-    m_endpoint.init_asio();
-    m_endpoint.start_perpetual();
+    _endpoint.init_asio();
+    _endpoint.start_perpetual();
 
-    m_endpoint.set_message_handler(
+    _endpoint.set_message_handler(
       bind(&Client::on_message, this, std::placeholders::_1, std::placeholders::_2));
 
-    m_thread.reset(new websocketpp::lib::thread(&ClientType::run, &m_endpoint));
+    _thread.reset(new websocketpp::lib::thread(&ClientType::run, &_endpoint));
   }
 
   virtual ~Client() {
-    m_endpoint.stop_perpetual();
-    m_thread->join();
+    _endpoint.stop_perpetual();
+    _thread->join();
   }
 
   void connect(const std::string& uri,
@@ -69,7 +69,7 @@ public:
     std::unique_lock<std::shared_mutex> lock(_mutex);
 
     websocketpp::lib::error_code ec;
-    _con = m_endpoint.get_connection(uri, ec);
+    _con = _endpoint.get_connection(uri, ec);
 
     if (ec) {
       throw std::runtime_error("Failed to get connection from URI " + uri);
@@ -83,7 +83,7 @@ public:
     }
 
     _con->add_subprotocol(SUPPORTED_SUBPROTOCOL);
-    m_endpoint.connect(_con);
+    _endpoint.connect(_con);
   }
 
   void close() override {
@@ -92,7 +92,7 @@ public:
       return;  // Already disconnected
     }
 
-    m_endpoint.close(_con, websocketpp::close::status::going_away, "");
+    _endpoint.close(_con, websocketpp::close::status::going_away, "");
     _con.reset();
   }
 
@@ -167,17 +167,17 @@ public:
 
   void sendText(const std::string& payload) {
     std::shared_lock<std::shared_mutex> lock(_mutex);
-    m_endpoint.send(_con, payload, OpCode::TEXT);
+    _endpoint.send(_con, payload, OpCode::TEXT);
   }
 
   void sendBinary(const uint8_t* data, size_t dataLength) {
     std::shared_lock<std::shared_mutex> lock(_mutex);
-    m_endpoint.send(_con, data, dataLength, OpCode::BINARY);
+    _endpoint.send(_con, data, dataLength, OpCode::BINARY);
   }
 
 protected:
-  ClientType m_endpoint;
-  websocketpp::lib::shared_ptr<websocketpp::lib::thread> m_thread;
+  ClientType _endpoint;
+  websocketpp::lib::shared_ptr<websocketpp::lib::thread> _thread;
   ConnectionPtr _con;
   std::shared_mutex _mutex;
   TextMessageHandler _textMessageHandler;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -15,6 +15,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "common.hpp"
 #include "serialization.hpp"
 #include "websocket_logging.hpp"
 #include "websocket_notls.hpp"
@@ -26,10 +27,6 @@ using json = nlohmann::json;
 
 using ConnHandle = websocketpp::connection_hdl;
 using OpCode = websocketpp::frame::opcode::value;
-
-using ChannelId = uint32_t;
-using ClientChannelId = uint32_t;
-using SubscriptionId = uint32_t;
 
 static const websocketpp::log::level APP = websocketpp::log::alevel::app;
 static const websocketpp::log::level RECOVERABLE = websocketpp::log::elevel::rerror;
@@ -72,14 +69,6 @@ struct Channel : ChannelWithoutId {
   }
 };
 
-struct ClientAdvertisement {
-  ChannelId channelId;
-  std::string topic;
-  std::string encoding;
-  std::string schemaName;
-  std::vector<uint8_t> schema;
-};
-
 struct ClientMessage {
   uint64_t logTime;
   uint64_t publishTime;
@@ -105,14 +94,6 @@ struct ClientMessage {
   std::size_t getLength() const {
     return dataLength - MSG_PAYLOAD_OFFSET;
   }
-};
-
-enum class BinaryOpcode : uint8_t {
-  MESSAGE_DATA = 1,
-};
-
-enum class ClientBinaryOpcode : uint8_t {
-  MESSAGE_DATA = 1,
 };
 
 enum class StatusLevel : uint8_t {
@@ -178,7 +159,6 @@ public:
   using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
   using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
 
-  static const std::string SUPPORTED_SUBPROTOCOL;
   static bool USES_TLS;
 
   explicit Server(std::string name, LogCallback logger, const std::string& certfile = "",
@@ -257,10 +237,6 @@ private:
   void sendBinary(ConnHandle hdl, const std::vector<uint8_t>& payload);
   void sendStatus(ConnHandle clientHandle, const StatusLevel level, const std::string& message);
 };
-
-template <typename ServerConfiguration>
-inline const std::string Server<ServerConfiguration>::SUPPORTED_SUBPROTOCOL =
-  "foxglove.websocket.v1";
 
 template <typename ServerConfiguration>
 inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,


### PR DESCRIPTION
**Public-Facing Changes**
Add client implementation

**Description**
Adds a client implementation that can be used to connect to the server and exchange messages according to the ws-protocol. This client implementation will be used for unit / smoke testing (#20)