### PR TITLE
Send ROS_DISTRO to clients via metadata field

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -194,6 +194,7 @@ public:
   explicit Server(std::string name, LogCallback logger,
                   const std::vector<std::string>& capabilities,
                   const std::vector<std::string>& supportedEncodings = {},
+                  const std::unordered_map<std::string, std::string>& metadata = {},
                   size_t send_buffer_limit_bytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES,
                   const std::string& certfile = "", const std::string& keyfile = "");
   virtual ~Server();
@@ -247,6 +248,7 @@ private:
   LogCallback _logger;
   std::vector<std::string> _capabilities;
   std::vector<std::string> _supportedEncodings;
+  std::unordered_map<std::string, std::string> _metadata;
   size_t _send_buffer_limit_bytes;
   std::string _certfile;
   std::string _keyfile;
@@ -291,15 +293,16 @@ private:
 };
 
 template <typename ServerConfiguration>
-inline Server<ServerConfiguration>::Server(std::string name, LogCallback logger,
-                                           const std::vector<std::string>& capabilities,
-                                           const std::vector<std::string>& supportedEncodings,
-                                           size_t send_buffer_limit_bytes,
-                                           const std::string& certfile, const std::string& keyfile)
+inline Server<ServerConfiguration>::Server(
+  std::string name, LogCallback logger, const std::vector<std::string>& capabilities,
+  const std::vector<std::string>& supportedEncodings,
+  const std::unordered_map<std::string, std::string>& metadata, size_t send_buffer_limit_bytes,
+  const std::string& certfile, const std::string& keyfile)
     : _name(std::move(name))
     , _logger(logger)
     , _capabilities(capabilities)
     , _supportedEncodings(supportedEncodings)
+    , _metadata(metadata)
     , _send_buffer_limit_bytes(send_buffer_limit_bytes)
     , _certfile(certfile)
     , _keyfile(keyfile) {
@@ -368,6 +371,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
                    {"name", _name},
                    {"capabilities", _capabilities},
                    {"supportedEncodings", _supportedEncodings},
+                   {"metadata", _metadata},
                  })
               .dump());
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -76,17 +76,19 @@ public:
         serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
       }
       const std::vector<std::string> supportedEncodings = {ROS1_CHANNEL_ENCODING};
+      const std::unordered_map<std::string, std::string> metadata = {
+        {"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
 
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
       if (useTLS) {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
           "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
-          send_buffer_limit, certfile, keyfile);
+          metadata, send_buffer_limit, certfile, keyfile);
       } else {
         _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
           "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
-          send_buffer_limit);
+          metadata, send_buffer_limit);
       }
 
       _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -63,14 +63,16 @@ public:
       serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
     }
     const std::vector<std::string> supportedEncodings = {"cdr"};
+    const std::unordered_map<std::string, std::string> metadata = {
+      {"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
 
     if (useTLS) {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings, metadata,
         send_buffer_limit, certfile, keyfile);
     } else {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings,
+        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings, metadata,
         send_buffer_limit);
     }
     _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));


### PR DESCRIPTION
**Public-Facing Changes**
- Send current `$ROS_DISTRO` to clients via `serverInfo`'s `metadata` field

**Description**
- Add support for `serverInfo`'s `metadata` field (https://github.com/foxglove/ws-protocol/pull/334)
- Inform clients about the value of the `$ROS_DISTRO` environment variable via the `metadata` field

Blocked by https://github.com/foxglove/ws-protocol/pull/334



