### PR TITLE
Allow to whitelist topics via a ROS paramater

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * __tls__: If `true`, use Transport Layer Security (TLS) for encrypted communication. Defaults to `false`.
  * __certfile__: Path to the certificate to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
  * __keyfile__: Path to the private key to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
+ * __topic_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted topic names. Defaults to `[".*"]`.
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `10`.


### PR DESCRIPTION
**Public-Facing Changes**
Allow to whitelist topics via a ROS paramater


**Description**
Allows the user to explicitly set the topics which should be exposed over the websocket server

Fixes the topic part of #105 