### PR TITLE
Add ros2 smoke test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,6 +171,10 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
 
     ament_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
     target_link_libraries(version_test foxglove_bridge_base)
+
+    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp)
+    ament_target_dependencies(smoke_test rclcpp rclcpp_components std_msgs)
+    target_link_libraries(smoke_test foxglove_bridge_base)
   endif()
 endif()
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -54,7 +54,7 @@ public:
     _endpoint.start_perpetual();
 
     _endpoint.set_message_handler(
-      bind(&Client::on_message, this, std::placeholders::_1, std::placeholders::_2));
+      bind(&Client::messageHandler, this, std::placeholders::_1, std::placeholders::_2));
 
     _thread.reset(new websocketpp::lib::thread(&ClientType::run, &_endpoint));
   }
@@ -109,7 +109,7 @@ public:
     _con.reset();
   }
 
-  void on_message(websocketpp::connection_hdl hdl, MessagePtr msg) {
+  void messageHandler(websocketpp::connection_hdl hdl, MessagePtr msg) {
     (void)hdl;
     const OpCode op = msg->get_opcode();
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -134,7 +134,7 @@ public:
 
   void subscribe(const std::vector<std::pair<SubscriptionId, ChannelId>>& subscriptions) override {
     nlohmann::json subscriptionsJson;
-    for (const auto [subId, channelId] : subscriptions) {
+    for (const auto& [subId, channelId] : subscriptions) {
       subscriptionsJson.push_back({{"id", subId}, {"channelId", channelId}});
     }
 

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -57,11 +57,13 @@ TEST(SmokeTest, testSubscription) {
     ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(std::chrono::seconds(5)));
 
     // Set up binary message handler to resolve when a binary message has been received
-    std::promise<std::pair<const uint8_t*, size_t>> msgPromise;
+    std::promise<std::vector<uint8_t>> msgPromise;
     auto msgFuture = msgPromise.get_future();
     wsClient.setBinaryMessageHandler([&msgPromise](const uint8_t* data, size_t dataLength) {
       const size_t offset = 1 + 4 + 8;
-      msgPromise.set_value({data + offset, dataLength - offset});
+      std::vector<uint8_t> dataCopy(dataLength - offset);
+      std::memcpy(dataCopy.data(), data + offset, dataLength - offset);
+      msgPromise.set_value(std::move(dataCopy));
     });
 
     // Subscribe to the channel that corresponds to the string topic
@@ -70,9 +72,9 @@ TEST(SmokeTest, testSubscription) {
 
     // Wait until we have received a binary message and test that it is the right one
     ASSERT_EQ(std::future_status::ready, msgFuture.wait_for(std::chrono::seconds(5)));
-    const auto& [data, dataLength] = msgFuture.get();
-    ASSERT_EQ(sizeof(HELLO_WORLD_BINARY), dataLength);
-    EXPECT_TRUE(std::memcmp(HELLO_WORLD_BINARY, data, dataLength));
+    const auto& msgData = msgFuture.get();
+    ASSERT_EQ(sizeof(HELLO_WORLD_BINARY), msgData.size());
+    EXPECT_EQ(0, std::memcmp(HELLO_WORLD_BINARY, msgData.data(), msgData.size()));
   }
 }
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -88,8 +88,7 @@ public:
     maxQosDepthDescription.integer_range[0].from_value = 0;
     maxQosDepthDescription.integer_range[0].to_value = INT32_MAX;
     maxQosDepthDescription.integer_range[0].step = 1;
-    this->declare_parameter("max_qos_depth", static_cast<int>(DEFAULT_MAX_QOS_DEPTH),
-                            maxQosDepthDescription);
+    this->declare_parameter("max_qos_depth", int(DEFAULT_MAX_QOS_DEPTH), maxQosDepthDescription);
 
     const auto useTLS = this->get_parameter("tls").as_bool();
     const auto certfile = this->get_parameter("certfile").as_string();
@@ -230,8 +229,8 @@ public:
         _channelToTopicAndDatatype.erase(channel.id);
         _advertisedTopics.erase(topicAndDatatype);
 
-        RCLCPP_DEBUG(this->get_logger(), "Removed channel %d for topic \"%s\" (%s)", channel.id,
-                     topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
+        RCLCPP_INFO(this->get_logger(), "Removed channel %d for topic \"%s\" (%s)", channel.id,
+                    topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
       }
 
       // Advertise new topics
@@ -397,6 +396,15 @@ private:
       qos.durability_volatile();
     }
 
+    if (firstSubscription) {
+      RCLCPP_INFO(this->get_logger(), "Subscribing to topic \"%s\" (%s) on channel %d",
+                  topic.c_str(), datatype.c_str(), channelId);
+
+    } else {
+      RCLCPP_INFO(this->get_logger(), "Adding subscriber #%ld to topic \"%s\" (%s) on channel %d",
+                  subscriptionsByClient.size(), topic.c_str(), datatype.c_str(), channelId);
+    }
+
     try {
       auto subscriber = this->create_generic_subscription(
         topic, datatype, qos,
@@ -404,15 +412,6 @@ private:
         subscriptionOptions);
       subscriptionsByClient.emplace(clientHandle,
                                     std::make_pair(std::move(subscriber), subscriptionOptions));
-
-      if (firstSubscription) {
-        RCLCPP_INFO(this->get_logger(), "Subscribed to topic \"%s\" (%s) on channel %d",
-                    topic.c_str(), datatype.c_str(), channelId);
-
-      } else {
-        RCLCPP_INFO(this->get_logger(), "Added subscriber #%ld to topic \"%s\" (%s) on channel %d",
-                    subscriptionsByClient.size(), topic.c_str(), datatype.c_str(), channelId);
-      }
     } catch (const std::exception& ex) {
       RCLCPP_ERROR(this->get_logger(), "Failed to subscribe to topic \"%s\" (%s): %s",
                    topic.c_str(), datatype.c_str(), ex.what());

--- a/ros2_foxglove_bridge/tests/smoke.test
+++ b/ros2_foxglove_bridge/tests/smoke.test
@@ -1,5 +1,0 @@
-<launch>
-  <node name="foxglove_bridge" pkg="foxglove_bridge" type="foxglove_bridge">
-    <param name="port" value="0" />
-  </node>
-</launch>

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -54,10 +54,6 @@ TEST(SmokeTest, testSubscription) {
       }
     });
 
-    // Connect the client and wait for the channel future
-    ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
-    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(std::chrono::seconds(5)));
-
     // Set up binary message handler to resolve when a binary message has been received
     std::promise<std::vector<uint8_t>> msgPromise;
     auto msgFuture = msgPromise.get_future();
@@ -67,6 +63,10 @@ TEST(SmokeTest, testSubscription) {
       std::memcpy(dataCopy.data(), data + offset, dataLength - offset);
       msgPromise.set_value(std::move(dataCopy));
     });
+
+    // Connect the client and wait for the channel future
+    ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(std::chrono::seconds(5)));
 
     // Subscribe to the channel that corresponds to the string topic
     const auto channelId = channelFuture.get().at("id").get<foxglove::ChannelId>();

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -5,17 +5,17 @@
 #include <thread>
 
 #include <gtest/gtest.h>
-#include <ros/ros.h>
-#include <std_msgs/String.h>
+#include <rclcpp_components/component_manager.hpp>
+#include <std_msgs/msg/string.hpp>
 #include <websocketpp/config/asio_client.hpp>
 
 #include <foxglove_bridge/websocket_client.hpp>
 
-constexpr char URI[] = "ws://localhost:9876";
+constexpr char URI[] = "ws://localhost:8765";
 
 // Binary representation of std_msgs/String for "hello world"
-constexpr uint8_t HELLO_WORLD_BINARY[] = {11,  0,  0,   0,   104, 101, 108, 108,
-                                          111, 32, 119, 111, 114, 108, 100};
+constexpr uint8_t HELLO_WORLD_BINARY[] = {0,   1,   0,   0,  12,  0,   0,   0,   104, 101,
+                                          108, 108, 111, 32, 119, 111, 114, 108, 100, 0};
 
 TEST(SmokeTest, testConnection) {
   foxglove::Client<websocketpp::config::asio_client> wsClient;
@@ -25,12 +25,14 @@ TEST(SmokeTest, testConnection) {
 TEST(SmokeTest, testSubscription) {
   // Publish a string message on a latched ros topic
   const std::string topic_name = "/pub_topic";
-  ros::NodeHandle nh;
-  auto pub = nh.advertise<std_msgs::String>(topic_name, 10, true);
-
-  std_msgs::String rosMsg;
+  std_msgs::msg::String rosMsg;
   rosMsg.data = "hello world";
-  pub.publish(rosMsg);
+
+  auto node = rclcpp::Node::make_shared("tester");
+  rclcpp::QoS qos = rclcpp::QoS{rclcpp::KeepLast(1lu)};
+  qos.transient_local();
+  auto pub = node->create_publisher<std_msgs::msg::String>(topic_name, qos);
+  pub->publish(rosMsg);
 
   const auto clientCount = 3;
   for (auto i = 0; i < clientCount; ++i) {
@@ -77,24 +79,25 @@ TEST(SmokeTest, testSubscription) {
 }
 
 TEST(SmokeTest, testPublishing) {
-  foxglove::Client<websocketpp::config::asio_client> wsClient;
-
   foxglove::ClientAdvertisement advertisement;
   advertisement.channelId = 1;
   advertisement.topic = "/foo";
-  advertisement.encoding = "ros1";
+  advertisement.encoding = "cdr";
   advertisement.schemaName = "std_msgs/String";
 
   // Set up a ROS node with a subscriber
-  ros::NodeHandle nh;
   std::promise<std::string> msgPromise;
   auto msgFuture = msgPromise.get_future();
-  auto subscriber = nh.subscribe<std_msgs::String>(
-    advertisement.topic, 10, [&msgPromise](const std_msgs::String::ConstPtr& msg) {
+  auto node = rclcpp::Node::make_shared("tester");
+  auto sub = node->create_subscription<std_msgs::msg::String>(
+    advertisement.topic, 10, [&msgPromise, &node](const std_msgs::msg::String::SharedPtr msg) {
       msgPromise.set_value(msg->data);
     });
+  rclcpp::executors::SingleThreadedExecutor executor;
+  executor.add_node(node);
 
   // Set up the client, advertise and publish the binary message
+  foxglove::Client<websocketpp::config::asio_client> wsClient;
   ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
   wsClient.advertise({advertisement});
   std::this_thread::sleep_for(std::chrono::seconds(1));
@@ -102,24 +105,40 @@ TEST(SmokeTest, testPublishing) {
   wsClient.unadvertise({advertisement.channelId});
 
   // Ensure that we have received the correct message via our ROS subscriber
-  const auto msgResult = msgFuture.wait_for(std::chrono::seconds(1));
-  ASSERT_EQ(std::future_status::ready, msgResult);
+  const auto ret = executor.spin_until_future_complete(msgFuture, std::chrono::seconds(1));
+  ASSERT_EQ(rclcpp::FutureReturnCode::SUCCESS, ret);
   EXPECT_EQ("hello world", msgFuture.get());
 }
 
 // Run all the tests that were declared with TEST()
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
-  ros::init(argc, argv, "tester");
-  ros::NodeHandle nh;
+  rclcpp::init(argc, argv);
 
-  // Give the server some time to start
-  std::this_thread::sleep_for(std::chrono::seconds(2));
+  const size_t numThreads = 2;
+  auto executor =
+    rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
 
-  ros::AsyncSpinner spinner(1);
-  spinner.start();
+  rclcpp_components::ComponentManager componentManager(executor, "ComponentManager");
+  const auto componentResources = componentManager.get_component_resources("foxglove_bridge");
+
+  if (componentResources.empty()) {
+    RCLCPP_INFO(componentManager.get_logger(), "No loadable resources found");
+    return EXIT_FAILURE;
+  }
+
+  auto componentFactory = componentManager.create_component_factory(componentResources.front());
+  auto node = componentFactory->create_node_instance(rclcpp::NodeOptions());
+  executor->add_node(node.get_node_base_interface());
+
+  std::thread spinnerThread([&executor]() {
+    executor->spin();
+  });
+
   const auto testResult = RUN_ALL_TESTS();
-  spinner.stop();
+  executor->cancel();
+  spinnerThread.join();
+  rclcpp::shutdown();
 
   return testResult;
 }

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -13,7 +13,7 @@
 
 constexpr char URI[] = "ws://localhost:8765";
 
-// Binary representation of std_msgs/String for "hello world"
+// Binary representation of std_msgs/msg/String for "hello world"
 constexpr uint8_t HELLO_WORLD_BINARY[] = {0,   1,   0,   0,  12,  0,   0,   0,   104, 101,
                                           108, 108, 111, 32, 119, 111, 114, 108, 100, 0};
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Adds a smoke test for the ROS2 implementation. This also adds a no-op timer in the ROS 2 node with a 100ms frequency, this appears to be required to spin the node when repeatedly subscribing and unsubscribing to a topic.

Fixes #20
