### PR TITLE
Release 0.2.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package foxglove_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+0.2.1 (2022-12-05)
+------------------
 * Fix compilation on platforms where size_t is defined as `unsigned int`
 * Contributors: Hans-Joachim Krauch
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package foxglove_bridge
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Fix compilation on platforms where size_t is defined as `unsigned int`
+* Contributors: Hans-Joachim Krauch
+
 0.2.0 (2022-12-01)
 ------------------
 

--- a/package.xml
+++ b/package.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <package format="3">
     <name>foxglove_bridge</name>
-    <version>0.2.0</version>
+    <version>0.2.1</version>
     <description>ROS Foxglove Bridge</description>
     <license>MIT</license>
     <url type="website">https://github.com/foxglove/ros-foxglove-bridge</url>


### PR DESCRIPTION
**Public-Facing Changes**
Release `0.2.1`

**Description**
Patch release to fix failing Jenkins jobs:

- https://build.ros.org/job/Nbin_ufhf_uFhf__foxglove_bridge__ubuntu_focal_armhf__binary/ will be solved by #106 
- https://build.ros.org/job/Nbin_db_dB64__foxglove_bridge__debian_buster_amd64__binary/ will be solved by re-releasing the package. In a previous release, I ran bloom in a wrong environment, causing it to generate invalid dependencies
