### PR TITLE
Publish binary time data when `use_sim_time` parameter is `true`

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -7,6 +7,7 @@
 namespace foxglove {
 
 constexpr char SUPPORTED_SUBPROTOCOL[] = "foxglove.websocket.v1";
+constexpr char CAPABILITY_CLIENT_PUBLISH[] = "clientPublish";
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -8,6 +8,7 @@ namespace foxglove {
 
 constexpr char SUPPORTED_SUBPROTOCOL[] = "foxglove.websocket.v1";
 constexpr char CAPABILITY_CLIENT_PUBLISH[] = "clientPublish";
+constexpr char CAPABILITY_TIME[] = "time";
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -15,6 +15,7 @@ using SubscriptionId = uint32_t;
 
 enum class BinaryOpcode : uint8_t {
   MESSAGE_DATA = 1,
+  TIME_DATA = 2,
 };
 
 enum class ClientBinaryOpcode : uint8_t {

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -164,7 +164,8 @@ public:
 
   static bool USES_TLS;
 
-  explicit Server(std::string name, LogCallback logger, const std::string& certfile = "",
+  explicit Server(std::string name, LogCallback logger,
+                  const std::vector<std::string>& capabilities, const std::string& certfile = "",
                   const std::string& keyfile = "");
   virtual ~Server();
 
@@ -208,6 +209,7 @@ private:
 
   std::string _name;
   LogCallback _logger;
+  std::vector<std::string> _capabilities;
   std::string _certfile;
   std::string _keyfile;
   ServerType _server;
@@ -242,9 +244,11 @@ private:
 
 template <typename ServerConfiguration>
 inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,
+                                           const std::vector<std::string>& capabilities,
                                            const std::string& certfile, const std::string& keyfile)
     : _name(std::move(name))
     , _logger(logger)
+    , _capabilities(capabilities)
     , _certfile(certfile)
     , _keyfile(keyfile) {
   // Redirect logging
@@ -310,7 +314,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
   con->send(json({
                    {"op", "serverInfo"},
                    {"name", _name},
-                   {"capabilities", json::array({"clientPublish"})},
+                   {"capabilities", _capabilities},
                  })
               .dump());
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -64,6 +64,7 @@ public:
     try {
       const std::vector<std::string> serverCapabilities = {
         foxglove::CAPABILITY_CLIENT_PUBLISH,
+        foxglove::CAPABILITY_TIME,
       };
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -62,14 +62,17 @@ public:
              foxglove::WebSocketUserAgent());
 
     try {
+      const std::vector<std::string> serverCapabilities = {
+        foxglove::CAPABILITY_CLIENT_PUBLISH,
+      };
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
       if (useTLS) {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-          "foxglove_bridge", std::move(logHandler), certfile, keyfile);
+          "foxglove_bridge", std::move(logHandler), serverCapabilities, certfile, keyfile);
       } else {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-          "foxglove_bridge", std::move(logHandler));
+          "foxglove_bridge", std::move(logHandler), serverCapabilities);
       }
 
       _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this,

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -1,6 +1,5 @@
 #define ASIO_STANDALONE
 
-#include <atomic>
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -46,6 +45,7 @@ public:
     const auto certfile = nhp.param<std::string>("certfile", "");
     const auto keyfile = nhp.param<std::string>("keyfile", "");
     _maxUpdateMs = static_cast<size_t>(nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS));
+    _useSimTime = nhp.param<bool>("/use_sim_time", false);
 
     const auto regexPatterns = nhp.param<std::vector<std::string>>("topic_whitelist", {".*"});
     _topicWhitelistPatterns.reserve(regexPatterns.size());
@@ -62,10 +62,13 @@ public:
              foxglove::WebSocketUserAgent());
 
     try {
-      const std::vector<std::string> serverCapabilities = {
+      std::vector<std::string> serverCapabilities = {
         foxglove::CAPABILITY_CLIENT_PUBLISH,
-        foxglove::CAPABILITY_TIME,
       };
+      if (_useSimTime) {
+        serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
+      }
+
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
       if (useTLS) {
@@ -90,6 +93,13 @@ public:
       _server->start(address, static_cast<uint16_t>(port));
 
       updateAdvertisedTopics(ros::TimerEvent());
+
+      if (_useSimTime) {
+        _clockSubscription = getMTNodeHandle().subscribe<rosgraph_msgs::Clock>(
+          "/clock", 10, [&](const rosgraph_msgs::Clock::ConstPtr msg) {
+            _server->broadcastTime(msg->clock.toNSec());
+          });
+      }
     } catch (const std::exception& err) {
       ROS_ERROR("Failed to start websocket server: %s", err.what());
       // Rethrow exception such that the nodelet is unloaded.
@@ -333,13 +343,9 @@ private:
 
     std::unordered_set<TopicAndDatatype, PairHash> latestTopics;
     latestTopics.reserve(topicNamesAndTypes.size());
-    bool hasClockTopic = false;
     for (const auto& topicNameAndType : topicNamesAndTypes) {
       const auto& topicName = topicNameAndType.name;
       const auto& datatype = topicNameAndType.datatype;
-
-      // Check if a /clock topic is published
-      hasClockTopic = hasClockTopic || (topicName == "/clock" && datatype == "rosgraph_msgs/Clock");
 
       // Ignore the topic if it is not on the topic whitelist
       if (std::find_if(_topicWhitelistPatterns.begin(), _topicWhitelistPatterns.end(),
@@ -354,21 +360,6 @@ private:
       ROS_DEBUG(
         "%zu topics have been ignored as they do not match any pattern on the topic whitelist",
         numIgnoredTopics);
-    }
-
-    // Enable or disable simulated time based on the presence of a /clock topic
-    if (!_useSimTime && hasClockTopic) {
-      ROS_INFO("/clock topic found, using simulated time");
-      _useSimTime = true;
-      _clockSubscription = getMTNodeHandle().subscribe<rosgraph_msgs::Clock>(
-        "/clock", 10, [&](const rosgraph_msgs::Clock::ConstPtr msg) {
-          _simTimeNs = msg->clock.toNSec();
-          _server->broadcastTime(_simTimeNs);
-        });
-    } else if (_useSimTime && !hasClockTopic) {
-      ROS_WARN("/clock topic disappeared");
-      _useSimTime = false;
-      _clockSubscription.shutdown();
     }
 
     // Create a list of topics that are new to us
@@ -480,7 +471,7 @@ private:
     const foxglove::Channel& channel, foxglove::ConnHandle clientHandle,
     const ros::MessageEvent<ros_babel_fish::BabelFishMessage const>& msgEvent) {
     const auto& msg = msgEvent.getConstMessage();
-    const auto receiptTimeNs = _useSimTime ? _simTimeNs.load() : msgEvent.getReceiptTime().toNSec();
+    const auto receiptTimeNs = msgEvent.getReceiptTime().toNSec();
     _server->sendMessage(
       clientHandle, channel.id, receiptTimeNs,
       std::string_view(reinterpret_cast<const char*>(msg->buffer()), msg->size()));
@@ -499,8 +490,7 @@ private:
   size_t _maxUpdateMs = size_t(DEFAULT_MAX_UPDATE_MS);
   size_t _updateCount = 0;
   ros::Subscriber _clockSubscription;
-  std::atomic<uint64_t> _simTimeNs = 0;
-  std::atomic<bool> _useSimTime = false;
+  bool _useSimTime = false;
 };
 
 }  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -362,6 +362,7 @@ private:
       _clockSubscription = getMTNodeHandle().subscribe<rosgraph_msgs::Clock>(
         "/clock", 10, [&](const rosgraph_msgs::Clock::ConstPtr msg) {
           _simTimeNs = msg->clock.toNSec();
+          _server->broadcastTime(_simTimeNs);
         });
     } else if (_useSimTime && !hasClockTopic) {
       ROS_WARN("/clock topic disappeared");

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -231,6 +231,7 @@ public:
         "/clock", rclcpp::QoS{rclcpp::KeepLast(1)}.best_effort(),
         [&](std::shared_ptr<rosgraph_msgs::msg::Clock> msg) {
           _simTimeNs = uint64_t(rclcpp::Time{msg->clock}.nanoseconds());
+          _server->broadcastTime(_simTimeNs);
         });
     } else if (_useSimTime && !hasClockTopic) {
       RCLCPP_WARN(this->get_logger(), "/clock topic disappeared");

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -113,6 +113,9 @@ public:
       }
     }
 
+    const std::vector<std::string> serverCapabilities = {
+      foxglove::CAPABILITY_CLIENT_PUBLISH,
+    };
     const auto useTLS = this->get_parameter("tls").as_bool();
     const auto certfile = this->get_parameter("certfile").as_string();
     const auto keyfile = this->get_parameter("keyfile").as_string();
@@ -120,10 +123,10 @@ public:
 
     if (useTLS) {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-        "foxglove_bridge", std::move(logHandler), certfile, keyfile);
+        "foxglove_bridge", std::move(logHandler), serverCapabilities, certfile, keyfile);
     } else {
-      _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>("foxglove_bridge",
-                                                                             std::move(logHandler));
+      _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
+        "foxglove_bridge", std::move(logHandler), serverCapabilities);
     }
     _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));
     _server->setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2));

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -115,6 +115,7 @@ public:
 
     const std::vector<std::string> serverCapabilities = {
       foxglove::CAPABILITY_CLIENT_PUBLISH,
+      foxglove::CAPABILITY_TIME,
     };
     const auto useTLS = this->get_parameter("tls").as_bool();
     const auto certfile = this->get_parameter("certfile").as_string();


### PR DESCRIPTION
**Public-Facing Changes**
- Publish binary time data when `use_sim_time` is `true`

**Description**
Depends on https://github.com/foxglove/ws-protocol/pull/299

- When the `use_sim_time` parameter is set
  - The server advertises the `time` capability
  - It subscribes to the `/clock` topic and broadcasts binary time messages
- I have removed the code that detects presence of the `/clock` topic, since now it has to be known at startup whether `use_sim_time` is true or false

- Includes #115 (will rebase after it got merged)
