### PR TITLE
Fix WebSocket logging sometimes going straight to stdout/stderr, misc CI warnings

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.0
         continue-on-error: true
 
       - name: Login to GitHub Container Registry
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - uses: satackey/action-docker-layer-caching@v0.0.11
+      - uses: jpribyl/action-docker-layer-caching@v0.1.0
         continue-on-error: true
 
       - name: Login to GitHub Container Registry

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,12 @@
 cmake_minimum_required(VERSION 3.10.2)
 
+if(POLICY CMP0048)
+  cmake_policy(SET CMP0048 NEW)
+endif()
+if(POLICY CMP0024)
+  cmake_policy(SET CMP0024 NEW)
+endif()
+
 project(foxglove_bridge LANGUAGES CXX VERSION 0.0.1)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
@@ -7,11 +7,34 @@
 
 namespace foxglove {
 
-struct WebSocketNoTls : public websocketpp::config::asio {
-public:
-  // Replace default stream loggers with custom loggers
-  typedef CallbackLogger<concurrency_type, websocketpp::log::elevel> elog_type;
-  typedef CallbackLogger<concurrency_type, websocketpp::log::alevel> alog_type;
+struct WebSocketNoTls : public websocketpp::config::core {
+  typedef WebSocketNoTls type;
+  typedef core base;
+
+  typedef base::concurrency_type concurrency_type;
+
+  typedef base::request_type request_type;
+  typedef base::response_type response_type;
+
+  typedef base::message_type message_type;
+  typedef base::con_msg_manager_type con_msg_manager_type;
+  typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
+
+  typedef CallbackLogger alog_type;
+  typedef CallbackLogger elog_type;
+
+  typedef base::rng_type rng_type;
+
+  struct transport_config : public base::transport_config {
+    typedef type::concurrency_type concurrency_type;
+    typedef CallbackLogger alog_type;
+    typedef CallbackLogger elog_type;
+    typedef type::request_type request_type;
+    typedef type::response_type response_type;
+    typedef websocketpp::transport::asio::basic_socket::endpoint socket_type;
+  };
+
+  typedef websocketpp::transport::asio::endpoint<transport_config> transport_type;
 };
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
@@ -6,11 +6,34 @@
 
 namespace foxglove {
 
-struct WebSocketTls : public websocketpp::config::asio_tls {
-public:
-  // Replace default stream loggers with custom loggers
-  typedef CallbackLogger<concurrency_type, websocketpp::log::elevel> elog_type;
-  typedef CallbackLogger<concurrency_type, websocketpp::log::alevel> alog_type;
+struct WebSocketTls : public websocketpp::config::core {
+  typedef WebSocketTls type;
+  typedef core base;
+
+  typedef base::concurrency_type concurrency_type;
+
+  typedef base::request_type request_type;
+  typedef base::response_type response_type;
+
+  typedef base::message_type message_type;
+  typedef base::con_msg_manager_type con_msg_manager_type;
+  typedef base::endpoint_msg_manager_type endpoint_msg_manager_type;
+
+  typedef CallbackLogger alog_type;
+  typedef CallbackLogger elog_type;
+
+  typedef base::rng_type rng_type;
+
+  struct transport_config : public base::transport_config {
+    typedef type::concurrency_type concurrency_type;
+    typedef CallbackLogger alog_type;
+    typedef CallbackLogger elog_type;
+    typedef type::request_type request_type;
+    typedef type::response_type response_type;
+    typedef websocketpp::transport::asio::tls_socket::endpoint socket_type;
+  };
+
+  typedef websocketpp::transport::asio::endpoint<transport_config> transport_type;
 };
 
 }  // namespace foxglove


### PR DESCRIPTION
**Public-Facing Changes**
- Fix some log messages going straight to stdout/stderr instead of ROS logging functions

**Description**
- Fix WebSocket log messages sometimes going straight to stdout/stderr
- Use new action-docker-layer-caching for publish CI workflow
- Fix cmake deprecation warnings

Fixes https://github.com/foxglove/ros-foxglove-bridge/issues/78