### PR TITLE
Add build dependency on ros_environment

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -35,6 +35,7 @@
     <build_depend>libssl-dev</build_depend>
     <build_depend>libwebsocketpp-dev</build_depend>
     <build_depend>nlohmann-json-dev</build_depend>
+    <build_depend>ros_environment</build_depend>
 
     <exec_depend>openssl</exec_depend>
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
This should make the `ROS_VERSION` env variable available during build to handle ROS 1 / ROS 2 conditional packages

See https://discourse.ros.org/t/why-not-exposing-ros-version-in-the-ros-1-2-build-farms/25476 for reference

Fixes #79 