### PR TITLE
Use a more ROS-friendly approach to linking gtest

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ SHELL ["/bin/bash", "-c"]
 # Unset the ROS_DISTRO and add aliases to .bashrc
 RUN echo $'\
 unset ROS_DISTRO\n\
-alias ros2_build_debug="colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n\
-alias ros2_build_release="colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo"\n\
+alias ros2_build_debug="colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n\
+alias ros2_build_release="colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo"\n\
 alias ros2_foxglove_bridge="source /ros_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge --ros-args --log-level debug --log-level rcl:=INFO"\n\
 ' >> ~/.bashrc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -137,8 +137,8 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
   if (CATKIN_ENABLE_TESTING)
     message(STATUS "Building tests with catkin")
 
-    find_package(catkin REQUIRED COMPONENTS std_msgs)
-    find_package(GTest)
+    find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
+    find_package(GTest QUIET)
     find_package(rostest REQUIRED)
 
     catkin_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,6 +138,7 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
     message(STATUS "Building tests with catkin")
 
     find_package(catkin REQUIRED COMPONENTS rostest)
+    find_package(GTest)
 
     catkin_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
     target_link_libraries(version_test foxglove_bridge_base)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,10 +138,9 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
     message(STATUS "Building tests with catkin")
 
     find_package(catkin REQUIRED COMPONENTS rostest)
-    find_package(GTest REQUIRED)
 
     catkin_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
-    target_link_libraries(version_test foxglove_bridge_base GTest::GTest GTest::Main)
+    target_link_libraries(version_test foxglove_bridge_base)
 
     add_rostest(ros1_foxglove_bridge/tests/smoke.test)
   endif()
@@ -149,12 +148,12 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
   if(BUILD_TESTING)
     message(STATUS "Building tests with ament_cmake")
 
+    find_package(ament_cmake_gtest REQUIRED)
     find_package(ament_lint_auto REQUIRED)
-    find_package(GTest REQUIRED)
     ament_lint_auto_find_test_dependencies()
 
     ament_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
-    target_link_libraries(version_test foxglove_bridge_base GTest::GTest GTest::Main)
+    target_link_libraries(version_test foxglove_bridge_base)
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,7 +138,9 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
     message(STATUS "Building tests with catkin")
 
     find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
-    find_package(GTest QUIET)
+    if(NOT "$ENV{ROS_DISTRO}" STREQUAL "melodic")
+      find_package(GTest REQUIRED)
+    endif()
     find_package(rostest REQUIRED)
 
     catkin_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -19,12 +19,6 @@ COPY foxglove_bridge_base /ros1_ws/src/ros-foxglove-bridge/foxglove_bridge_base
 COPY nodelets.xml /ros1_ws/src/ros-foxglove-bridge/nodelets.xml
 COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
 
-# Build and install gtest.
-RUN cd /usr/src/gtest \
-  && cmake CMakeLists.txt \
-  && make \
-  && cp ./*.a /usr/lib || true
-
 # Build the Catkin workspace and ensure it's sourced when a container is run
 RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh \
   && cd /ros1_ws \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -36,7 +36,7 @@ SHELL [ "/bin/bash" , "-c" ]
 # Build the ROS 2 workspace and ensure it's sourced when a container is run
 RUN source /opt/ros/$ROS_DISTRIBUTION/setup.bash \
   && cd /ros2_ws \
-  && colcon build
+  && colcon build --event-handlers console_direct+
 RUN echo "source /ros2_ws/install/setup.bash" >> ~/.bashrc
 
 # Set the working folder at startup

--- a/foxglove_bridge_base/tests/version_test.cpp
+++ b/foxglove_bridge_base/tests/version_test.cpp
@@ -9,3 +9,8 @@ TEST(VersionTest, TestWebSocketVersion) {
   const std::string version = foxglove::WebSocketUserAgent();
   EXPECT_EQ(version.substr(0, 14), "WebSocket++/0.");
 }
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,7 @@
     <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
 
     <!-- Test dependencies -->
-    <test_depend condition="$ROS_VERSION == 1">libgtest-dev</test_depend>
+    <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rosunit</test_depend>
     <test_depend condition="$ROS_VERSION == 1">geometry_msgs</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -24,7 +24,8 @@
     <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
 
     <!-- Test dependencies -->
-    <build_depend condition="$ROS_VERSION == 1">rostest</build_depend>
+    <test_depend condition="$ROS_VERSION == 1">libgtest-dev</test_depend>
+    <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rosunit</test_depend>
     <test_depend condition="$ROS_VERSION == 1">geometry_msgs</test_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>


### PR DESCRIPTION
**Public-Facing Changes**

**Description**
This modifies ROS 1 test builds to try and find a system gtest to link against, then fall back to using the ROS CMake macros for building and linking gtest from source. ROS 2 test builds avoid the find_package(GTest) entirely and delegate finding gtest to ament CMake macros. Should fix #75
