### PR TITLE
Optimize Dockerfiles

### DIFF
--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -27,10 +27,11 @@ COPY ros1_foxglove_bridge src/ros-foxglove-bridge/ros1_foxglove_bridge
 # Build the Catkin workspace and ensure it's sourced when a container is run
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
   && catkin_make
-RUN echo "source devel/setup.bash" >> ~/.bashrc
 
-# Set the working folder at startup
-WORKDIR /ros1_ws
+# source workspace from entrypoint
+RUN sed --in-place \
+      's|^source .*|source "$ROS_WS/install/setup.bash"|' \
+      /ros_entrypoint.sh
 
 # Run foxglove_bridge
-CMD ["/bin/bash", "-c", "source devel/setup.bash && rosrun foxglove_bridge foxglove_bridge"]
+CMD ["rosrun", "foxglove_bridge", "foxglove_bridge"]

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -1,10 +1,8 @@
 ARG ROS_DISTRIBUTION=noetic
-ARG ROS_WS=/ros1_ws
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Set environment and working directory
-ARG ROS_WS
-ENV ROS_WS $ROS_WS
+ENV ROS_WS /ros1_ws
 WORKDIR $ROS_WS
 
 # Add package.xml so we can install package dependencies.

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -1,12 +1,11 @@
 ARG ROS_DISTRIBUTION=noetic
 FROM ros:$ROS_DISTRIBUTION-ros-base
-ARG ROS_DISTRIBUTION=noetic
 
 # Add package.xml so we can install package dependencies.
 COPY package.xml /ros1_ws/src/ros-foxglove-bridge/package.xml
 
 # Install rosdep dependencies
-RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep update && rosdep install -y \
       --from-paths \
         /ros1_ws/src \
@@ -20,7 +19,7 @@ COPY nodelets.xml /ros1_ws/src/ros-foxglove-bridge/nodelets.xml
 COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
 
 # Build the Catkin workspace and ensure it's sourced when a container is run
-RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh \
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
   && cd /ros1_ws \
   && catkin_make
 RUN echo "source /ros1_ws/devel/setup.bash" >> ~/.bashrc

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -8,7 +8,7 @@ ENV ROS_WS $ROS_WS
 WORKDIR $ROS_WS
 
 # Add package.xml so we can install package dependencies.
-COPY package.xml src/ros-foxglove-bridge/package.xml
+COPY package.xml src/ros-foxglove-bridge/
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -24,7 +24,7 @@ COPY foxglove_bridge_base src/ros-foxglove-bridge/foxglove_bridge_base
 COPY nodelets.xml src/ros-foxglove-bridge/nodelets.xml
 COPY ros1_foxglove_bridge src/ros-foxglove-bridge/ros1_foxglove_bridge
 
-# Build the Catkin workspace and ensure it's sourced when a container is run
+# Build the Catkin workspace
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
   && catkin_make
 

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -28,7 +28,7 @@ RUN . /opt/ros/$ROS_DISTRO/setup.sh \
 
 # source workspace from entrypoint
 RUN sed --in-place \
-      's|^source .*|source "$ROS_WS/install/setup.bash"|' \
+      's|^source .*|source "$ROS_WS/devel/setup.bash"|' \
       /ros_entrypoint.sh
 
 # Run foxglove_bridge

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -1,31 +1,36 @@
 ARG ROS_DISTRIBUTION=noetic
+ARG ROS_WS=/ros1_ws
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
+# Set environment and working directory
+ARG ROS_WS
+ENV ROS_WS $ROS_WS
+WORKDIR $ROS_WS
+
 # Add package.xml so we can install package dependencies.
-COPY package.xml /ros1_ws/src/ros-foxglove-bridge/package.xml
+COPY package.xml src/ros-foxglove-bridge/package.xml
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep update && rosdep install -y \
       --from-paths \
-        /ros1_ws/src \
+        src \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
 # Add common files and ROS 1 source code
-COPY CMakeLists.txt /ros1_ws/src/ros-foxglove-bridge/CMakeLists.txt
-COPY foxglove_bridge_base /ros1_ws/src/ros-foxglove-bridge/foxglove_bridge_base
-COPY nodelets.xml /ros1_ws/src/ros-foxglove-bridge/nodelets.xml
-COPY ros1_foxglove_bridge /ros1_ws/src/ros-foxglove-bridge/ros1_foxglove_bridge
+COPY CMakeLists.txt src/ros-foxglove-bridge/CMakeLists.txt
+COPY foxglove_bridge_base src/ros-foxglove-bridge/foxglove_bridge_base
+COPY nodelets.xml src/ros-foxglove-bridge/nodelets.xml
+COPY ros1_foxglove_bridge src/ros-foxglove-bridge/ros1_foxglove_bridge
 
 # Build the Catkin workspace and ensure it's sourced when a container is run
 RUN . /opt/ros/$ROS_DISTRO/setup.sh \
-  && cd /ros1_ws \
   && catkin_make
-RUN echo "source /ros1_ws/devel/setup.bash" >> ~/.bashrc
+RUN echo "source devel/setup.bash" >> ~/.bashrc
 
 # Set the working folder at startup
 WORKDIR /ros1_ws
 
 # Run foxglove_bridge
-CMD ["/bin/bash", "-c", "source /ros1_ws/devel/setup.bash && rosrun foxglove_bridge foxglove_bridge"]
+CMD ["/bin/bash", "-c", "source devel/setup.bash && rosrun foxglove_bridge foxglove_bridge"]

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -1,10 +1,8 @@
 ARG ROS_DISTRIBUTION=humble
-ARG ROS_WS=/ros2_ws
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Set environment and working directory
-ARG ROS_WS
-ENV ROS_WS $ROS_WS
+ENV ROS_WS /ros2_ws
 WORKDIR $ROS_WS
 
 # Install system dependencies

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -43,10 +43,11 @@ SHELL [ "/bin/bash" , "-c" ]
 # Build the ROS 2 workspace and ensure it's sourced when a container is run
 RUN source /opt/ros/$ROS_DISTRO/setup.bash \
   && colcon build --event-handlers console_direct+
-RUN echo "source install/setup.bash" >> ~/.bashrc
 
-# Set the working folder at startup
-WORKDIR /ros2_ws
+# source workspace from entrypoint
+RUN sed --in-place \
+      's|^source .*|source "$ROS_WS/install/setup.bash"|' \
+      /ros_entrypoint.sh
 
 # Run foxglove_bridge
-CMD ["/bin/bash", "-c", "source install/setup.bash && ros2 run foxglove_bridge foxglove_bridge"]
+CMD ["ros2", "run", "foxglove_bridge", "foxglove_bridge"]

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -9,24 +9,18 @@ WORKDIR $ROS_WS
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  build-essential \
-  python3-colcon-common-extensions \
-  python3-rosdep \
   nlohmann-json3-dev \
   libasio-dev \
   libssl-dev \
   libwebsocketpp-dev \
   && rm -rf /var/lib/apt/lists/*
 
-# Initialize rosdep
-RUN rosdep init && rosdep update
-
 # Add package.xml so we can install package dependencies.
 COPY package.xml src/ros-foxglove-bridge/
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    apt-get update && rosdep install -y \
+    apt-get update && rosdep update && rosdep install -y \
       --from-paths \
         src \
       --ignore-src \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -22,7 +22,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN rosdep init && rosdep update
 
 # Add package.xml so we can install package dependencies.
-COPY package.xml src/ros-foxglove-bridge/package.xml
+COPY package.xml src/ros-foxglove-bridge/
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -1,6 +1,5 @@
 ARG ROS_DISTRIBUTION=humble
 FROM ros:$ROS_DISTRIBUTION-ros-core
-ARG ROS_DISTRIBUTION=humble
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,7 +19,7 @@ RUN rosdep init && rosdep update
 COPY package.xml /ros2_ws/src/ros-foxglove-bridge/package.xml
 
 # Install rosdep dependencies
-RUN . /opt/ros/$ROS_DISTRIBUTION/setup.sh && \
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep install -y \
       --from-paths \
         /ros2_ws/src \
@@ -36,7 +35,7 @@ COPY ros2_foxglove_bridge /ros2_ws/src/ros-foxglove-bridge/ros2_foxglove_bridge
 SHELL [ "/bin/bash" , "-c" ]
 
 # Build the ROS 2 workspace and ensure it's sourced when a container is run
-RUN source /opt/ros/$ROS_DISTRIBUTION/setup.bash \
+RUN source /opt/ros/$ROS_DISTRO/setup.bash \
   && cd /ros2_ws \
   && colcon build --event-handlers console_direct+
 RUN echo "source /ros2_ws/install/setup.bash" >> ~/.bashrc

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -1,5 +1,11 @@
 ARG ROS_DISTRIBUTION=humble
-FROM ros:$ROS_DISTRIBUTION-ros-core
+ARG ROS_WS=/ros2_ws
+FROM ros:$ROS_DISTRIBUTION-ros-base
+
+# Set environment and working directory
+ARG ROS_WS
+ENV ROS_WS $ROS_WS
+WORKDIR $ROS_WS
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -16,32 +22,31 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN rosdep init && rosdep update
 
 # Add package.xml so we can install package dependencies.
-COPY package.xml /ros2_ws/src/ros-foxglove-bridge/package.xml
+COPY package.xml src/ros-foxglove-bridge/package.xml
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep install -y \
       --from-paths \
-        /ros2_ws/src \
+        src \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
 
 # Add common files and ROS 2 source code
-COPY CMakeLists.txt /ros2_ws/src/ros-foxglove-bridge/CMakeLists.txt
-COPY foxglove_bridge_base /ros2_ws/src/ros-foxglove-bridge/foxglove_bridge_base
-COPY ros2_foxglove_bridge /ros2_ws/src/ros-foxglove-bridge/ros2_foxglove_bridge
+COPY CMakeLists.txt src/ros-foxglove-bridge/CMakeLists.txt
+COPY foxglove_bridge_base src/ros-foxglove-bridge/foxglove_bridge_base
+COPY ros2_foxglove_bridge src/ros-foxglove-bridge/ros2_foxglove_bridge
 
 # Use the bash shell so we can use the source command
 SHELL [ "/bin/bash" , "-c" ]
 
 # Build the ROS 2 workspace and ensure it's sourced when a container is run
 RUN source /opt/ros/$ROS_DISTRO/setup.bash \
-  && cd /ros2_ws \
   && colcon build --event-handlers console_direct+
-RUN echo "source /ros2_ws/install/setup.bash" >> ~/.bashrc
+RUN echo "source install/setup.bash" >> ~/.bashrc
 
 # Set the working folder at startup
 WORKDIR /ros2_ws
 
 # Run foxglove_bridge
-CMD ["/bin/bash", "-c", "source /ros2_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge"]
+CMD ["/bin/bash", "-c", "source install/setup.bash && ros2 run foxglove_bridge foxglove_bridge"]

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -37,11 +37,8 @@ COPY CMakeLists.txt src/ros-foxglove-bridge/CMakeLists.txt
 COPY foxglove_bridge_base src/ros-foxglove-bridge/foxglove_bridge_base
 COPY ros2_foxglove_bridge src/ros-foxglove-bridge/ros2_foxglove_bridge
 
-# Use the bash shell so we can use the source command
-SHELL [ "/bin/bash" , "-c" ]
-
-# Build the ROS 2 workspace and ensure it's sourced when a container is run
-RUN source /opt/ros/$ROS_DISTRO/setup.bash \
+# Build the ROS 2 workspace
+RUN . /opt/ros/$ROS_DISTRO/setup.sh \
   && colcon build --event-handlers console_direct+
 
 # source workspace from entrypoint


### PR DESCRIPTION
I was looking at the source Dockerfile for the `ghcr.io/foxglove/rolling-ros2-bridge` image, and noticed some optimizations that could be made. See commit history for details.

The only major change is swapping the base image for the ros2 bridge from `ros-core` over to `ros-base`:

```
REPOSITORY                TAG                SIZE
foxglove_bridge_rolling   base (after)       1.03GB
foxglove_bridge_rolling   core (before)      945MB
ros                       rolling-ros-base   752MB
ros                       rolling-ros-core   474MB
ubuntu                    jammy              77.8MB
```
I did this as most of the large dependencies being manually installed should already be provided by the base tag. While the resulting image is a little larger `(1.03GB-945MB)=85MB`, the resulting size of the added layers to be regularly pushed over the network and saved to disk with every update to the bridge image is reduced from `(945MB-474MB)=471MB` to just `(1.03GB-752MB)=278MB`. Given 1) most robots using docker are more likely to have at least the image layers for the `ros-base` tag cached locally already for other running ROS containers, 2) the lower cadence of changed layers in the `ros-base` image, this should help reduce the bandwidth and storage requirements for deploying these bridge images.
