### PR TITLE
Skip sending messages if send buffer is full

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -124,6 +124,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
 
     add_library(foxglove_bridge_component SHARED
       ros2_foxglove_bridge/src/message_definition_cache.cpp
+      ros2_foxglove_bridge/src/param_utils.cpp
       ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
     )
     target_include_directories(foxglove_bridge_component

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -73,7 +73,7 @@ public:
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
       if (useTLS) {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-          "foxglove_bridge", std::move(logHandler), serverCapabilities, certfile, keyfile);
+          "foxglove_bridge", std::move(logHandler), serverCapabilities, 1000UL, certfile, keyfile);
       } else {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
           "foxglove_bridge", std::move(logHandler), serverCapabilities);

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -1,0 +1,28 @@
+#pragma once
+
+#include <regex>
+#include <string>
+#include <vector>
+
+#include <rclcpp/node.hpp>
+
+namespace foxglove_bridge {
+
+constexpr char PARAM_PORT[] = "port";
+constexpr char PARAM_ADDRESS[] = "address";
+constexpr char PARAM_USETLS[] = "tls";
+constexpr char PARAM_CERTFILE[] = "certfile";
+constexpr char PARAM_KEYFILE[] = "keyfile";
+constexpr char PARAM_MAX_QOS_DEPTH[] = "max_qos_depth";
+constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
+
+constexpr int64_t DEFAULT_PORT = 8765;
+constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
+constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 10;
+
+void declareParameters(rclcpp::Node* node);
+
+std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,
+                                          const std::vector<std::string>& strings);
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -15,10 +15,13 @@ constexpr char PARAM_CERTFILE[] = "certfile";
 constexpr char PARAM_KEYFILE[] = "keyfile";
 constexpr char PARAM_MAX_QOS_DEPTH[] = "max_qos_depth";
 constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
+constexpr char PARAM_BEST_EFFORT_TOPICS[] = "best_effort_topics";
+constexpr char PARAM_BEST_EFFORT_BUFF_SIZE_LIMIT[] = "best_effort_max_buff_size";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
 constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 10;
+constexpr int64_t DEFAULT_BEST_EFFORT_BUFF_SIZE_LIMIT_KB = 1000;
 
 void declareParameters(rclcpp::Node* node);
 

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -66,6 +66,30 @@ void declareParameters(rclcpp::Node* node) {
   topicWhiteListDescription.read_only = true;
   node->declare_parameter(PARAM_TOPIC_WHITELIST, std::vector<std::string>({".*"}),
                           topicWhiteListDescription);
+
+  auto bestEffortTopicsListDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  bestEffortTopicsListDescription.name = PARAM_BEST_EFFORT_TOPICS;
+  bestEffortTopicsListDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  bestEffortTopicsListDescription.description =
+    "List of regular expressions (ECMAScript) of topic names of which messages can be dropped in "
+    "case the client can't keep up with the server's sending rate.";
+  bestEffortTopicsListDescription.read_only = true;
+  node->declare_parameter(PARAM_BEST_EFFORT_TOPICS, std::vector<std::string>(),
+                          bestEffortTopicsListDescription);
+
+  auto bestEffortBuffSizeLimit = rcl_interfaces::msg::ParameterDescriptor{};
+  bestEffortBuffSizeLimit.name = PARAM_BEST_EFFORT_BUFF_SIZE_LIMIT;
+  bestEffortBuffSizeLimit.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  bestEffortBuffSizeLimit.description =
+    "When a connection's send buffer reaches this limit best-effort published topics (or "
+    "topics that are treated as such) will be dropped to avoid a queue of old messages building "
+    "up.";
+  maxQosDepthDescription.integer_range.resize(1);
+  maxQosDepthDescription.integer_range[0].from_value = 0;
+  maxQosDepthDescription.integer_range[0].to_value = 100000;
+  bestEffortBuffSizeLimit.read_only = true;
+  node->declare_parameter(PARAM_BEST_EFFORT_BUFF_SIZE_LIMIT, DEFAULT_BEST_EFFORT_BUFF_SIZE_LIMIT_KB,
+                          bestEffortBuffSizeLimit);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -1,0 +1,89 @@
+
+
+#include <foxglove_bridge/param_utils.hpp>
+
+namespace foxglove_bridge {
+
+void declareParameters(rclcpp::Node* node) {
+  auto portDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  portDescription.name = PARAM_PORT;
+  portDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  portDescription.description = "The TCP port to bind the WebSocket server to";
+  portDescription.read_only = true;
+  portDescription.additional_constraints =
+    "Must be a valid TCP port number, or 0 to use a random port";
+  portDescription.integer_range.resize(1);
+  portDescription.integer_range[0].from_value = 0;
+  portDescription.integer_range[0].to_value = 65535;
+  portDescription.integer_range[0].step = 1;
+  node->declare_parameter(PARAM_PORT, DEFAULT_PORT, portDescription);
+
+  auto addressDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  addressDescription.name = PARAM_ADDRESS;
+  addressDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  addressDescription.description = "The host address to bind the WebSocket server to";
+  addressDescription.read_only = true;
+  node->declare_parameter(PARAM_ADDRESS, DEFAULT_ADDRESS, addressDescription);
+
+  auto useTlsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  useTlsDescription.name = PARAM_USETLS;
+  useTlsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  useTlsDescription.description = "Use Transport Layer Security for encrypted communication";
+  useTlsDescription.read_only = true;
+  node->declare_parameter(PARAM_USETLS, false, useTlsDescription);
+
+  auto certfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  certfileDescription.name = PARAM_CERTFILE;
+  certfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  certfileDescription.description = "Path to the certificate to use for TLS";
+  certfileDescription.read_only = true;
+  node->declare_parameter(PARAM_CERTFILE, "", certfileDescription);
+
+  auto keyfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  keyfileDescription.name = PARAM_KEYFILE;
+  keyfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
+  keyfileDescription.description = "Path to the private key to use for TLS";
+  keyfileDescription.read_only = true;
+  node->declare_parameter(PARAM_KEYFILE, "", keyfileDescription);
+
+  auto maxQosDepthDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  maxQosDepthDescription.name = PARAM_MAX_QOS_DEPTH;
+  maxQosDepthDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
+  maxQosDepthDescription.description = "Maximum depth used for the QoS profile of subscriptions.";
+  maxQosDepthDescription.read_only = true;
+  maxQosDepthDescription.additional_constraints = "Must be a non-negative integer";
+  maxQosDepthDescription.integer_range.resize(1);
+  maxQosDepthDescription.integer_range[0].from_value = 0;
+  maxQosDepthDescription.integer_range[0].to_value = INT32_MAX;
+  maxQosDepthDescription.integer_range[0].step = 1;
+  node->declare_parameter(PARAM_MAX_QOS_DEPTH, DEFAULT_MAX_QOS_DEPTH, maxQosDepthDescription);
+
+  auto topicWhiteListDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  topicWhiteListDescription.name = PARAM_TOPIC_WHITELIST;
+  topicWhiteListDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  topicWhiteListDescription.description =
+    "List of regular expressions (ECMAScript) of whitelisted topic names.";
+  topicWhiteListDescription.read_only = true;
+  node->declare_parameter(PARAM_TOPIC_WHITELIST, std::vector<std::string>({".*"}),
+                          topicWhiteListDescription);
+}
+
+std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,
+                                          const std::vector<std::string>& strings) {
+  std::vector<std::regex> regexVector;
+  regexVector.reserve(strings.size());
+
+  for (const auto& pattern : strings) {
+    try {
+      regexVector.push_back(
+        std::regex(pattern, std::regex_constants::ECMAScript | std::regex_constants::icase));
+    } catch (const std::exception& ex) {
+      RCLCPP_ERROR(node->get_logger(), "Ignoring invalid regular expression '%s': %s",
+                   pattern.c_str(), ex.what());
+    }
+  }
+
+  return regexVector;
+}
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -11,11 +11,8 @@
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
 #include <foxglove_bridge/message_definition_cache.hpp>
+#include <foxglove_bridge/param_utils.hpp>
 #include <foxglove_bridge/websocket_server.hpp>
-
-constexpr uint16_t DEFAULT_PORT = 8765;
-constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
-constexpr size_t DEFAULT_MAX_QOS_DEPTH = 10;
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
@@ -37,87 +34,19 @@ public:
     RCLCPP_INFO(this->get_logger(), "Starting %s with %s", this->get_name(),
                 foxglove::WebSocketUserAgent());
 
-    auto portDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    portDescription.name = "port";
-    portDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
-    portDescription.description = "The TCP port to bind the WebSocket server to";
-    portDescription.read_only = true;
-    portDescription.additional_constraints =
-      "Must be a valid TCP port number, or 0 to use a random port";
-    portDescription.integer_range.resize(1);
-    portDescription.integer_range[0].from_value = 0;
-    portDescription.integer_range[0].to_value = 65535;
-    portDescription.integer_range[0].step = 1;
-    this->declare_parameter("port", DEFAULT_PORT, portDescription);
+    declareParameters(this);
 
-    auto addressDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    addressDescription.name = "address";
-    addressDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    addressDescription.description = "The host address to bind the WebSocket server to";
-    addressDescription.read_only = true;
-    this->declare_parameter("address", DEFAULT_ADDRESS, addressDescription);
-
-    auto useTlsDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    useTlsDescription.name = "tls";
-    useTlsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
-    useTlsDescription.description = "Use Transport Layer Security for encrypted communication";
-    useTlsDescription.read_only = true;
-    this->declare_parameter("tls", false, useTlsDescription);
-
-    auto certfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    certfileDescription.name = "certfile";
-    certfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    certfileDescription.description = "Path to the certificate to use for TLS";
-    certfileDescription.read_only = true;
-    this->declare_parameter("certfile", "", certfileDescription);
-
-    auto keyfileDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    keyfileDescription.name = "keyfile";
-    keyfileDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING;
-    keyfileDescription.description = "Path to the private key to use for TLS";
-    keyfileDescription.read_only = true;
-    this->declare_parameter("keyfile", "", keyfileDescription);
-
-    auto maxQosDepthDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    maxQosDepthDescription.name = "max_qos_depth";
-    maxQosDepthDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER;
-    maxQosDepthDescription.description = "Maximum depth used for the QoS profile of subscriptions.";
-    maxQosDepthDescription.read_only = true;
-    maxQosDepthDescription.additional_constraints = "Must be a non-negative integer";
-    maxQosDepthDescription.integer_range.resize(1);
-    maxQosDepthDescription.integer_range[0].from_value = 0;
-    maxQosDepthDescription.integer_range[0].to_value = INT32_MAX;
-    maxQosDepthDescription.integer_range[0].step = 1;
-    this->declare_parameter("max_qos_depth", int(DEFAULT_MAX_QOS_DEPTH), maxQosDepthDescription);
-
-    auto topicWhiteListDescription = rcl_interfaces::msg::ParameterDescriptor{};
-    topicWhiteListDescription.name = "topic_whitelist";
-    topicWhiteListDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
-    topicWhiteListDescription.description =
-      "List of regular expressions (ECMAScript) of whitelisted topic names.";
-    topicWhiteListDescription.read_only = true;
-    this->declare_parameter<std::vector<std::string>>(
-      topicWhiteListDescription.name, std::vector<std::string>({".*"}), topicWhiteListDescription);
-
-    const auto regexPatterns =
-      this->get_parameter(topicWhiteListDescription.name).as_string_array();
-    _topicWhitelistPatterns.reserve(regexPatterns.size());
-    for (const auto& pattern : regexPatterns) {
-      try {
-        _topicWhitelistPatterns.push_back(
-          std::regex(pattern, std::regex_constants::ECMAScript | std::regex_constants::icase));
-      } catch (const std::exception& ex) {
-        RCLCPP_ERROR(this->get_logger(), "Ignoring invalid regular expression '%s': %s",
-                     pattern.c_str(), ex.what());
-      }
-    }
-
-    const auto useTLS = this->get_parameter("tls").as_bool();
-    const auto certfile = this->get_parameter("certfile").as_string();
-    const auto keyfile = this->get_parameter("keyfile").as_string();
+    const uint16_t port = uint16_t(this->get_parameter(PARAM_PORT).as_int());
+    const auto address = this->get_parameter(PARAM_ADDRESS).as_string();
+    const auto useTLS = this->get_parameter(PARAM_USETLS).as_bool();
+    const auto certfile = this->get_parameter(PARAM_CERTFILE).as_string();
+    const auto keyfile = this->get_parameter(PARAM_KEYFILE).as_string();
+    _maxQosDepth = this->get_parameter(PARAM_MAX_QOS_DEPTH).as_int();
+    const auto topicWhiteList = this->get_parameter(PARAM_TOPIC_WHITELIST).as_string_array();
+    _topicWhitelistPatterns = parseRegexStrings(this, topicWhiteList);
     _useSimTime = this->get_parameter("use_sim_time").as_bool();
-    const auto logHandler = std::bind(&FoxgloveBridge::logHandler, this, _1, _2);
 
+    const auto logHandler = std::bind(&FoxgloveBridge::logHandler, this, _1, _2);
     std::vector<std::string> serverCapabilities = {
       foxglove::CAPABILITY_CLIENT_PUBLISH,
     };
@@ -141,8 +70,6 @@ public:
     _server->setClientMessageHandler(
       std::bind(&FoxgloveBridge::clientMessageHandler, this, _1, _2));
 
-    auto address = this->get_parameter("address").as_string();
-    uint16_t port = uint16_t(this->get_parameter("port").as_int());
     _server->start(address, port);
 
     // Get the actual port we bound to
@@ -150,10 +77,8 @@ public:
     if (port != listeningPort) {
       RCLCPP_DEBUG(this->get_logger(), "Reassigning \"port\" parameter from %d to %d", port,
                    listeningPort);
-      this->set_parameter(rclcpp::Parameter{"port", listeningPort});
+      this->set_parameter(rclcpp::Parameter{PARAM_PORT, listeningPort});
     }
-
-    _maxQosDepth = this->get_parameter("max_qos_depth").as_int();
 
     // Start the thread polling for rosgraph changes
     _rosgraphPollThread =


### PR DESCRIPTION
**Public-Facing Changes**
- Prevent a connection's send buffer from getting to full when a client can't keep up with receiving messages

**Description**
- Allows the user to configure which topics shall be treated as best-effort topics for which messages can be dropped if the connection's send buffer reaches a certain limit. The added parameters are
  - **best_effort_max_buff_size**: Buffer size after which best-effort topic messages will be dropped
  - **best_effort_topics**: List of regex pattern for topic names which can be treated as best-effort (besides topics that are published with that qos)




