### PR TITLE
Add support for optional request id for `setParameter` operation

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -2,6 +2,7 @@
 
 #include <functional>
 #include <future>
+#include <optional>
 #include <shared_mutex>
 #include <utility>
 #include <vector>
@@ -43,8 +44,9 @@ public:
   virtual void unadvertise(const std::vector<ClientChannelId>& channelIds) = 0;
   virtual void publish(ClientChannelId channelId, const uint8_t* buffer, size_t size) = 0;
   virtual void getParameters(const std::vector<std::string>& parameterNames,
-                             const std::string& requestId) = 0;
-  virtual void setParameters(const std::vector<Parameter>& parameters) = 0;
+                             const std::optional<std::string>& requestId) = 0;
+  virtual void setParameters(const std::vector<Parameter>& parameters,
+                             const std::optional<std::string>& requestId) = 0;
   virtual void subscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
   virtual void unsubscribeParameterUpdates(const std::vector<std::string>& parameterNames) = 0;
 
@@ -182,14 +184,20 @@ public:
   }
 
   void getParameters(const std::vector<std::string>& parameterNames,
-                     const std::string& requestId) override {
-    nlohmann::json jsonPayload{
-      {"op", "getParameters"}, {"parameterNames", parameterNames}, {"id", requestId}};
+                     const std::optional<std::string>& requestId = std::nullopt) override {
+    nlohmann::json jsonPayload{{"op", "getParameters"}, {"parameterNames", parameterNames}};
+    if (requestId) {
+      jsonPayload["id"] = requestId.value();
+    }
     sendText(jsonPayload.dump());
   }
 
-  void setParameters(const std::vector<Parameter>& parameters) override {
+  void setParameters(const std::vector<Parameter>& parameters,
+                     const std::optional<std::string>& requestId = std::nullopt) override {
     nlohmann::json jsonPayload{{"op", "setParameters"}, {"parameters", parameters}};
+    if (requestId) {
+      jsonPayload["id"] = requestId.value();
+    }
     sendText(jsonPayload.dump());
   }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -142,9 +142,10 @@ class ServerInterface {
   using ClientAdvertiseHandler = std::function<void(const ClientAdvertisement&, ConnHandle)>;
   using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
   using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
-  using ParameterRequestHandler =
-    std::function<void(const std::vector<std::string>&, const std::string&, ConnHandle)>;
-  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&, ConnHandle)>;
+  using ParameterRequestHandler = std::function<void(
+    const std::vector<std::string>&, const std::optional<std::string>&, ConnHandle)>;
+  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&,
+                                                    const std::optional<std::string>&, ConnHandle)>;
   using ParameterSubscriptionHandler = std::function<void(
     const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
 
@@ -158,7 +159,7 @@ public:
   virtual void broadcastChannels() = 0;
   virtual void publishParameterValues(ConnHandle clientHandle,
                                       const std::vector<Parameter>& parameters,
-                                      const std::string& requestId = std::string()) = 0;
+                                      const std::optional<std::string>& requestId) = 0;
   virtual void updateParameterValues(const std::vector<Parameter>& parameters) = 0;
 
   virtual void setSubscribeHandler(SubscribeUnsubscribeHandler handler) = 0;
@@ -192,9 +193,10 @@ public:
   using ClientAdvertiseHandler = std::function<void(const ClientAdvertisement&, ConnHandle)>;
   using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
   using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
-  using ParameterRequestHandler =
-    std::function<void(const std::vector<std::string>&, const std::string&, ConnHandle)>;
-  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&, ConnHandle)>;
+  using ParameterRequestHandler = std::function<void(
+    const std::vector<std::string>&, const std::optional<std::string>&, ConnHandle)>;
+  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&,
+                                                    const std::optional<std::string>&, ConnHandle)>;
   using ParameterSubscriptionHandler = std::function<void(
     const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
 
@@ -218,7 +220,7 @@ public:
   void removeChannel(ChannelId chanId) override;
   void broadcastChannels() override;
   void publishParameterValues(ConnHandle clientHandle, const std::vector<Parameter>& parameters,
-                              const std::string& requestId = std::string()) override;
+                              const std::optional<std::string>& requestId = std::nullopt) override;
   void updateParameterValues(const std::vector<Parameter>& parameters) override;
 
   void setSubscribeHandler(SubscribeUnsubscribeHandler handler) override;
@@ -788,7 +790,9 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
       }
 
       const auto paramNames = payload.at("parameterNames").get<std::vector<std::string>>();
-      const auto requestId = payload.value("id", "");
+      const auto requestId = payload.find("id") == payload.end()
+                               ? std::nullopt
+                               : std::optional<std::string>(payload["id"].get<std::string>());
       _parameterRequestHandler(paramNames, requestId, hdl);
     } break;
     case SET_PARAMETERS: {
@@ -802,7 +806,10 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, const
       }
 
       const auto parameters = payload.at("parameters").get<std::vector<Parameter>>();
-      _parameterChangeHandler(parameters, hdl);
+      const auto requestId = payload.find("id") == payload.end()
+                               ? std::nullopt
+                               : std::optional<std::string>(payload["id"].get<std::string>());
+      _parameterChangeHandler(parameters, requestId, hdl);
     } break;
     case SUBSCRIBE_PARAMETER_UPDATES: {
       if (!hasCapability(CAPABILITY_PARAMETERS_SUBSCRIBE)) {
@@ -962,10 +969,11 @@ inline void Server<ServerConfiguration>::broadcastChannels() {
 
 template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::publishParameterValues(
-  ConnHandle hdl, const std::vector<Parameter>& parameters, const std::string& requestId) {
+  ConnHandle hdl, const std::vector<Parameter>& parameters,
+  const std::optional<std::string>& requestId) {
   nlohmann::json jsonPayload{{"op", "parameterValues"}, {"parameters", parameters}};
-  if (!requestId.empty()) {
-    jsonPayload["id"] = requestId;
+  if (requestId) {
+    jsonPayload["id"] = requestId.value();
   }
   sendJsonRaw(hdl, jsonPayload.dump());
 }

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -136,19 +136,19 @@ constexpr const char* StatusLevelToString(StatusLevel level) {
   }
 }
 
-class ServerInterface {
-  using Tcp = websocketpp::lib::asio::ip::tcp;
-  using SubscribeUnsubscribeHandler = std::function<void(ChannelId, ConnHandle)>;
-  using ClientAdvertiseHandler = std::function<void(const ClientAdvertisement&, ConnHandle)>;
-  using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
-  using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
-  using ParameterRequestHandler = std::function<void(
-    const std::vector<std::string>&, const std::optional<std::string>&, ConnHandle)>;
-  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&,
-                                                    const std::optional<std::string>&, ConnHandle)>;
-  using ParameterSubscriptionHandler = std::function<void(
-    const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
+using Tcp = websocketpp::lib::asio::ip::tcp;
+using SubscribeUnsubscribeHandler = std::function<void(ChannelId, ConnHandle)>;
+using ClientAdvertiseHandler = std::function<void(const ClientAdvertisement&, ConnHandle)>;
+using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
+using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
+using ParameterRequestHandler = std::function<void(const std::vector<std::string>&,
+                                                   const std::optional<std::string>&, ConnHandle)>;
+using ParameterChangeHandler =
+  std::function<void(const std::vector<Parameter>&, const std::optional<std::string>&, ConnHandle)>;
+using ParameterSubscriptionHandler =
+  std::function<void(const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
 
+class ServerInterface {
 public:
   virtual ~ServerInterface() {}
   virtual void start(const std::string& host, uint16_t port) = 0;
@@ -188,17 +188,6 @@ public:
   using ServerType = websocketpp::server<ServerConfiguration>;
   using ConnectionType = websocketpp::connection<ServerConfiguration>;
   using MessagePtr = typename ServerType::message_ptr;
-  using Tcp = websocketpp::lib::asio::ip::tcp;
-  using SubscribeUnsubscribeHandler = std::function<void(ChannelId, ConnHandle)>;
-  using ClientAdvertiseHandler = std::function<void(const ClientAdvertisement&, ConnHandle)>;
-  using ClientUnadvertiseHandler = std::function<void(ClientChannelId, ConnHandle)>;
-  using ClientMessageHandler = std::function<void(const ClientMessage&, ConnHandle)>;
-  using ParameterRequestHandler = std::function<void(
-    const std::vector<std::string>&, const std::optional<std::string>&, ConnHandle)>;
-  using ParameterChangeHandler = std::function<void(const std::vector<Parameter>&,
-                                                    const std::optional<std::string>&, ConnHandle)>;
-  using ParameterSubscriptionHandler = std::function<void(
-    const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
 
   static bool USES_TLS;
 

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -180,6 +180,19 @@ TEST_F(ParameterTest, testSetParameters) {
   EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
 }
 
+TEST_F(ParameterTest, testSetParametersWithReqId) {
+  const PARAM_1_TYPE newP1value = "world";
+  const std::vector<foxglove::Parameter> parameters = {
+    foxglove::Parameter(PARAM_1_NAME, newP1value),
+  };
+
+  const std::string requestId = "req-testSetParameters";
+  _wsClient->setParameters(parameters, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_EQ(1UL, params.size());
+}
+
 TEST_F(ParameterTest, testParameterSubscription) {
   _wsClient->subscribeParameterUpdates({PARAM_1_NAME});
   _wsClient->setParameters({foxglove::Parameter(PARAM_1_NAME, "foo")});

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -222,6 +222,20 @@ TEST_F(ParameterTest, testSetParameters) {
   EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
 }
 
+TEST_F(ParameterTest, testSetParametersWithReqId) {
+  const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
+  const PARAM_1_TYPE newP1value = "world";
+  const std::vector<foxglove::Parameter> parameters = {
+    foxglove::Parameter(p1, newP1value),
+  };
+
+  const std::string requestId = "req-testSetParameters";
+  _wsClient->setParameters(parameters, requestId);
+  std::vector<foxglove::Parameter> params;
+  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  EXPECT_EQ(1UL, params.size());
+}
+
 TEST_F(ParameterTest, testParameterSubscription) {
   const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
 


### PR DESCRIPTION
**Public-Facing Changes**
- Add support for optional request id for `setParameter` operation


**Description**
Corresponding spec PR: https://github.com/foxglove/ws-protocol/pull/328:

> The server may reject requests to update parameters for various reasons such as e.g. parameters being readonly. To allow a client to verify if parameter updates were successful, this PR adds an optional request ID field to the setParameters operation.


