### PR TITLE
Add test dependency on ament_lint_auto

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -28,6 +28,7 @@
     <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rosunit</test_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
+    <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
     <test_depend>std_msgs</test_depend>
 
     <!-- Common dependencies -->


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Should fix the following build error (see https://build.ros2.org/job/Rdev__foxglove_bridge__ubuntu_jammy_amd64/14)

```
CMake Error at CMakeLists.txt:169 (find_package):
  By not providing "Findament_lint_auto.cmake" in CMAKE_MODULE_PATH this
  project has asked CMake to find a package configuration file provided by
  "ament_lint_auto", but CMake did not find one.
 
  Could not find a package configuration file provided by "ament_lint_auto"
  with any of the following names:
 
    ament_lint_autoConfig.cmake
    ament_lint_auto-config.cmake
```
