### PR TITLE
Remove galactic support (from README)

### DIFF
--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -18,7 +18,7 @@ COPY package.xml src/ros-foxglove-bridge/
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    apt-get update && rosdep update && rosdep install -y \
+    apt-get update && rosdep update --include-eol-distros && rosdep install -y \
       --from-paths \
         src \
       --ignore-src \

--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@ foxglove_bridge
 
 [![ROS Melodic version](https://img.shields.io/ros/v/melodic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#melodic)
 [![ROS Noetic version](https://img.shields.io/ros/v/noetic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#noetic)
-[![ROS Galactic version](https://img.shields.io/ros/v/galactic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#galactic)
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#humble)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#rolling)
 
@@ -17,9 +16,9 @@ The foxglove_bridge uses the [Foxglove WebSocket protocol](https://github.com/fo
 
 ## Installation
 
-ROS packages will be made available soon for ROS 1 Melodic and Noetic, and ROS 2 Galactic, Humble, and Rolling. Earlier releases of ROS will not be supported due to API design and/or performance limitations.
+ROS packages are available for ROS 1 Melodic and Noetic, and ROS 2 Humble and Rolling. Earlier releases of ROS will not be supported due to API design and/or performance limitations.
 
-In the meantime, you can try foxglove_bridge now by building from source or running a pre-built Docker container.
+You can also try foxglove_bridge by building from source or running a pre-built Docker container.
 
 ### Building from source
 
@@ -57,7 +56,7 @@ docker run --rm -it -v /opt/ros:/opt/ros --net=host ghcr.io/foxglove/noetic-ros1
 #### ROS 2
 
 ```bash
-docker run --rm -it -v /opt/ros:/opt/ros --net=host ghcr.io/foxglove/galactic-ros2-bridge
+docker run --rm -it -v /opt/ros:/opt/ros --net=host ghcr.io/foxglove/humble-ros2-bridge
 ```
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ foxglove_bridge
 
 [![ROS Melodic version](https://img.shields.io/ros/v/melodic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#melodic)
 [![ROS Noetic version](https://img.shields.io/ros/v/noetic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#noetic)
+[![ROS Galactic version](https://img.shields.io/ros/v/galactic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#galactic)
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#humble)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#rolling)
 


### PR DESCRIPTION
**Public-Facing Changes**
- Remove references to galactic support from README (EOL since December 9th, 2022)

**Description**
- Remove references to galactic support from README
- CI builds for galactic are kept for now, until we reach a point where we must drop support for it due to incompatibilities
  - This PR fixes `galactic` CI builds

Fixes #113 
