### PR TITLE
Fix client advertised channels not being updated on unadvertise

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -772,6 +772,11 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
           continue;
         }
         clientPublications.erase(channelIt);
+        if (const auto advertisedChannelIt = clientInfo.advertisedChannels.find(channelId) !=
+                                             clientInfo.advertisedChannels.end()) {
+          clientInfo.advertisedChannels.erase(advertisedChannelIt);
+        }
+
         if (_clientUnadvertiseHandler) {
           _clientUnadvertiseHandler(channelId, hdl);
         }


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
When a client unadvertised a channel, we did not update the client's publications list, leading to lots of 
`Ignoring client unadvertisement from ... for unknown channel ...,` messages once the client disconnected
