### PR TITLE
[ros1] Mirror ros2 node behavior when /clock topic is present

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -90,13 +90,13 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     message(STATUS "Building with catkin")
     set(ROS_BUILD_TYPE "catkin")
 
-    find_package(catkin REQUIRED COMPONENTS nodelet ros_babel_fish roslib roscpp)
+    find_package(catkin REQUIRED COMPONENTS nodelet ros_babel_fish rosgraph_msgs roslib roscpp)
     find_package(Boost REQUIRED)
 
     catkin_package(
       INCLUDE_DIRS foxglove_bridge_base/include
       LIBRARIES foxglove_bridge_base foxglove_bridge_nodelet
-      CATKIN_DEPENDS nodelet ros_babel_fish roslib roscpp
+      CATKIN_DEPENDS nodelet ros_babel_fish rosgraph_msgs roslib roscpp
       DEPENDS Boost
     )
 
@@ -117,6 +117,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     set(ROS_BUILD_TYPE "ament_cmake")
 
     find_package(ament_cmake REQUIRED)
+    find_package(rosgraph_msgs REQUIRED)
     find_package(rclcpp REQUIRED)
     find_package(rclcpp_components REQUIRED)
 
@@ -130,7 +131,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros2_foxglove_bridge/include>
         $<INSTALL_INTERFACE:include>
     )
-    ament_target_dependencies(foxglove_bridge_component rclcpp rclcpp_components)
+    ament_target_dependencies(foxglove_bridge_component rclcpp rclcpp_components rosgraph_msgs)
     target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
     rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")
 

--- a/package.xml
+++ b/package.xml
@@ -40,6 +40,8 @@
 
     <exec_depend>openssl</exec_depend>
 
+    <depend>rosgraph_msgs</depend>
+
     <!-- The export tag contains other, unspecified, tags -->
     <export>
         <build_type condition="$ROS_VERSION == 1">catkin</build_type>

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -1,5 +1,6 @@
 #define ASIO_STANDALONE
 
+#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -13,6 +14,7 @@
 #include <ros/ros.h>
 #include <ros_babel_fish/babel_fish_message.h>
 #include <ros_babel_fish/generation/providers/integrated_description_provider.h>
+#include <rosgraph_msgs/Clock.h>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
 #include <foxglove_bridge/websocket_server.hpp>
@@ -315,8 +317,27 @@ private:
 
     std::unordered_set<TopicAndDatatype, PairHash> latestTopics;
     latestTopics.reserve(topicNamesAndTypes.size());
-    for (const auto& topicNameAndType : topicNamesAndTypes) {
-      latestTopics.emplace(topicNameAndType.name, topicNameAndType.datatype);
+    bool hasClockTopic = false;
+    for (const auto& [topicName, datatype] : topicNamesAndTypes) {
+      // Check if a /clock topic is published
+      if (topicName == "/clock" && datatype == "rosgraph_msgs/Clock") {
+        hasClockTopic = true;
+      }
+      latestTopics.emplace(topicName, datatype);
+    }
+
+    // Enable or disable simulated time based on the presence of a /clock topic
+    if (!_useSimTime && hasClockTopic) {
+      ROS_INFO("/clock topic found, using simulated time");
+      _useSimTime = true;
+      _clockSubscription = getMTNodeHandle().subscribe<rosgraph_msgs::Clock>(
+        "/clock", 10, [&](const rosgraph_msgs::Clock::ConstPtr msg) {
+          _simTimeNs = msg->clock.toNSec();
+        });
+    } else if (_useSimTime && !hasClockTopic) {
+      ROS_WARN("/clock topic disappeared");
+      _useSimTime = false;
+      _clockSubscription.shutdown();
     }
 
     // Create a list of topics that are new to us
@@ -428,7 +449,7 @@ private:
     const foxglove::Channel& channel, foxglove::ConnHandle clientHandle,
     const ros::MessageEvent<ros_babel_fish::BabelFishMessage const>& msgEvent) {
     const auto& msg = msgEvent.getConstMessage();
-    const auto receiptTimeNs = msgEvent.getReceiptTime().toNSec();
+    const auto receiptTimeNs = _useSimTime ? _simTimeNs.load() : msgEvent.getReceiptTime().toNSec();
     _server->sendMessage(
       clientHandle, channel.id, receiptTimeNs,
       std::string_view(reinterpret_cast<const char*>(msg->buffer()), msg->size()));
@@ -445,6 +466,9 @@ private:
   ros::Timer _updateTimer;
   size_t _maxUpdateMs = size_t(DEFAULT_MAX_UPDATE_MS);
   size_t _updateCount = 0;
+  ros::Subscriber _clockSubscription;
+  std::atomic<uint64_t> _simTimeNs = 0;
+  std::atomic<bool> _useSimTime = false;
 };
 
 }  // namespace foxglove_bridge


### PR DESCRIPTION
**Public-Facing Changes**
[ros1] Message timestamps are set to sim time if /clock is published, use_sim_time parameter is no longer required

**Description**
Basically ports https://github.com/foxglove/ros-foxglove-bridge/pull/39 to the ros1 node
