### PR TITLE
Add parameter support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -128,6 +128,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
       ros2_foxglove_bridge/src/message_definition_cache.cpp
       ros2_foxglove_bridge/src/param_utils.cpp
       ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+      ros2_foxglove_bridge/src/parameter_interface.cpp
     )
     target_include_directories(foxglove_bridge_component
       PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -103,8 +103,17 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
       DEPENDS Boost
     )
 
-    add_library(foxglove_bridge_nodelet ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp)
-    target_include_directories(foxglove_bridge_nodelet SYSTEM PRIVATE ${catkin_INCLUDE_DIRS})
+    add_library(foxglove_bridge_nodelet
+      ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+      ros1_foxglove_bridge/src/param_utils.cpp
+    )
+    target_include_directories(foxglove_bridge_nodelet
+      SYSTEM PRIVATE
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros1_foxglove_bridge/include>
+        $<INSTALL_INTERFACE:include>
+        ${catkin_INCLUDE_DIRS}
+    )
     target_link_libraries(foxglove_bridge_nodelet foxglove_bridge_base ${catkin_LIBRARIES})
 
     add_executable(foxglove_bridge ros1_foxglove_bridge/src/ros1_foxglove_bridge_node.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
 
     add_library(foxglove_bridge_component SHARED
       ros2_foxglove_bridge/src/message_definition_cache.cpp
+      ros2_foxglove_bridge/src/param_utils.cpp
       ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
     )
     target_include_directories(foxglove_bridge_component

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,6 +64,8 @@ endif()
 # Build the foxglove_bridge_base library
 add_library(foxglove_bridge_base SHARED
   foxglove_bridge_base/src/foxglove_bridge.cpp
+  foxglove_bridge_base/src/parameter.cpp
+  foxglove_bridge_base/src/serialization.cpp
   foxglove_bridge_base/src/test/test_client.cpp
 )
 target_include_directories(foxglove_bridge_base

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -9,6 +9,8 @@ namespace foxglove {
 constexpr char SUPPORTED_SUBPROTOCOL[] = "foxglove.websocket.v1";
 constexpr char CAPABILITY_CLIENT_PUBLISH[] = "clientPublish";
 constexpr char CAPABILITY_TIME[] = "time";
+constexpr char CAPABILITY_PARAMETERS[] = "parameters";
+constexpr char CAPABILITY_PARAMETERS_SUBSCRIBE[] = "parametersSubscribe";
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
@@ -28,11 +28,13 @@ class Parameter {
 public:
   Parameter();
   Parameter(const std::string& name, bool value);
+  Parameter(const std::string& name, int value);
   Parameter(const std::string& name, int64_t value);
   Parameter(const std::string& name, double value);
   Parameter(const std::string& name, std::string value);
   Parameter(const std::string& name, const char* value);
   Parameter(const std::string& name, const std::vector<bool>& value);
+  Parameter(const std::string& name, const std::vector<int>& value);
   Parameter(const std::string& name, const std::vector<int64_t>& value);
   Parameter(const std::string& name, const std::vector<double>& value);
   Parameter(const std::string& name, const std::vector<std::string>& value);

--- a/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
@@ -1,0 +1,59 @@
+#pragma once
+
+#include <any>
+#include <stdint.h>
+#include <string>
+#include <vector>
+
+namespace foxglove {
+
+enum class ParameterSubscriptionOperation {
+  SUBSCRIBE,
+  UNSUBSCRIBE,
+};
+
+enum class ParameterType {
+  PARAMETER_NOT_SET,
+  PARAMETER_BOOL,
+  PARAMETER_INTEGER,
+  PARAMETER_DOUBLE,
+  PARAMETER_STRING,
+  PARAMETER_BOOL_ARRAY,
+  PARAMETER_INTEGER_ARRAY,
+  PARAMETER_DOUBLE_ARRAY,
+  PARAMETER_STRING_ARRAY,
+};
+
+class Parameter {
+public:
+  Parameter();
+  Parameter(const std::string& name, bool value);
+  Parameter(const std::string& name, int64_t value);
+  Parameter(const std::string& name, double value);
+  Parameter(const std::string& name, std::string value);
+  Parameter(const std::string& name, const char* value);
+  Parameter(const std::string& name, const std::vector<bool>& value);
+  Parameter(const std::string& name, const std::vector<int64_t>& value);
+  Parameter(const std::string& name, const std::vector<double>& value);
+  Parameter(const std::string& name, const std::vector<std::string>& value);
+
+  inline const std::string& getName() const {
+    return _name;
+  }
+
+  inline ParameterType getType() const {
+    return _type;
+  }
+
+  template <typename T>
+  inline const T& getValue() const {
+    return std::any_cast<const T&>(_value);
+  }
+
+private:
+  std::string _name;
+  ParameterType _type;
+  std::any _value;
+};
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -2,6 +2,10 @@
 
 #include <stdint.h>
 
+#include <nlohmann/json.hpp>
+
+#include "parameter.hpp"
+
 namespace foxglove {
 
 inline void WriteUint64LE(uint8_t* buf, uint64_t val) {
@@ -29,5 +33,8 @@ inline void WriteUint32LE(uint8_t* buf, uint32_t val) {
   reinterpret_cast<uint32_t*>(buf)[0] = val;
 #endif
 }
+
+void to_json(nlohmann::json& j, const Parameter& p);
+void from_json(const nlohmann::json& j, Parameter& p);
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -15,7 +15,7 @@ std::vector<uint8_t> connectClientAndReceiveMsg(const std::string& uri,
                                                 const std::string& topic_name);
 
 std::vector<Parameter> waitForParameters(
-  std::shared_ptr<ClientInterface> client,
+  std::shared_ptr<ClientInterface> client, const std::string& requestId = std::string(),
   const std::chrono::duration<double>& timeout = std::chrono::seconds(5));
 
 extern template class Client<websocketpp::config::asio_client>;

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -1,16 +1,22 @@
 #pragma once
 
+#include <chrono>
 #include <string>
 #include <vector>
 
 #include <websocketpp/config/asio_client.hpp>
 
+#include "../parameter.hpp"
 #include "../websocket_client.hpp"
 
 namespace foxglove {
 
 std::vector<uint8_t> connectClientAndReceiveMsg(const std::string& uri,
                                                 const std::string& topic_name);
+
+std::vector<Parameter> waitForParameters(
+  std::shared_ptr<ClientInterface> client,
+  const std::chrono::duration<double>& timeout = std::chrono::seconds(5));
 
 extern template class Client<websocketpp::config::asio_client>;
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -42,7 +42,8 @@ public:
   virtual void advertise(const std::vector<ClientAdvertisement>& channels) = 0;
   virtual void unadvertise(const std::vector<ClientChannelId>& channelIds) = 0;
   virtual void publish(ClientChannelId channelId, const uint8_t* buffer, size_t size) = 0;
-  virtual void getParameters(const std::vector<std::string>& parameterNames) = 0;
+  virtual void getParameters(const std::vector<std::string>& parameterNames,
+                             const std::string& requestId) = 0;
   virtual void setParameters(const std::vector<Parameter>& parameters) = 0;
   virtual void subscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
   virtual void unsubscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
@@ -180,8 +181,10 @@ public:
     sendBinary(payload.data(), payload.size());
   }
 
-  void getParameters(const std::vector<std::string>& parameterNames) override {
-    nlohmann::json jsonPayload{{"op", "getParameters"}, {"parameters", parameterNames}};
+  void getParameters(const std::vector<std::string>& parameterNames,
+                     const std::string& requestId) override {
+    nlohmann::json jsonPayload{
+      {"op", "getParameters"}, {"parameters", parameterNames}, {"id", requestId}};
     sendText(jsonPayload.dump());
   }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -12,6 +12,7 @@
 #include <websocketpp/common/thread.hpp>
 
 #include "common.hpp"
+#include "parameter.hpp"
 #include "serialization.hpp"
 
 namespace foxglove {
@@ -41,6 +42,10 @@ public:
   virtual void advertise(const std::vector<ClientAdvertisement>& channels) = 0;
   virtual void unadvertise(const std::vector<ClientChannelId>& channelIds) = 0;
   virtual void publish(ClientChannelId channelId, const uint8_t* buffer, size_t size) = 0;
+  virtual void getParameters(const std::vector<std::string>& parameterNames) = 0;
+  virtual void setParameters(const std::vector<Parameter>& parameters) = 0;
+  virtual void subscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
+  virtual void unsubscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
 
   virtual void setTextMessageHandler(TextMessageHandler handler) = 0;
   virtual void setBinaryMessageHandler(BinaryMessageHandler handler) = 0;
@@ -173,6 +178,27 @@ public:
     foxglove::WriteUint32LE(payload.data() + 1, channelId);
     std::memcpy(payload.data() + 1 + 4, buffer, size);
     sendBinary(payload.data(), payload.size());
+  }
+
+  void getParameters(const std::vector<std::string>& parameterNames) override {
+    nlohmann::json jsonPayload{{"op", "getParameters"}, {"parameters", parameterNames}};
+    sendText(jsonPayload.dump());
+  }
+
+  void setParameters(const std::vector<Parameter>& parameters) override {
+    nlohmann::json jsonPayload{{"op", "setParameters"}, {"parameters", parameters}};
+    sendText(jsonPayload.dump());
+  }
+
+  void subscribeParameterUpdates(const std::vector<std::string>& parameterNames) override {
+    nlohmann::json jsonPayload{{"op", "subscribeParameterUpdates"}, {"parameters", parameterNames}};
+    sendText(jsonPayload.dump());
+  }
+
+  void unsubscribeParameterUpdates(const std::vector<std::string>& parameterNames) override {
+    nlohmann::json jsonPayload{{"op", "unsubscribeParameterUpdates"},
+                               {"parameters", parameterNames}};
+    sendText(jsonPayload.dump());
   }
 
   void setTextMessageHandler(TextMessageHandler handler) override {

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -805,10 +805,8 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
                      });
 
         // Update the client's parameter subscriptions.
-        auto [clientSubscribedParamsIt, newlyInserted] =
-          _clientParamSubscriptions.try_emplace(hdl, std::unordered_set<std::string>());
-        (void)newlyInserted;
-        clientSubscribedParamsIt->second.insert(paramNames.begin(), paramNames.end());
+        auto& clientSubscribedParams = _clientParamSubscriptions[hdl];
+        clientSubscribedParams.insert(paramNames.begin(), paramNames.end());
       }
 
       if (!paramsToSubscribe.empty()) {

--- a/foxglove_bridge_base/src/parameter.cpp
+++ b/foxglove_bridge_base/src/parameter.cpp
@@ -1,0 +1,53 @@
+#include <foxglove_bridge/parameter.hpp>
+
+namespace foxglove {
+
+Parameter::Parameter()
+    : _name("")
+    , _type(ParameterType::PARAMETER_NOT_SET)
+    , _value() {}
+
+Parameter::Parameter(const std::string& name, bool value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_BOOL)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, int64_t value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_INTEGER)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, double value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_DOUBLE)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const char* value)
+    : Parameter(name, std::string(value)) {}
+
+Parameter::Parameter(const std::string& name, std::string value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_STRING)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const std::vector<bool>& value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_BOOL_ARRAY)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const std::vector<int64_t>& value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_INTEGER_ARRAY)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const std::vector<double>& value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_DOUBLE_ARRAY)
+    , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const std::vector<std::string>& value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_STRING_ARRAY)
+    , _value(value) {}
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/src/parameter.cpp
+++ b/foxglove_bridge_base/src/parameter.cpp
@@ -12,6 +12,9 @@ Parameter::Parameter(const std::string& name, bool value)
     , _type(ParameterType::PARAMETER_BOOL)
     , _value(value) {}
 
+Parameter::Parameter(const std::string& name, int value)
+    : Parameter(name, static_cast<int64_t>(value)) {}
+
 Parameter::Parameter(const std::string& name, int64_t value)
     : _name(name)
     , _type(ParameterType::PARAMETER_INTEGER)
@@ -34,6 +37,11 @@ Parameter::Parameter(const std::string& name, const std::vector<bool>& value)
     : _name(name)
     , _type(ParameterType::PARAMETER_BOOL_ARRAY)
     , _value(value) {}
+
+Parameter::Parameter(const std::string& name, const std::vector<int>& value)
+    : _name(name)
+    , _type(ParameterType::PARAMETER_INTEGER_ARRAY)
+    , _value(std::vector<int64_t>(value.begin(), value.end())) {}
 
 Parameter::Parameter(const std::string& name, const std::vector<int64_t>& value)
     : _name(name)

--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -1,0 +1,68 @@
+#include <foxglove_bridge/serialization.hpp>
+
+namespace foxglove {
+
+void to_json(nlohmann::json& j, const Parameter& p) {
+  const auto paramType = p.getType();
+  if (paramType == ParameterType::PARAMETER_BOOL) {
+    j["value"] = p.getValue<bool>();
+  } else if (paramType == ParameterType::PARAMETER_INTEGER) {
+    j["value"] = p.getValue<int64_t>();
+  } else if (paramType == ParameterType::PARAMETER_DOUBLE) {
+    j["value"] = p.getValue<double>();
+  } else if (paramType == ParameterType::PARAMETER_STRING) {
+    j["value"] = p.getValue<std::string>();
+  } else if (paramType == ParameterType::PARAMETER_BOOL_ARRAY) {
+    j["value"] = p.getValue<std::vector<bool>>();
+  } else if (paramType == ParameterType::PARAMETER_INTEGER_ARRAY) {
+    j["value"] = p.getValue<std::vector<int64_t>>();
+  } else if (paramType == ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    j["value"] = p.getValue<std::vector<double>>();
+  } else if (paramType == ParameterType::PARAMETER_STRING_ARRAY) {
+    j["value"] = p.getValue<std::vector<std::string>>();
+  } else if (paramType == ParameterType::PARAMETER_NOT_SET) {
+    throw std::runtime_error("Unintialized parameter");
+  }
+
+  j["name"] = p.getName();
+}
+
+void from_json(const nlohmann::json& j, Parameter& p) {
+  const auto name = j["name"].get<std::string>();
+  const auto value = j["value"];
+  const auto jsonType = j["value"].type();
+
+  if (jsonType == nlohmann::detail::value_t::string) {
+    p = Parameter(name, value.get<std::string>());
+  } else if (jsonType == nlohmann::detail::value_t::boolean) {
+    p = Parameter(name, value.get<bool>());
+  } else if (jsonType == nlohmann::detail::value_t::number_integer) {
+    p = Parameter(name, value.get<int64_t>());
+  } else if (jsonType == nlohmann::detail::value_t::number_unsigned) {
+    p = Parameter(name, value.get<int64_t>());
+  } else if (jsonType == nlohmann::detail::value_t::number_float) {
+    p = Parameter(name, value.get<double>());
+  } else if (jsonType == nlohmann::detail::value_t::array) {
+    if (j.empty()) {
+      throw std::runtime_error("Setting empty arrays is currently unsupported.");
+    }
+
+    if (value.front().is_string()) {
+      p = Parameter(name, value.get<std::vector<std::string>>());
+    } else if (value.front().is_boolean()) {
+      p = Parameter(name, value.get<std::vector<bool>>());
+    } else if (value.front().is_number_integer()) {
+      p = Parameter(name, value.get<std::vector<int64_t>>());
+    } else if (value.front().is_number_unsigned()) {
+      p = Parameter(name, value.get<std::vector<int64_t>>());
+    } else if (value.front().is_number_float()) {
+      p = Parameter(name, value.get<std::vector<double>>());
+    } else {
+      throw std::runtime_error("Unsupported array type");
+    }
+  } else {
+    throw std::runtime_error("Unsupported type");
+  }
+}
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/src/test/test_client.cpp
+++ b/foxglove_bridge_base/src/test/test_client.cpp
@@ -4,6 +4,7 @@
 #define ASIO_STANDALONE
 #include <websocketpp/config/asio_client.hpp>
 
+#include <foxglove_bridge/serialization.hpp>
 #include <foxglove_bridge/test/test_client.hpp>
 #include <foxglove_bridge/websocket_client.hpp>
 
@@ -53,6 +54,26 @@ std::vector<uint8_t> connectClientAndReceiveMsg(const std::string& uri,
     throw std::runtime_error("Client failed to receive message");
   }
   return msgFuture.get();
+}
+
+std::vector<Parameter> waitForParameters(std::shared_ptr<ClientInterface> client,
+                                         const std::chrono::duration<double>& timeout) {
+  std::promise<std::vector<Parameter>> paramPromise;
+  auto paramFuture = paramPromise.get_future();
+  client->setTextMessageHandler([&paramPromise](const std::string& payload) {
+    const auto msg = nlohmann::json::parse(payload);
+    const auto& op = msg["op"].get<std::string>();
+    if (op == "parameterValues") {
+      const auto parameters = msg["parameters"].get<std::vector<Parameter>>();
+      paramPromise.set_value(std::move(parameters));
+    }
+  });
+
+  // Wait until we have received parameters
+  if (std::future_status::ready != paramFuture.wait_for(timeout)) {
+    throw std::runtime_error("Client failed to receive parameters");
+  }
+  return paramFuture.get();
 }
 
 // Explicit template instantiation

--- a/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <xmlrpcpp/XmlRpc.h>
+
+#include <foxglove_bridge/parameter.hpp>
+
+namespace foxglove_bridge {
+
+foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value);
+
+std::vector<std::regex> parseRegexPatterns(const std::vector<std::string>& strings);
+
+bool isWhitelisted(const std::string& name, const std::vector<std::regex>& regexPatterns);
+
+}  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/param_utils.cpp
+++ b/ros1_foxglove_bridge/src/param_utils.cpp
@@ -1,0 +1,80 @@
+
+#include <stdexcept>
+
+#include <foxglove_bridge/param_utils.hpp>
+
+namespace {
+
+template <typename T>
+std::vector<T> toVector(const XmlRpc::XmlRpcValue& value) {
+  std::vector<T> arr;
+  arr.reserve(static_cast<size_t>(value.size()));
+  for (int i = 0; i < value.size(); i++) {
+    arr.push_back(static_cast<T>(value[i]));
+  }
+  return arr;
+}
+
+}  // namespace
+
+namespace foxglove_bridge {
+
+foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value) {
+  const auto type = value.getType();
+
+  if (type == XmlRpc::XmlRpcValue::Type::TypeBoolean) {
+    return foxglove::Parameter(name, static_cast<bool>(value));
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeInt) {
+    return foxglove::Parameter(name, static_cast<int64_t>(static_cast<int>(value)));
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeDouble) {
+    return foxglove::Parameter(name, static_cast<double>(value));
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeString) {
+    return foxglove::Parameter(name, static_cast<std::string>(value));
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeArray) {
+    if (value.size() == 0) {
+      // We can't defer the type in this case so we simply treat it as a int list
+      return foxglove::Parameter(name, std::vector<int>());
+    } else {
+      const auto firstElement = value[0];
+      const auto firstElementType = firstElement.getType();
+      if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeBoolean) {
+        return foxglove::Parameter(name, toVector<bool>(value));
+      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeInt) {
+        return foxglove::Parameter(name, toVector<int>(value));
+      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeDouble) {
+        return foxglove::Parameter(name, toVector<double>(value));
+      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeString) {
+        return foxglove::Parameter(name, toVector<std::string>(value));
+      } else {
+        throw std::runtime_error("Parameter '" + name + "': Unsupported parameter array type");
+      }
+    }
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeInvalid) {
+    throw std::runtime_error("Parameter '" + name + "': Not set");
+  } else {
+    throw std::runtime_error("Parameter '" + name + "': Unsupported parameter type");
+  }
+
+  return foxglove::Parameter();
+}
+
+std::vector<std::regex> parseRegexPatterns(const std::vector<std::string>& patterns) {
+  std::vector<std::regex> result;
+  for (const auto& pattern : patterns) {
+    try {
+      result.push_back(
+        std::regex(pattern, std::regex_constants::ECMAScript | std::regex_constants::icase));
+    } catch (...) {
+      continue;
+    }
+  }
+  return result;
+}
+
+bool isWhitelisted(const std::string& name, const std::vector<std::regex>& regexPatterns) {
+  return std::find_if(regexPatterns.begin(), regexPatterns.end(), [name](const auto& regex) {
+           return std::regex_match(name, regex);
+         }) != regexPatterns.end();
+}
+
+}  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -69,6 +69,8 @@ public:
     try {
       std::vector<std::string> serverCapabilities = {
         foxglove::CAPABILITY_CLIENT_PUBLISH,
+        foxglove::CAPABILITY_PARAMETERS,
+        foxglove::CAPABILITY_PARAMETERS_SUBSCRIBE,
       };
       if (_useSimTime) {
         serverCapabilities.push_back(foxglove::CAPABILITY_TIME);

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -18,6 +18,30 @@ constexpr char URI[] = "ws://localhost:9876";
 constexpr uint8_t HELLO_WORLD_BINARY[] = {11,  0,  0,   0,   104, 101, 108, 108,
                                           111, 32, 119, 111, 114, 108, 100};
 
+class ParameterTest : public ::testing::Test {
+public:
+  using PARAM_1_TYPE = std::string;
+  inline static const std::string PARAM_1_NAME = "/node_1/string_param";
+  inline static const PARAM_1_TYPE PARAM_1_DEFAULT_VALUE = "hello";
+
+  using PARAM_2_TYPE = std::vector<double>;
+  inline static const std::string PARAM_2_NAME = "/node_2/int_array_param";
+  inline static const PARAM_2_TYPE PARAM_2_DEFAULT_VALUE = {1.2, 2.1, 3.3};
+
+protected:
+  void SetUp() override {
+    _nh = ros::NodeHandle();
+    _nh.setParam(PARAM_1_NAME, PARAM_1_DEFAULT_VALUE);
+    _nh.setParam(PARAM_2_NAME, PARAM_2_DEFAULT_VALUE);
+
+    _wsClient = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
+    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(std::chrono::seconds(5)));
+  }
+
+  ros::NodeHandle _nh;
+  std::shared_ptr<foxglove::Client<websocketpp::config::asio_client>> _wsClient;
+};
+
 TEST(SmokeTest, testConnection) {
   foxglove::Client<websocketpp::config::asio_client> wsClient;
   EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
@@ -92,6 +116,113 @@ TEST(SmokeTest, testPublishing) {
   const auto msgResult = msgFuture.wait_for(std::chrono::seconds(1));
   ASSERT_EQ(std::future_status::ready, msgResult);
   EXPECT_EQ("hello world", msgFuture.get());
+}
+
+TEST_F(ParameterTest, testGetAllParams) {
+  const std::string requestId = "req-testGetAllParams";
+  _wsClient->getParameters({}, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_GE(params.size(), 2UL);
+}
+
+TEST_F(ParameterTest, testGetNonExistingParameters) {
+  const std::string requestId = "req-testGetNonExistingParameters";
+  _wsClient->getParameters(
+    {"/foo_1/non_existing_parameter", "/foo_2/non_existing/nested_parameter"}, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_TRUE(params.empty());
+}
+
+TEST_F(ParameterTest, testGetParameters) {
+  const std::string requestId = "req-testGetParameters";
+  _wsClient->getParameters({PARAM_1_NAME, PARAM_2_NAME}, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_EQ(2UL, params.size());
+  auto p1Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
+    return param.getName() == PARAM_1_NAME;
+  });
+  auto p2Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
+    return param.getName() == PARAM_2_NAME;
+  });
+  ASSERT_NE(p1Iter, params.end());
+  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue<PARAM_1_TYPE>());
+  ASSERT_NE(p2Iter, params.end());
+  EXPECT_EQ(PARAM_2_DEFAULT_VALUE, p2Iter->getValue<PARAM_2_TYPE>());
+}
+
+TEST_F(ParameterTest, testSetParameters) {
+  const PARAM_1_TYPE newP1value = "world";
+  const PARAM_2_TYPE newP2value = {4.1, 5.5, 6.6};
+
+  const std::vector<foxglove::Parameter> parameters = {
+    foxglove::Parameter(PARAM_1_NAME, newP1value),
+    foxglove::Parameter(PARAM_2_NAME, newP2value),
+  };
+
+  _wsClient->setParameters(parameters);
+  const std::string requestId = "req-testSetParameters";
+  _wsClient->getParameters({PARAM_1_NAME, PARAM_2_NAME}, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_EQ(2UL, params.size());
+  auto p1Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
+    return param.getName() == PARAM_1_NAME;
+  });
+  auto p2Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
+    return param.getName() == PARAM_2_NAME;
+  });
+  ASSERT_NE(p1Iter, params.end());
+  EXPECT_EQ(newP1value, p1Iter->getValue<PARAM_1_TYPE>());
+  ASSERT_NE(p2Iter, params.end());
+  EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
+}
+
+TEST_F(ParameterTest, testParameterSubscription) {
+  _wsClient->subscribeParameterUpdates({PARAM_1_NAME});
+  _wsClient->setParameters({foxglove::Parameter(PARAM_1_NAME, "foo")});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, "", std::chrono::seconds(5)));
+  ASSERT_EQ(1UL, params.size());
+  EXPECT_EQ(params.front().getName(), PARAM_1_NAME);
+
+  _wsClient->unsubscribeParameterUpdates({PARAM_1_NAME});
+  _wsClient->setParameters({foxglove::Parameter(PARAM_1_NAME, "bar")});
+  EXPECT_THROW((void)foxglove::waitForParameters(_wsClient, "", std::chrono::seconds(5)),
+               std::runtime_error);
+}
+
+TEST_F(ParameterTest, testGetParametersParallel) {
+  // Connect a few clients (in parallel) and make sure that they all receive parameters
+  auto clients = {
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+  };
+
+  std::vector<std::future<std::vector<foxglove::Parameter>>> futures;
+  for (auto client : clients) {
+    futures.push_back(
+      std::async(std::launch::async, [client]() -> std::vector<foxglove::Parameter> {
+        if (std::future_status::ready == client->connect(URI).wait_for(std::chrono::seconds(5))) {
+          const std::string requestId = "req-123";
+          client->getParameters({}, requestId);
+          const auto parameters =
+            foxglove::waitForParameters(client, requestId, std::chrono::seconds(5));
+          return parameters;
+        }
+        return {};
+      }));
+  }
+
+  for (auto& future : futures) {
+    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    std::vector<foxglove::Parameter> parameters;
+    EXPECT_NO_THROW(parameters = future.get());
+    EXPECT_GE(parameters.size(), 2UL);
+  }
 }
 
 // Run all the tests that were declared with TEST()

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -1,0 +1,30 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <rclcpp/node.hpp>
+
+namespace foxglove_bridge {
+
+constexpr char PARAM_PORT[] = "port";
+constexpr char PARAM_ADDRESS[] = "address";
+constexpr char PARAM_SEND_BUFFER_LIMIT[] = "send_buffer_limit";
+constexpr char PARAM_USETLS[] = "tls";
+constexpr char PARAM_CERTFILE[] = "certfile";
+constexpr char PARAM_KEYFILE[] = "keyfile";
+constexpr char PARAM_MAX_QOS_DEPTH[] = "max_qos_depth";
+constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
+
+constexpr int64_t DEFAULT_PORT = 8765;
+constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
+constexpr int64_t DEFAULT_SEND_BUFFER_LIMIT = 10000000;
+constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 10;
+
+void declareParameters(rclcpp::Node* node);
+
+std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,
+                                          const std::vector<std::string>& strings);
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -16,6 +16,7 @@ constexpr char PARAM_CERTFILE[] = "certfile";
 constexpr char PARAM_KEYFILE[] = "keyfile";
 constexpr char PARAM_MAX_QOS_DEPTH[] = "max_qos_depth";
 constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
+constexpr char PARAM_PARAMETER_WHITELIST[] = "param_whitelist";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <chrono>
+#include <functional>
+#include <mutex>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <foxglove_bridge/parameter.hpp>
+
+namespace foxglove_bridge {
+
+using ParameterList = std::vector<foxglove::Parameter>;
+using ParamUpdateFunc = std::function<void(const ParameterList&)>;
+
+class ParameterInterface {
+public:
+  ParameterInterface(rclcpp::Node* node);
+
+  ParameterList getParams(const std::vector<std::string>& paramNames,
+                          const std::chrono::duration<double>& timeout);
+  void setParams(const ParameterList& params, const std::chrono::duration<double>& timeout);
+  void subscribeParams(const std::vector<std::string>& paramNames);
+  void unsubscribeParams(const std::vector<std::string>& paramNames);
+  void setParamUpdateCallback(ParamUpdateFunc paramUpdateFunc);
+
+private:
+  rclcpp::Node* _node;
+  rclcpp::CallbackGroup::SharedPtr _callbackGroup;
+  std::mutex _mutex;
+  std::unordered_map<std::string, rclcpp::AsyncParametersClient::SharedPtr> _paramClientsByNode;
+  std::unordered_map<std::string, std::unordered_set<std::string>> _subscribedParamsByNode;
+  std::unordered_map<std::string, rclcpp::SubscriptionBase::SharedPtr> _paramSubscriptionsByNode;
+  ParamUpdateFunc _paramUpdateFunc;
+
+  ParameterList getNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,
+                                  const std::string& nodeName,
+                                  const std::vector<std::string>& paramNames,
+                                  const std::chrono::duration<double>& timeout);
+  void setNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,
+                         const std::string& nodeName, const std::vector<rclcpp::Parameter>& params,
+                         const std::chrono::duration<double>& timeout);
+};
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <functional>
 #include <mutex>
+#include <regex>
 #include <string>
 #include <unordered_set>
 #include <vector>
@@ -18,7 +19,7 @@ using ParamUpdateFunc = std::function<void(const ParameterList&)>;
 
 class ParameterInterface {
 public:
-  ParameterInterface(rclcpp::Node* node);
+  ParameterInterface(rclcpp::Node* node, std::vector<std::regex> paramWhitelistPatterns);
 
   ParameterList getParams(const std::vector<std::string>& paramNames,
                           const std::chrono::duration<double>& timeout);
@@ -29,6 +30,7 @@ public:
 
 private:
   rclcpp::Node* _node;
+  std::vector<std::regex> _paramWhitelistPatterns;
   rclcpp::CallbackGroup::SharedPtr _callbackGroup;
   std::mutex _mutex;
   std::unordered_map<std::string, rclcpp::AsyncParametersClient::SharedPtr> _paramClientsByNode;
@@ -43,6 +45,7 @@ private:
   void setNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,
                          const std::string& nodeName, const std::vector<rclcpp::Parameter>& params,
                          const std::chrono::duration<double>& timeout);
+  bool isWhitelistedParam(const std::string& paramName);
 };
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -79,6 +79,15 @@ void declareParameters(rclcpp::Node* node) {
   topicWhiteListDescription.read_only = true;
   node->declare_parameter(PARAM_TOPIC_WHITELIST, std::vector<std::string>({".*"}),
                           topicWhiteListDescription);
+
+  auto paramWhiteListDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  paramWhiteListDescription.name = PARAM_PARAMETER_WHITELIST;
+  paramWhiteListDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  paramWhiteListDescription.description =
+    "List of regular expressions (ECMAScript) of whitelisted parameter names.";
+  paramWhiteListDescription.read_only = true;
+  node->declare_parameter(PARAM_PARAMETER_WHITELIST, std::vector<std::string>({".*"}),
+                          paramWhiteListDescription);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -1,0 +1,102 @@
+
+
+#include <foxglove_bridge/param_utils.hpp>
+
+namespace foxglove_bridge {
+
+void declareParameters(rclcpp::Node* node) {
+  auto portDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  portDescription.name = PARAM_PORT;
+  portDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  portDescription.description = "The TCP port to bind the WebSocket server to";
+  portDescription.read_only = true;
+  portDescription.additional_constraints =
+    "Must be a valid TCP port number, or 0 to use a random port";
+  portDescription.integer_range.resize(1);
+  portDescription.integer_range[0].from_value = 0;
+  portDescription.integer_range[0].to_value = 65535;
+  portDescription.integer_range[0].step = 1;
+  node->declare_parameter(PARAM_PORT, DEFAULT_PORT, portDescription);
+
+  auto addressDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  addressDescription.name = PARAM_ADDRESS;
+  addressDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  addressDescription.description = "The host address to bind the WebSocket server to";
+  addressDescription.read_only = true;
+  node->declare_parameter(PARAM_ADDRESS, DEFAULT_ADDRESS, addressDescription);
+
+  auto sendBufferLimitDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  sendBufferLimitDescription.name = PARAM_SEND_BUFFER_LIMIT;
+  sendBufferLimitDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  sendBufferLimitDescription.description =
+    "Connection send buffer limit in bytes. Messages will be dropped when a connection's send "
+    "buffer reaches this limit to avoid a queue of outdated messages building up.";
+  sendBufferLimitDescription.integer_range.resize(1);
+  sendBufferLimitDescription.integer_range[0].from_value = 0;
+  sendBufferLimitDescription.integer_range[0].to_value = std::numeric_limits<int64_t>::max();
+  sendBufferLimitDescription.read_only = true;
+  node->declare_parameter(PARAM_SEND_BUFFER_LIMIT, DEFAULT_SEND_BUFFER_LIMIT,
+                          sendBufferLimitDescription);
+
+  auto useTlsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  useTlsDescription.name = PARAM_USETLS;
+  useTlsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  useTlsDescription.description = "Use Transport Layer Security for encrypted communication";
+  useTlsDescription.read_only = true;
+  node->declare_parameter(PARAM_USETLS, false, useTlsDescription);
+
+  auto certfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  certfileDescription.name = PARAM_CERTFILE;
+  certfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  certfileDescription.description = "Path to the certificate to use for TLS";
+  certfileDescription.read_only = true;
+  node->declare_parameter(PARAM_CERTFILE, "", certfileDescription);
+
+  auto keyfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  keyfileDescription.name = PARAM_KEYFILE;
+  keyfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  keyfileDescription.description = "Path to the private key to use for TLS";
+  keyfileDescription.read_only = true;
+  node->declare_parameter(PARAM_KEYFILE, "", keyfileDescription);
+
+  auto maxQosDepthDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  maxQosDepthDescription.name = PARAM_MAX_QOS_DEPTH;
+  maxQosDepthDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  maxQosDepthDescription.description = "Maximum depth used for the QoS profile of subscriptions.";
+  maxQosDepthDescription.read_only = true;
+  maxQosDepthDescription.additional_constraints = "Must be a non-negative integer";
+  maxQosDepthDescription.integer_range.resize(1);
+  maxQosDepthDescription.integer_range[0].from_value = 0;
+  maxQosDepthDescription.integer_range[0].to_value = INT32_MAX;
+  maxQosDepthDescription.integer_range[0].step = 1;
+  node->declare_parameter(PARAM_MAX_QOS_DEPTH, DEFAULT_MAX_QOS_DEPTH, maxQosDepthDescription);
+
+  auto topicWhiteListDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  topicWhiteListDescription.name = PARAM_TOPIC_WHITELIST;
+  topicWhiteListDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  topicWhiteListDescription.description =
+    "List of regular expressions (ECMAScript) of whitelisted topic names.";
+  topicWhiteListDescription.read_only = true;
+  node->declare_parameter(PARAM_TOPIC_WHITELIST, std::vector<std::string>({".*"}),
+                          topicWhiteListDescription);
+}
+
+std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,
+                                          const std::vector<std::string>& strings) {
+  std::vector<std::regex> regexVector;
+  regexVector.reserve(strings.size());
+
+  for (const auto& pattern : strings) {
+    try {
+      regexVector.push_back(
+        std::regex(pattern, std::regex_constants::ECMAScript | std::regex_constants::icase));
+    } catch (const std::exception& ex) {
+      RCLCPP_ERROR(node->get_logger(), "Ignoring invalid regular expression '%s': %s",
+                   pattern.c_str(), ex.what());
+    }
+  }
+
+  return regexVector;
+}
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -1,0 +1,285 @@
+#include "foxglove_bridge/parameter_interface.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace {
+
+constexpr char PARAM_SEP = '.';
+
+static std::pair<std::string, std::string> getNodeAndParamName(
+  const std::string& nodeNameAndParamName) {
+  return {nodeNameAndParamName.substr(0UL, nodeNameAndParamName.find(PARAM_SEP)),
+          nodeNameAndParamName.substr(nodeNameAndParamName.find(PARAM_SEP) + 1UL)};
+}
+
+static std::string prependNodeNameToParamName(const std::string& paramName,
+                                              const std::string& nodeName) {
+  return nodeName + PARAM_SEP + paramName;
+}
+
+static rclcpp::Parameter toRosParam(const foxglove::Parameter& p) {
+  using foxglove::Parameter;
+  using foxglove::ParameterType;
+
+  const auto paramType = p.getType();
+  if (paramType == ParameterType::PARAMETER_BOOL) {
+    return rclcpp::Parameter(p.getName(), p.getValue<bool>());
+  } else if (paramType == ParameterType::PARAMETER_INTEGER) {
+    return rclcpp::Parameter(p.getName(), p.getValue<int64_t>());
+  } else if (paramType == ParameterType::PARAMETER_DOUBLE) {
+    return rclcpp::Parameter(p.getName(), p.getValue<double>());
+  } else if (paramType == ParameterType::PARAMETER_STRING) {
+    return rclcpp::Parameter(p.getName(), p.getValue<std::string>());
+  } else if (paramType == ParameterType::PARAMETER_BOOL_ARRAY) {
+    return rclcpp::Parameter(p.getName(), p.getValue<std::vector<bool>>());
+  } else if (paramType == ParameterType::PARAMETER_INTEGER_ARRAY) {
+    return rclcpp::Parameter(p.getName(), p.getValue<std::vector<int64_t>>());
+  } else if (paramType == ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    return rclcpp::Parameter(p.getName(), p.getValue<std::vector<double>>());
+  } else if (paramType == ParameterType::PARAMETER_STRING_ARRAY) {
+    return rclcpp::Parameter(p.getName(), p.getValue<std::vector<std::string>>());
+  } else if (paramType == ParameterType::PARAMETER_NOT_SET) {
+    throw std::runtime_error("Unintialized parameter");
+  }
+
+  return rclcpp::Parameter();
+}
+
+static foxglove::Parameter fromRosParam(const rclcpp::Parameter& p) {
+  const auto type = p.get_type();
+
+  if (type == rclcpp::ParameterType::PARAMETER_NOT_SET) {
+    return foxglove::Parameter();
+  } else if (type == rclcpp::ParameterType::PARAMETER_BOOL) {
+    return foxglove::Parameter(p.get_name(), p.as_bool());
+  } else if (type == rclcpp::ParameterType::PARAMETER_INTEGER) {
+    return foxglove::Parameter(p.get_name(), p.as_int());
+  } else if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) {
+    return foxglove::Parameter(p.get_name(), p.as_double());
+  } else if (type == rclcpp::ParameterType::PARAMETER_STRING) {
+    return foxglove::Parameter(p.get_name(), p.as_string());
+  } else if (type == rclcpp::ParameterType::PARAMETER_BOOL_ARRAY) {
+    return foxglove::Parameter(p.get_name(), p.as_bool_array());
+  } else if (type == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY) {
+    return foxglove::Parameter(p.get_name(), p.as_integer_array());
+  } else if (type == rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
+    return foxglove::Parameter(p.get_name(), p.as_double_array());
+  } else if (type == rclcpp::ParameterType::PARAMETER_STRING_ARRAY) {
+    return foxglove::Parameter(p.get_name(), p.as_string_array());
+  } else {
+    throw std::runtime_error("Unsupported parameter type");
+  }
+}
+
+}  // namespace
+
+namespace foxglove_bridge {
+
+ParameterInterface::ParameterInterface(rclcpp::Node* node)
+    : _node(node)
+    , _callbackGroup(node->create_callback_group(rclcpp::CallbackGroupType::Reentrant)) {}
+
+ParameterList ParameterInterface::getParams(const std::vector<std::string>& paramNames,
+                                            const std::chrono::duration<double>& timeout) {
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  std::unordered_map<std::string, std::vector<std::string>> paramNamesByNodeName;
+  for (const auto& paramName : paramNames) {
+    const auto& [nodeName, paramN] = getNodeAndParamName(paramName);
+    paramNamesByNodeName[nodeName].push_back(paramN);
+  }
+
+  if (paramNamesByNodeName.empty()) {
+    const auto nodeNames = _node->get_node_names();
+    for (const auto& nodeName : nodeNames) {
+      paramNamesByNodeName.insert({nodeName, {}});
+    }
+  }
+
+  RCLCPP_INFO(_node->get_logger(), "Getting %zu paramters for %zu nodes...", paramNames.size(),
+              paramNamesByNodeName.size());
+
+  std::vector<std::future<ParameterList>> getParametersFuture;
+  for (const auto& [nodeName, nodeParamNames] : paramNamesByNodeName) {
+    const auto this_name = _node->get_fully_qualified_name();
+
+    if (nodeName == this_name) {
+      continue;
+    }
+
+    auto [paramClientIt, wasNewlyCreated] = _paramClientsByNode.try_emplace(
+      nodeName, rclcpp::AsyncParametersClient::make_shared(
+                  _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+
+    getParametersFuture.emplace_back(
+      std::async(std::launch::async, &ParameterInterface::getNodeParameters, this,
+                 paramClientIt->second, nodeName, nodeParamNames, timeout));
+  }
+
+  ParameterList result;
+  for (auto& future : getParametersFuture) {
+    try {
+      const auto params = future.get();
+      result.insert(result.begin(), params.begin(), params.end());
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR(_node->get_logger(), "Exception when getting paramters: %s", e.what());
+    }
+  }
+
+  return result;
+}
+
+void ParameterInterface::setParams(const ParameterList& parameters,
+                                   const std::chrono::duration<double>& timeout) {
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  rclcpp::ParameterMap paramsByNode;
+  for (const auto& param : parameters) {
+    const auto rosParam = toRosParam(param);
+    const auto& [nodeName, paramName] = getNodeAndParamName(rosParam.get_name());
+    paramsByNode[nodeName].emplace_back(paramName, rosParam.get_parameter_value());
+  }
+
+  std::vector<std::future<void>> setParametersFuture;
+  for (const auto& [nodeName, params] : paramsByNode) {
+    auto [paramClientIt, wasNewlyCreated] = _paramClientsByNode.try_emplace(
+      nodeName, rclcpp::AsyncParametersClient::make_shared(
+                  _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+
+    setParametersFuture.emplace_back(std::async(std::launch::async,
+                                                &ParameterInterface::setNodeParameters, this,
+                                                paramClientIt->second, nodeName, params, timeout));
+  }
+
+  for (auto& future : setParametersFuture) {
+    try {
+      future.get();
+    } catch (const std::exception& e) {
+      RCLCPP_ERROR(_node->get_logger(), "Exception when setting paramters: %s", e.what());
+    }
+  }
+}
+
+void ParameterInterface::subscribeParams(const std::vector<std::string>& paramNames) {
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  std::unordered_set<std::string> nodesToSubscribe;
+  for (const auto& paramName : paramNames) {
+    const auto& [nodeName, paramN] = getNodeAndParamName(paramName);
+
+    auto [subscribedParamsit, wasNewlyCreated] = _subscribedParamsByNode.try_emplace(nodeName);
+
+    auto& subscribedNodeParams = subscribedParamsit->second;
+    subscribedNodeParams.insert(paramN);
+
+    if (wasNewlyCreated) {
+      nodesToSubscribe.insert(nodeName);
+    }
+  }
+
+  for (const auto& nodeName : nodesToSubscribe) {
+    auto [paramClientIt, wasNewlyCreated] = _paramClientsByNode.try_emplace(
+      nodeName, rclcpp::AsyncParametersClient::make_shared(
+                  _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+    auto& paramClient = paramClientIt->second;
+
+    _paramSubscriptionsByNode[nodeName] = paramClient->on_parameter_event(
+      [this, nodeName](rcl_interfaces::msg::ParameterEvent::ConstSharedPtr msg) {
+        RCLCPP_DEBUG(_node->get_logger(), "Retrieved param update for node %s: %zu params changed",
+                     nodeName.c_str(), msg->changed_parameters.size());
+
+        ParameterList result;
+        const auto& subscribedNodeParams = _subscribedParamsByNode[nodeName];
+        for (const auto& param : msg->changed_parameters) {
+          if (subscribedNodeParams.find(param.name) != subscribedNodeParams.end()) {
+            result.push_back(fromRosParam(
+              rclcpp::Parameter(prependNodeNameToParamName(param.name, nodeName), param.value)));
+          }
+        }
+
+        if (!result.empty() && _paramUpdateFunc) {
+          _paramUpdateFunc(result);
+        }
+      });
+  }
+}
+
+void ParameterInterface::unsubscribeParams(const std::vector<std::string>& paramNames) {
+  std::lock_guard<std::mutex> lock(_mutex);
+
+  for (const auto& paramName : paramNames) {
+    const auto& [nodeName, paramN] = getNodeAndParamName(paramName);
+
+    const auto subscribedNodeParamsIt = _subscribedParamsByNode.find(nodeName);
+    if (subscribedNodeParamsIt != _subscribedParamsByNode.end()) {
+      subscribedNodeParamsIt->second.erase(subscribedNodeParamsIt->second.find(paramN));
+
+      if (subscribedNodeParamsIt->second.empty()) {
+        _subscribedParamsByNode.erase(subscribedNodeParamsIt);
+        _paramSubscriptionsByNode.erase(_paramSubscriptionsByNode.find(nodeName));
+      }
+    }
+  }
+}
+
+void ParameterInterface::setParamUpdateCallback(ParamUpdateFunc paramUpdateFunc) {
+  std::lock_guard<std::mutex> lock(_mutex);
+  _paramUpdateFunc = paramUpdateFunc;
+}
+
+ParameterList ParameterInterface::getNodeParameters(
+  const rclcpp::AsyncParametersClient::SharedPtr paramClient, const std::string& nodeName,
+  const std::vector<std::string>& paramNames, const std::chrono::duration<double>& timeout) {
+  const auto deadline = std::chrono::system_clock::now() + timeout;
+
+  if (!paramClient->service_is_ready() || !paramClient->wait_for_service(std::chrono::seconds(1))) {
+    throw std::runtime_error("Param client for node '" + nodeName + "' not ready");
+  }
+
+  auto paramsToRequest = paramNames;
+  if (paramsToRequest.empty()) {
+    auto future = paramClient->list_parameters({}, 0UL);
+    if (std::future_status::ready != future.wait_until(deadline)) {
+      throw std::runtime_error("Failed to retrieve parameter names for node '" + nodeName + "'");
+    }
+    paramsToRequest = future.get().names;
+  }
+
+  auto getParamsFuture = paramClient->get_parameters(paramsToRequest);
+  if (std::future_status::ready != getParamsFuture.wait_until(deadline)) {
+    throw std::runtime_error("Failed to get parameter values for node '" + nodeName + "'");
+  }
+  const auto params = getParamsFuture.get();
+
+  ParameterList result;
+  for (const auto& param : params) {
+    result.push_back(fromRosParam(rclcpp::Parameter(
+      prependNodeNameToParamName(param.get_name(), nodeName), param.get_parameter_value())));
+  }
+  return result;
+}
+
+void ParameterInterface::setNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,
+                                           const std::string& nodeName,
+                                           const std::vector<rclcpp::Parameter>& params,
+                                           const std::chrono::duration<double>& timeout) {
+  if (!paramClient->service_is_ready() || !paramClient->wait_for_service(std::chrono::seconds(1))) {
+    throw std::runtime_error("Param client for node '" + nodeName + "' not ready");
+  }
+
+  auto future = paramClient->set_parameters(params);
+  if (std::future_status::ready != future.wait_for(timeout)) {
+    throw std::runtime_error("Param client failed to set parameters for node '" + nodeName +
+                             "' within the given timeout");
+  }
+
+  const auto setParamResults = future.get();
+  for (auto& result : setParamResults) {
+    if (!result.successful) {
+      RCLCPP_WARN(_node->get_logger(), "Failed to set a paramter for node '%s': %s",
+                  nodeName.c_str(), result.reason.c_str());
+    }
+  }
+}
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -82,7 +82,7 @@ public:
     _server->setClientMessageHandler(
       std::bind(&FoxgloveBridge::clientMessageHandler, this, _1, _2));
     _server->setParameterRequestHandler(
-      std::bind(&FoxgloveBridge::parameterRequestHandler, this, _1, _2));
+      std::bind(&FoxgloveBridge::parameterRequestHandler, this, _1, _2, _3));
     _server->setParameterChangeHandler(
       std::bind(&FoxgloveBridge::parameterChangeHandler, this, _1, _2));
     _server->setParameterSubscriptionHandler(
@@ -562,7 +562,7 @@ private:
   }
 
   void parameterRequestHandler(const std::vector<std::string>& parameters,
-                               foxglove::ConnHandle hdl) {
+                               const std::string& requestId, foxglove::ConnHandle hdl) {
     RCLCPP_INFO(this->get_logger(), "Received a parameter request, %zu parameters requested",
                 parameters.size());
 
@@ -570,7 +570,7 @@ private:
 
     RCLCPP_INFO(this->get_logger(), "sending back, %zu parameters", params.size());
 
-    _server->publishParameterValues(hdl, params);
+    _server->publishParameterValues(hdl, params, requestId);
   }
 
   void parameterSubscriptionHandler(const std::vector<std::string>& parameters,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
@@ -3,27 +3,32 @@
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
-  auto dummyNode = std::make_shared<rclcpp::Node>("dummy");
-  auto numThreadsDescription = rcl_interfaces::msg::ParameterDescriptor{};
-  numThreadsDescription.name = "num_threads";
-  numThreadsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
-  numThreadsDescription.description =
-    "The number of threads to use for the ROS node executor. 0 means one thread per CPU core.";
-  numThreadsDescription.read_only = true;
-  numThreadsDescription.additional_constraints = "Must be a non-negative integer";
-  numThreadsDescription.integer_range.resize(1);
-  numThreadsDescription.integer_range[0].from_value = 0;
-  numThreadsDescription.integer_range[0].to_value = INT32_MAX;
-  numThreadsDescription.integer_range[0].step = 1;
-  constexpr int DEFAULT_NUM_THREADS = 0;
-  dummyNode->declare_parameter("num_threads", DEFAULT_NUM_THREADS, numThreadsDescription);
-
-  const auto numThreads = dummyNode->get_parameter("num_threads").as_int();
+  size_t numThreads = 0;
+  {
+    // Temporary dummy node to get num_threads param.
+    auto dummyNode = std::make_shared<rclcpp::Node>("dummy");
+    auto numThreadsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+    numThreadsDescription.name = "num_threads";
+    numThreadsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+    numThreadsDescription.description =
+      "The number of threads to use for the ROS node executor. 0 means one thread per CPU core.";
+    numThreadsDescription.read_only = true;
+    numThreadsDescription.additional_constraints = "Must be a non-negative integer";
+    numThreadsDescription.integer_range.resize(1);
+    numThreadsDescription.integer_range[0].from_value = 0;
+    numThreadsDescription.integer_range[0].to_value = INT32_MAX;
+    numThreadsDescription.integer_range[0].step = 1;
+    constexpr int DEFAULT_NUM_THREADS = 0;
+    dummyNode->declare_parameter(numThreadsDescription.name, DEFAULT_NUM_THREADS,
+                                 numThreadsDescription);
+    numThreads = static_cast<size_t>(dummyNode->get_parameter(numThreadsDescription.name).as_int());
+  }
 
   auto executor =
     rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
 
-  rclcpp_components::ComponentManager componentManager(executor, "ComponentManager");
+  rclcpp_components::ComponentManager componentManager(executor,
+                                                       "foxglove_bridge_component_manager");
   const auto componentResources = componentManager.get_component_resources("foxglove_bridge");
 
   if (componentResources.empty()) {

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -18,6 +18,56 @@ constexpr char URI[] = "ws://localhost:8765";
 constexpr uint8_t HELLO_WORLD_BINARY[] = {0,   1,   0,   0,  12,  0,   0,   0,   104, 101,
                                           108, 108, 111, 32, 119, 111, 114, 108, 100, 0};
 
+class ParameterTest : public ::testing::Test {
+public:
+  using PARAM_1_TYPE = std::string;
+  inline static const std::string NODE_1_NAME = "node_1";
+  inline static const std::string PARAM_1_NAME = "string_param";
+  inline static const PARAM_1_TYPE PARAM_1_DEFAULT_VALUE = "hello";
+
+  using PARAM_2_TYPE = std::vector<int64_t>;
+  inline static const std::string NODE_2_NAME = "node_2";
+  inline static const std::string PARAM_2_NAME = "int_array_param";
+  inline static const PARAM_2_TYPE PARAM_2_DEFAULT_VALUE = {1, 2, 3};
+
+protected:
+  void SetUp() override {
+    _paramNode1 = rclcpp::Node::make_shared(NODE_1_NAME);
+    auto p1Param = rcl_interfaces::msg::ParameterDescriptor{};
+    p1Param.name = PARAM_1_NAME;
+    p1Param.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+    p1Param.read_only = false;
+    _paramNode1->declare_parameter(p1Param.name, PARAM_1_DEFAULT_VALUE, p1Param);
+
+    _paramNode2 = rclcpp::Node::make_shared(NODE_2_NAME);
+    auto p2Param = rcl_interfaces::msg::ParameterDescriptor{};
+    p2Param.name = PARAM_2_NAME;
+    p2Param.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
+    p2Param.read_only = false;
+    _paramNode2->declare_parameter(p2Param.name, PARAM_2_DEFAULT_VALUE, p2Param);
+
+    _executor.add_node(_paramNode1);
+    _executor.add_node(_paramNode2);
+    _executorThread = std::thread([this]() {
+      _executor.spin();
+    });
+
+    _wsClient = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
+    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(std::chrono::seconds(5)));
+  }
+
+  void TearDown() override {
+    _executor.cancel();
+    _executorThread.join();
+  }
+
+  rclcpp::executors::SingleThreadedExecutor _executor;
+  rclcpp::Node::SharedPtr _paramNode1;
+  rclcpp::Node::SharedPtr _paramNode2;
+  std::thread _executorThread;
+  std::shared_ptr<foxglove::Client<websocketpp::config::asio_client>> _wsClient;
+};
+
 TEST(SmokeTest, testConnection) {
   foxglove::Client<websocketpp::config::asio_client> wsClient;
   EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
@@ -103,6 +153,114 @@ TEST(SmokeTest, testPublishing) {
   const auto ret = executor.spin_until_future_complete(msgFuture, std::chrono::seconds(1));
   ASSERT_EQ(rclcpp::FutureReturnCode::SUCCESS, ret);
   EXPECT_EQ("hello world", msgFuture.get());
+}
+
+TEST_F(ParameterTest, testGetAllParams) {
+  _wsClient->getParameters({});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  EXPECT_GE(params.size(), 2UL);
+}
+
+TEST_F(ParameterTest, testGetNonExistingParameters) {
+  _wsClient->getParameters(
+    {"/foo_1.non_existing_parameter", "/foo_2.non_existing.nested_parameter"});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  EXPECT_TRUE(params.empty());
+}
+
+TEST_F(ParameterTest, testGetParameters) {
+  const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
+  const auto p2 = NODE_2_NAME + "." + PARAM_2_NAME;
+
+  _wsClient->getParameters({p1, p2});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  EXPECT_EQ(2UL, params.size());
+  auto p1Iter = std::find_if(params.begin(), params.end(), [&p1](const auto& param) {
+    return param.getName() == p1;
+  });
+  auto p2Iter = std::find_if(params.begin(), params.end(), [&p2](const auto& param) {
+    return param.getName() == p2;
+  });
+  ASSERT_NE(p1Iter, params.end());
+  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue<PARAM_1_TYPE>());
+  ASSERT_NE(p2Iter, params.end());
+  EXPECT_EQ(PARAM_2_DEFAULT_VALUE, p2Iter->getValue<PARAM_2_TYPE>());
+}
+
+TEST_F(ParameterTest, testSetParameters) {
+  const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
+  const auto p2 = NODE_2_NAME + "." + PARAM_2_NAME;
+  const PARAM_1_TYPE newP1value = "world";
+  const PARAM_2_TYPE newP2value = {4, 5, 6};
+
+  const std::vector<foxglove::Parameter> parameters = {
+    foxglove::Parameter(p1, newP1value),
+    foxglove::Parameter(p2, newP2value),
+  };
+
+  _wsClient->setParameters(parameters);
+  _wsClient->getParameters({p1, p2});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  EXPECT_EQ(2UL, params.size());
+  auto p1Iter = std::find_if(params.begin(), params.end(), [&p1](const auto& param) {
+    return param.getName() == p1;
+  });
+  auto p2Iter = std::find_if(params.begin(), params.end(), [&p2](const auto& param) {
+    return param.getName() == p2;
+  });
+  ASSERT_NE(p1Iter, params.end());
+  EXPECT_EQ(newP1value, p1Iter->getValue<PARAM_1_TYPE>());
+  ASSERT_NE(p2Iter, params.end());
+  EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
+}
+
+TEST_F(ParameterTest, testParameterSubscription) {
+  const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
+
+  _wsClient->subscribeParameterUpdates({p1});
+  _wsClient->setParameters({foxglove::Parameter(p1, "foo")});
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  ASSERT_EQ(1UL, params.size());
+  EXPECT_EQ(params.front().getName(), p1);
+
+  _wsClient->unsubscribeParameterUpdates({p1});
+  _wsClient->setParameters({foxglove::Parameter(p1, "bar")});
+  EXPECT_THROW((void)foxglove::waitForParameters(_wsClient, std::chrono::seconds(5)),
+               std::runtime_error);
+}
+
+TEST_F(ParameterTest, testGetParametersParallel) {
+  // Connect a few clients (in parallel) and make sure that they all receive parameters
+  auto clients = {
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+  };
+
+  std::vector<std::future<std::vector<foxglove::Parameter>>> futures;
+  for (auto client : clients) {
+    futures.push_back(
+      std::async(std::launch::async, [client]() -> std::vector<foxglove::Parameter> {
+        if (std::future_status::ready == client->connect(URI).wait_for(std::chrono::seconds(5))) {
+          client->getParameters({});
+          const auto parameters = foxglove::waitForParameters(client, std::chrono::seconds(5));
+          return parameters;
+        }
+        return {};
+      }));
+  }
+
+  for (auto& future : futures) {
+    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    std::vector<foxglove::Parameter> parameters;
+    EXPECT_NO_THROW(parameters = future.get());
+    EXPECT_GE(parameters.size(), 2UL);
+  }
 }
 
 // Run all the tests that were declared with TEST()


### PR DESCRIPTION
**Public-Facing Changes**
- Adds parameter support


**Description**
Implements support for parameters which was added to the ws-protocol specification in https://github.com/foxglove/ws-protocol/pull/288

This PR is rather big due to the different implementation of parameters for ROS 1 and ROS 2

ROS 1:
- Parameters are owned by ROS master
- Every node can get and set parameters on the master
- Simple API for setting / getting parameters
  - `ros::NodeHandle::getParamNames`, `ros::NodeHandle::getParam`, `ros::NodeHandle::setParam`

ROS 2 (see also [About-ROS-2-Parameters](https://docs.ros.org/en/rolling/Concepts/About-ROS-2-Parameters.html)):
- No single parameter store, parameters are owned by individual nodes 
- Getting / setting parameters of different nodes requires calling services for each involved node: 
  - `list_parameters`, `get_parameters`, `set_parameters`

Fixes #9

[FG-1203](https://linear.app/foxglove/issue/FG-1203/add-parameter-support)