### PR TITLE
Fix exception when setting parameter to empty array

### DIFF
--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -43,7 +43,8 @@ void from_json(const nlohmann::json& j, Parameter& p) {
   } else if (jsonType == nlohmann::detail::value_t::number_float) {
     p = Parameter(name, value.get<double>());
   } else if (jsonType == nlohmann::detail::value_t::array) {
-    if (j.empty()) {
+    if (value.empty()) {
+      // We do not know the type when an empty array is received.
       throw std::runtime_error("Setting empty arrays is currently unsupported.");
     }
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Fixes an exception being raised when setting a parameter to an empty list
