### PR TITLE
Remove "/usr/lib/cmake/" hardcoded path in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 
-find_package(nlohmann_json REQUIRED CONFIG PATHS "/usr/lib/cmake/")
+find_package(nlohmann_json REQUIRED)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,7 @@ target_link_libraries(foxglove_bridge_base
 if(nlohmann_json_FOUND)
   target_link_libraries(foxglove_bridge_base nlohmann_json::nlohmann_json)
 else()
-  message("nlohmann_json not found, will search at compile time")
+  message(STATUS "nlohmann_json not found, will search at compile time")
 endif()
 
 message(STATUS "ROS_VERSION: " $ENV{ROS_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,7 +16,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 option(ENABLE_ASAN "Enable Address Sanitizer" OFF)
 
-find_package(nlohmann_json REQUIRED)
+find_package(nlohmann_json QUIET)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -71,11 +71,15 @@ target_include_directories(foxglove_bridge_base
     $<INSTALL_INTERFACE:include>
 )
 target_link_libraries(foxglove_bridge_base
-  nlohmann_json
   OpenSSL::Crypto
   OpenSSL::SSL
   ${CMAKE_THREAD_LIBS_INIT}
 )
+if(nlohmann_json_FOUND)
+  target_link_libraries(foxglove_bridge_base nlohmann_json::nlohmann_json)
+else()
+  message("nlohmann_json not found, will search at compile time")
+endif()
 
 message(STATUS "ROS_VERSION: " $ENV{ROS_VERSION})
 message(STATUS "ROS_DISTRO: " $ENV{ROS_DISTRO})


### PR DESCRIPTION
**Public-Facing Changes**
- None

**Description**
Fixes CMake warnings on Ubuntu Bionic by removing the platform-specific search path for nlohmann_json's CMake file, allowing it to fail on Bionic quietly, and building anyways. This will result in a compile-time error instead of a configuration-time error for users who don't have the correct system dependency installed, but the error is easy enough to deduce what went wrong and we print a status message warning this may happen.
