### PR TITLE
Communicate supported encodings for client-side publishing

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -202,6 +202,7 @@ public:
 
   explicit Server(std::string name, LogCallback logger,
                   const std::vector<std::string>& capabilities,
+                  const std::vector<std::string>& supportedEncodings = {},
                   size_t send_buffer_limit_bytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES,
                   const std::string& certfile = "", const std::string& keyfile = "");
   virtual ~Server();
@@ -254,6 +255,7 @@ private:
   std::string _name;
   LogCallback _logger;
   std::vector<std::string> _capabilities;
+  std::vector<std::string> _supportedEncodings;
   size_t _send_buffer_limit_bytes;
   std::string _certfile;
   std::string _keyfile;
@@ -300,11 +302,13 @@ private:
 template <typename ServerConfiguration>
 inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,
                                            const std::vector<std::string>& capabilities,
+                                           const std::vector<std::string>& supportedEncodings,
                                            size_t send_buffer_limit_bytes,
                                            const std::string& certfile, const std::string& keyfile)
     : _name(std::move(name))
     , _logger(logger)
     , _capabilities(capabilities)
+    , _supportedEncodings(supportedEncodings)
     , _send_buffer_limit_bytes(send_buffer_limit_bytes)
     , _certfile(certfile)
     , _keyfile(keyfile) {
@@ -372,6 +376,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
                    {"op", "serverInfo"},
                    {"name", _name},
                    {"capabilities", _capabilities},
+                   {"supportedEncodings", _supportedEncodings},
                  })
               .dump());
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -75,16 +75,18 @@ public:
       if (_useSimTime) {
         serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
       }
+      const std::vector<std::string> supportedEncodings = {ROS1_CHANNEL_ENCODING};
 
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
       if (useTLS) {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-          "foxglove_bridge", std::move(logHandler), serverCapabilities, send_buffer_limit, certfile,
-          keyfile);
+          "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+          send_buffer_limit, certfile, keyfile);
       } else {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-          "foxglove_bridge", std::move(logHandler), serverCapabilities, send_buffer_limit);
+          "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+          send_buffer_limit);
       }
 
       _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -62,14 +62,16 @@ public:
     if (_useSimTime) {
       serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
     }
+    const std::vector<std::string> supportedEncodings = {"cdr"};
 
     if (useTLS) {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, send_buffer_limit, certfile,
-        keyfile);
+        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+        send_buffer_limit, certfile, keyfile);
     } else {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, send_buffer_limit);
+        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+        send_buffer_limit);
     }
     _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));
     _server->setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2));


### PR DESCRIPTION
**Public-Facing Changes**
- Communicate supported encodings for client-side publishing


**Description**
Corresponding spec PR: https://github.com/foxglove/ws-protocol/pull/326

> A client currently has no way in determining which message encodings the server supports for client publishing. This PR adds a field to the serverInfo message which informs clients about supported encodings.



