### PR TITLE
Switch devcontainer to ROS2 humble

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,36 +1,15 @@
-FROM ros:noetic-ros-core
+FROM ros:humble-ros-base
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
-  build-essential \
   clang-format \
   curl \
-  git \
   git-lfs \
-  gnupg \
   lldb \
-  lsb-release \
   openssh-client \
-  python3-colcon-common-extensions \
-  python3-pip \
-  python3-rosdep \
-  python3-rosinstall \
-  python3-rosinstall-generator \
-  python3-wstool \
+  ros-$ROS_DISTRO-foxglove-msgs \
+  ros-$ROS_DISTRO-rosbag2-storage-mcap \
   strace \
-  && rm -rf /var/lib/apt/lists/*
-
-# Authorize the ROS 2 GPG key and add the ROS 2 apt repository
-RUN curl -sSL https://raw.githubusercontent.com/ros/rosdistro/master/ros.key -o /usr/share/keyrings/ros-archive-keyring.gpg
-RUN echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/ros-archive-keyring.gpg] http://packages.ros.org/ros2/ubuntu focal main" > /etc/apt/sources.list.d/ros2.list
-
-# Install ROS 2
-RUN apt-get update && apt-get install -y --no-install-recommends \
-  ros-galactic-foxglove-msgs \
-  ros-galactic-ros-core \
-  ros-galactic-rosbag2 \
-  ros-galactic-rosbag2-storage-mcap \
-  ros-galactic-tf2-msgs \
   && rm -rf /var/lib/apt/lists/*
 
 # Create a ROS workspace
@@ -38,29 +17,16 @@ RUN mkdir -p /ros_ws/src/ros-foxglove-bridge
 
 COPY package.xml /ros_ws/src/ros-foxglove-bridge/package.xml
 
-# Initialize rosdep
-RUN rosdep init && rosdep update
-
-# Install rosdep dependencies for ROS 1
-RUN . /opt/ros/noetic/setup.sh && \
+# Install rosdep dependencies
+RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
     apt-get update && rosdep update && rosdep install -y \
       --from-paths /ros_ws/src \
       --ignore-src \
     && rm -rf /var/lib/apt/lists/*
-
-# Install rosdep dependencies for ROS 2
-RUN . /opt/ros/galactic/setup.sh && \
-    apt-get update && rosdep update && rosdep install -y \
-      --from-paths /ros_ws/src \
-      --ignore-src \
-    && rm -rf /var/lib/apt/lists/*
-
-SHELL ["/bin/bash", "-c"]
 
 # Unset the ROS_DISTRO and add aliases to .bashrc
-RUN echo $'\
-unset ROS_DISTRO\n\
-alias ros2_build_debug="colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n\
-alias ros2_build_release="colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo"\n\
-alias ros2_foxglove_bridge="source /ros_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge --ros-args --log-level debug --log-level rcl:=INFO"\n\
-' >> ~/.bashrc
+RUN echo \
+  'alias ros2_build_debug="/ros_entrypoint.sh colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n'\
+  'alias ros2_build_release="/ros_entrypoint.sh colcon build --event-handlers console_direct+ --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo"\n'\
+  'alias ros2_foxglove_bridge="source /ros_ws/install/setup.bash && ros2 run foxglove_bridge foxglove_bridge --ros-args --log-level debug --log-level rcl:=INFO"\n'\
+>> ~/.bashrc

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -5,15 +5,13 @@
       "name": "Linux",
       "includePath": [
         "${workspaceFolder}/**",
-        "/opt/ros/galactic/include/**",
-        "/opt/ros/noetic/include/**",
+        "/opt/ros/humble/include/**",
         "/usr/include/**"
       ],
       "browse": {
         "path": [
           "${workspaceFolder}",
-          "/opt/ros/galactic/include",
-          "/opt/ros/noetic/include",
+          "/opt/ros/humble/include",
           "/usr/include"
         ]
       },

--- a/README.md
+++ b/README.md
@@ -80,11 +80,10 @@ Parameters are provided to configure the behavior of the bridge. These parameter
 
 ## Development
 
-A VSCode container is provided with a dual ROS 1 and ROS 2 installation and
+A VSCode container is provided with a ROS 2 installation and
 enough tools to build and run the bridge. Some bash aliases are defined to simplify the common workflow. Here's an example of building and running the ROS 2 node:
 
 ```bash
-source /opt/ros/galactic/setup.bash
 ros2_build_debug  # or ros2_build_release
 ros2_foxglove_bridge
 ```
@@ -98,7 +97,7 @@ To test the bridge with example data, open another terminal and download the tes
 Then start playback:
 
 ```bash
-source /opt/ros/galactic/setup.bash
+source /opt/ros/$ROS_DISTRO/setup.bash
 ros2 bag play -l --clock 100 -s mcap data/nuScenes-v1.0-mini-scene-0061-ros2.mcap
 ```
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
ROS2 `galactic` is EOL since December 9th 2022. This PR changes the devcontainer to be based on ROS 2 `humble`. 

With that change, the devcontainer does not support ROS1 anymore. `humble` is supported on Ubuntu focal (Tier 3), but it needs to be compiled from source and I don't think it is worth the effort. Instead, for ROS1 development it is recommended to mount the workspace into a container and attach to the container with VsCode
