### PR TITLE
[ros2]: Improve finding of message file

### DIFF
--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -16,12 +16,6 @@
 
 namespace foxglove {
 
-#ifdef _WIN32
-static const std::string SEPARATOR = "\\";
-#else
-static const std::string SEPARATOR = "/";
-#endif
-
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar)
 static const std::regex PACKAGE_TYPENAME_REGEX{R"(^([a-zA-Z0-9_]+)/(?:msg/)?([a-zA-Z0-9_]+)$)"};
 
@@ -164,7 +158,7 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   }
 
   // Read the file
-  const std::string full_path = share_dir + SEPARATOR + *it;
+  const std::string full_path = share_dir + std::filesystem::path::preferred_separator + *it;
   std::ifstream file{full_path};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -1,5 +1,6 @@
 #include "foxglove_bridge/message_definition_cache.hpp"
 
+#include <filesystem>
 #include <fstream>
 #include <optional>
 #include <regex>
@@ -155,8 +156,8 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   // Find the first line that ends with the filename we're looking for
   const auto lines = split_string(index_contents);
   const auto it = std::find_if(lines.begin(), lines.end(), [&filename](const std::string& line) {
-    return line.size() >= filename.size() &&
-           line.compare(line.size() - filename.size(), filename.size(), filename) == 0;
+    std::filesystem::path filePath(line);
+    return filePath.filename() == filename;
   });
   if (it == lines.end()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Can now handle cases where a message file's name is a substring of another message file's name, e.g. `Foo.msg` and `AAAAFoo.msg`

Fixes #97
