### PR TITLE
Use `%zu` instead of `%ld` for variables of type `size_t`

### DIFF
--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -135,7 +135,7 @@ private:
                  channelId);
 
       } else {
-        ROS_INFO("Added subscriber #%ld to topic \"%s\" (%s) on channel %d",
+        ROS_INFO("Added subscriber #%zu to topic \"%s\" (%s) on channel %d",
                  subscriptionsByClient.size(), topic.c_str(), datatype.c_str(), channelId);
       }
     } catch (const std::exception& ex) {
@@ -181,7 +181,7 @@ private:
                topicAndDatatype.second.c_str(), channelId);
       _subscriptions.erase(it2);
     } else {
-      ROS_INFO("Removed one subscription from channel %d (%ld subscription(s) left)", channelId,
+      ROS_INFO("Removed one subscription from channel %d (%zu subscription(s) left)", channelId,
                subscriptionsByClient.size());
     }
   }

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -399,7 +399,7 @@ private:
                   topic.c_str(), datatype.c_str(), channelId);
 
     } else {
-      RCLCPP_INFO(this->get_logger(), "Adding subscriber #%ld to topic \"%s\" (%s) on channel %d",
+      RCLCPP_INFO(this->get_logger(), "Adding subscriber #%zu to topic \"%s\" (%s) on channel %d",
                   subscriptionsByClient.size(), topic.c_str(), datatype.c_str(), channelId);
     }
 
@@ -457,7 +457,7 @@ private:
       _subscriptions.erase(it2);
     } else {
       RCLCPP_INFO(this->get_logger(),
-                  "Removed one subscription from channel %d (%ld subscription(s) left)", channelId,
+                  "Removed one subscription from channel %d (%zu subscription(s) left)", channelId,
                   subscriptionsByClient.size());
     }
   }


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Fixes compilation on platforms where size_t is e.g. defined as `unsigned int`

See also https://build.ros.org/job/Nbin_ufhf_uFhf__foxglove_bridge__ubuntu_focal_armhf__binary/16