### PR TITLE
Add ROS1 support for calling server-advertised services

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,9 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
     catkin_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
     target_link_libraries(version_test foxglove_bridge_base)
 
+    catkin_add_gtest(serialization_test foxglove_bridge_base/tests/serialization_test.cpp)
+    target_link_libraries(serialization_test foxglove_bridge_base)
+
     add_rostest_gtest(smoke_test ros1_foxglove_bridge/tests/smoke.test ros1_foxglove_bridge/tests/smoke_test.cpp)
     target_include_directories(smoke_test SYSTEM PRIVATE
       $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>
@@ -194,6 +197,9 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
 
     ament_add_gtest(version_test foxglove_bridge_base/tests/version_test.cpp)
     target_link_libraries(version_test foxglove_bridge_base)
+
+    ament_add_gtest(serialization_test foxglove_bridge_base/tests/serialization_test.cpp)
+    target_link_libraries(serialization_test foxglove_bridge_base)
 
     ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp)
     ament_target_dependencies(smoke_test rclcpp rclcpp_components std_msgs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -106,6 +106,7 @@ if("$ENV{ROS_VERSION}" STREQUAL "1")
     add_library(foxglove_bridge_nodelet
       ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
       ros1_foxglove_bridge/src/param_utils.cpp
+      ros1_foxglove_bridge/src/service_utils.cpp
     )
     target_include_directories(foxglove_bridge_nodelet
       SYSTEM PRIVATE
@@ -167,7 +168,7 @@ if(ROS_BUILD_TYPE STREQUAL "catkin")
   if (CATKIN_ENABLE_TESTING)
     message(STATUS "Building tests with catkin")
 
-    find_package(catkin REQUIRED COMPONENTS roscpp std_msgs)
+    find_package(catkin REQUIRED COMPONENTS roscpp std_msgs std_srvs)
     if(NOT "$ENV{ROS_DISTRO}" STREQUAL "melodic")
       find_package(GTest REQUIRED)
     endif()

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * __certfile__: Path to the certificate to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
  * __keyfile__: Path to the private key to use for TLS. Required when __tls__ is set to `true`. Defaults to `""`.
  * __topic_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted topic names. Defaults to `[".*"]`.
+ * __service_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted service names. Defaults to `[".*"]`.
+ * __param_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted parameter names. Defaults to `[".*"]`.
  * __send_buffer_limit__: Connection send buffer limit in bytes. Messages will be dropped when a connection's send buffer reaches this limit to avoid a queue of outdated messages building up. Defaults to `10000000` (10 MB).
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -11,18 +11,22 @@ constexpr char CAPABILITY_CLIENT_PUBLISH[] = "clientPublish";
 constexpr char CAPABILITY_TIME[] = "time";
 constexpr char CAPABILITY_PARAMETERS[] = "parameters";
 constexpr char CAPABILITY_PARAMETERS_SUBSCRIBE[] = "parametersSubscribe";
+constexpr char CAPABILITY_SERVICES[] = "services";
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;
 using SubscriptionId = uint32_t;
+using ServiceId = uint32_t;
 
 enum class BinaryOpcode : uint8_t {
   MESSAGE_DATA = 1,
   TIME_DATA = 2,
+  SERVICE_CALL_RESPONSE = 3,
 };
 
 enum class ClientBinaryOpcode : uint8_t {
   MESSAGE_DATA = 1,
+  SERVICE_CALL_REQUEST = 2,
 };
 
 struct ClientAdvertisement {
@@ -32,5 +36,41 @@ struct ClientAdvertisement {
   std::string schemaName;
   std::vector<uint8_t> schema;
 };
+
+struct ServiceWithoutId {
+  std::string name;
+  std::string type;
+  std::string requestSchema;
+  std::string responseSchema;
+};
+
+struct Service : ServiceWithoutId {
+  ServiceId id;
+
+  Service() = default;
+  Service(const ServiceWithoutId& s, const ServiceId& id)
+      : ServiceWithoutId(s)
+      , id(id) {}
+};
+
+struct ServiceResponse {
+  ServiceId serviceId;
+  uint32_t callId;
+  std::string encoding;
+  std::vector<uint8_t> data;
+
+  size_t size() const {
+    return 4 + 4 + 4 + encoding.size() + data.size();
+  }
+  void read(const uint8_t* data, size_t size);
+  void write(uint8_t* data) const;
+
+  bool operator==(const ServiceResponse& other) const {
+    return serviceId == other.serviceId && callId == other.callId && encoding == other.encoding &&
+           data == other.data;
+  }
+};
+
+using ServiceRequest = ServiceResponse;
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -4,6 +4,7 @@
 
 #include <nlohmann/json.hpp>
 
+#include "common.hpp"
 #include "parameter.hpp"
 
 namespace foxglove {
@@ -36,5 +37,7 @@ inline void WriteUint32LE(uint8_t* buf, uint32_t val) {
 
 void to_json(nlohmann::json& j, const Parameter& p);
 void from_json(const nlohmann::json& j, Parameter& p);
+void to_json(nlohmann::json& j, const Service& p);
+void from_json(const nlohmann::json& j, Service& p);
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -17,6 +17,11 @@ std::vector<uint8_t> connectClientAndReceiveMsg(const std::string& uri,
 std::future<std::vector<Parameter>> waitForParameters(std::shared_ptr<ClientInterface> client,
                                                       const std::string& requestId = std::string());
 
+std::future<ServiceResponse> waitForServiceResponse(std::shared_ptr<ClientInterface> client);
+
+std::future<Service> waitForService(std::shared_ptr<ClientInterface> client,
+                                    const std::string& serviceName);
+
 extern template class Client<websocketpp::config::asio_client>;
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -43,6 +43,7 @@ public:
   virtual void advertise(const std::vector<ClientAdvertisement>& channels) = 0;
   virtual void unadvertise(const std::vector<ClientChannelId>& channelIds) = 0;
   virtual void publish(ClientChannelId channelId, const uint8_t* buffer, size_t size) = 0;
+  virtual void sendServiceRequest(const ServiceRequest& request) = 0;
   virtual void getParameters(const std::vector<std::string>& parameterNames,
                              const std::optional<std::string>& requestId) = 0;
   virtual void setParameters(const std::vector<Parameter>& parameters,
@@ -180,6 +181,13 @@ public:
     payload[0] = uint8_t(ClientBinaryOpcode::MESSAGE_DATA);
     foxglove::WriteUint32LE(payload.data() + 1, channelId);
     std::memcpy(payload.data() + 1 + 4, buffer, size);
+    sendBinary(payload.data(), payload.size());
+  }
+
+  void sendServiceRequest(const ServiceRequest& request) override {
+    std::vector<uint8_t> payload(1 + request.size());
+    payload[0] = uint8_t(ClientBinaryOpcode::SERVICE_CALL_REQUEST);
+    request.write(payload.data() + 1);
     sendBinary(payload.data(), payload.size());
   }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -147,6 +147,7 @@ using ParameterChangeHandler =
   std::function<void(const std::vector<Parameter>&, const std::optional<std::string>&, ConnHandle)>;
 using ParameterSubscriptionHandler =
   std::function<void(const std::vector<std::string>&, ParameterSubscriptionOperation, ConnHandle)>;
+using ServiceRequestHandler = std::function<void(const ServiceRequest&, ConnHandle)>;
 
 class ServerInterface {
 public:
@@ -161,6 +162,8 @@ public:
                                       const std::vector<Parameter>& parameters,
                                       const std::optional<std::string>& requestId) = 0;
   virtual void updateParameterValues(const std::vector<Parameter>& parameters) = 0;
+  virtual std::vector<ServiceId> addServices(const std::vector<ServiceWithoutId>& services) = 0;
+  virtual void removeServices(const std::vector<ServiceId>& serviceIds) = 0;
 
   virtual void setSubscribeHandler(SubscribeUnsubscribeHandler handler) = 0;
   virtual void setUnsubscribeHandler(SubscribeUnsubscribeHandler handler) = 0;
@@ -170,10 +173,12 @@ public:
   virtual void setParameterRequestHandler(ParameterRequestHandler handler) = 0;
   virtual void setParameterChangeHandler(ParameterChangeHandler handler) = 0;
   virtual void setParameterSubscriptionHandler(ParameterSubscriptionHandler handler) = 0;
+  virtual void setServiceRequestHandler(ServiceRequestHandler handler) = 0;
 
   virtual void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
                            std::string_view data) = 0;
   virtual void broadcastTime(uint64_t timestamp) = 0;
+  virtual void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) = 0;
 
   virtual std::optional<Tcp::endpoint> localEndpoint() = 0;
   virtual std::string remoteEndpointString(ConnHandle clientHandle) = 0;
@@ -213,6 +218,8 @@ public:
   void publishParameterValues(ConnHandle clientHandle, const std::vector<Parameter>& parameters,
                               const std::optional<std::string>& requestId = std::nullopt) override;
   void updateParameterValues(const std::vector<Parameter>& parameters) override;
+  std::vector<ServiceId> addServices(const std::vector<ServiceWithoutId>& services) override;
+  void removeServices(const std::vector<ServiceId>& serviceIds) override;
 
   void setSubscribeHandler(SubscribeUnsubscribeHandler handler) override;
   void setUnsubscribeHandler(SubscribeUnsubscribeHandler handler) override;
@@ -222,10 +229,12 @@ public:
   void setParameterRequestHandler(ParameterRequestHandler handler) override;
   void setParameterChangeHandler(ParameterChangeHandler handler) override;
   void setParameterSubscriptionHandler(ParameterSubscriptionHandler handler) override;
+  void setServiceRequestHandler(ServiceRequestHandler handler) override;
 
   void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
                    std::string_view data) override;
   void broadcastTime(uint64_t timestamp) override;
+  void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) override;
 
   std::optional<Tcp::endpoint> localEndpoint() override;
   std::string remoteEndpointString(ConnHandle clientHandle) override;
@@ -262,6 +271,8 @@ private:
     _clientChannels;
   std::map<ConnHandle, std::unordered_set<std::string>, std::owner_less<>>
     _clientParamSubscriptions;
+  ServiceId _nextServiceId = 0;
+  std::unordered_map<ServiceId, ServiceWithoutId> _services;
   SubscribeUnsubscribeHandler _subscribeHandler;
   SubscribeUnsubscribeHandler _unsubscribeHandler;
   ClientAdvertiseHandler _clientAdvertiseHandler;
@@ -270,6 +281,7 @@ private:
   ParameterRequestHandler _parameterRequestHandler;
   ParameterChangeHandler _parameterChangeHandler;
   ParameterSubscriptionHandler _parameterSubscriptionHandler;
+  ServiceRequestHandler _serviceRequestHandler;
   std::shared_mutex _clientsChannelMutex;
   std::mutex _clientParamSubscriptionsMutex;
 
@@ -375,7 +387,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
                  })
               .dump());
 
-  json channels;
+  std::vector<Channel> channels;
   for (const auto& [id, channel] : _channels) {
     (void)id;
     channels.push_back(channel);
@@ -383,6 +395,15 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
   sendJson(hdl, {
                   {"op", "advertise"},
                   {"channels", std::move(channels)},
+                });
+
+  std::vector<Service> services;
+  for (const auto& [id, service] : _services) {
+    services.push_back(Service(service, id));
+  }
+  sendJson(hdl, {
+                  {"op", "advertiseServices"},
+                  {"services", std::move(services)},
                 });
 }
 
@@ -481,6 +502,11 @@ template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::setParameterSubscriptionHandler(
   ParameterSubscriptionHandler handler) {
   _parameterSubscriptionHandler = std::move(handler);
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::setServiceRequestHandler(ServiceRequestHandler handler) {
+  _serviceRequestHandler = std::move(handler);
 }
 
 template <typename ServerConfiguration>
@@ -883,16 +909,6 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
     return;
   }
 
-  std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
-
-  auto clientPublicationsIt = _clientChannels.find(hdl);
-  if (clientPublicationsIt == _clientChannels.end()) {
-    sendStatus(hdl, StatusLevel::Error, "Client has no advertised channels");
-    return;
-  }
-
-  auto& clientPublications = clientPublicationsIt->second;
-
   const auto op = static_cast<ClientBinaryOpcode>(msg[0]);
   switch (op) {
     case ClientBinaryOpcode::MESSAGE_DATA: {
@@ -901,6 +917,15 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
         return;
       }
       const ClientChannelId channelId = *reinterpret_cast<const ClientChannelId*>(msg + 1);
+      std::unique_lock<std::shared_mutex> lock(_clientsChannelMutex);
+
+      auto clientPublicationsIt = _clientChannels.find(hdl);
+      if (clientPublicationsIt == _clientChannels.end()) {
+        sendStatus(hdl, StatusLevel::Error, "Client has no advertised channels");
+        return;
+      }
+
+      auto& clientPublications = clientPublicationsIt->second;
       const auto& channelIt = clientPublications.find(channelId);
       if (channelIt == clientPublications.end()) {
         sendStatus(hdl, StatusLevel::Error,
@@ -918,6 +943,25 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, con
                                           length,
                                           msg};
         _clientMessageHandler(clientMessage, hdl);
+      }
+    } break;
+    case ClientBinaryOpcode::SERVICE_CALL_REQUEST: {
+      ServiceRequest request;
+      if (length < request.size()) {
+        sendStatus(hdl, StatusLevel::Error,
+                   "Invalid service call request length " + std::to_string(length));
+        return;
+      }
+
+      request.read(msg + 1, length - 1);
+      if (_services.find(request.serviceId) == _services.end()) {
+        sendStatus(hdl, StatusLevel::Error,
+                   "Service " + std::to_string(request.serviceId) + " is not advertised");
+        return;
+      }
+
+      if (_serviceRequestHandler) {
+        _serviceRequestHandler(request, hdl);
       }
     } break;
     default: {
@@ -1002,6 +1046,51 @@ inline void Server<ServerConfiguration>::updateParameterValues(
 }
 
 template <typename ServerConfiguration>
+inline std::vector<ServiceId> Server<ServerConfiguration>::addServices(
+  const std::vector<ServiceWithoutId>& services) {
+  if (services.empty()) {
+    return {};
+  }
+
+  std::vector<ServiceId> serviceIds;
+  json newServices;
+  for (const auto& service : services) {
+    const ServiceId serviceId = ++_nextServiceId;
+    _services.emplace(serviceId, service);
+    serviceIds.push_back(serviceId);
+    newServices.push_back(Service(service, serviceId));
+  }
+
+  const auto msg = json{{"op", "advertiseServices"}, {"services", std::move(newServices)}}.dump();
+  for (const auto& [hdl, clientInfo] : _clients) {
+    (void)clientInfo;
+    sendJsonRaw(hdl, msg);
+  }
+
+  return serviceIds;
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::removeServices(const std::vector<ServiceId>& serviceIds) {
+  std::vector<ServiceId> removedServices;
+  for (const auto& serviceId : serviceIds) {
+    if (const auto it = _services.find(serviceId); it != _services.end()) {
+      _services.erase(it);
+      removedServices.push_back(serviceId);
+    }
+  }
+
+  if (!removedServices.empty()) {
+    const auto msg =
+      json{{"op", "unadvertiseServices"}, {"serviceIds", std::move(removedServices)}}.dump();
+    for (const auto& [hdl, clientInfo] : _clients) {
+      (void)clientInfo;
+      sendJsonRaw(hdl, msg);
+    }
+  }
+}
+
+template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, ChannelId chanId,
                                                      uint64_t timestamp, std::string_view data) {
   std::error_code ec;
@@ -1057,6 +1146,15 @@ inline void Server<ServerConfiguration>::broadcastTime(uint64_t timestamp) {
     (void)clientInfo;
     sendBinary(hdl, message);
   }
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendServiceResponse(ConnHandle clientHandle,
+                                                             const ServiceResponse& response) {
+  std::vector<uint8_t> payload(1 + response.size());
+  payload[0] = uint8_t(BinaryOpcode::SERVICE_CALL_RESPONSE);
+  response.write(payload.data() + 1);
+  sendBinary(clientHandle, payload);
 }
 
 template <typename ServerConfiguration>

--- a/foxglove_bridge_base/tests/serialization_test.cpp
+++ b/foxglove_bridge_base/tests/serialization_test.cpp
@@ -1,0 +1,27 @@
+#include <gtest/gtest.h>
+
+#include <foxglove_bridge/serialization.hpp>
+
+TEST(SerializationTest, ServiceRequestSerialization) {
+  foxglove::ServiceRequest req;
+  req.serviceId = 2;
+  req.callId = 1;
+  req.encoding = "json";
+  req.data = {1, 2, 3};
+
+  std::vector<uint8_t> data(req.size());
+  req.write(data.data());
+
+  foxglove::ServiceRequest req2;
+  req2.read(data.data(), data.size());
+  EXPECT_EQ(req.serviceId, req2.serviceId);
+  EXPECT_EQ(req.callId, req2.callId);
+  EXPECT_EQ(req.encoding, req2.encoding);
+  EXPECT_EQ(req.data.size(), req2.data.size());
+  EXPECT_EQ(req.data, req2.data);
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/package.xml
+++ b/package.xml
@@ -30,6 +30,7 @@
     <test_depend condition="$ROS_VERSION == 2">ament_cmake_gtest</test_depend>
     <test_depend condition="$ROS_VERSION == 2">ament_lint_auto</test_depend>
     <test_depend>std_msgs</test_depend>
+    <test_depend>std_srvs</test_depend>
 
     <!-- Common dependencies -->
     <build_depend>asio</build_depend>

--- a/ros1_foxglove_bridge/include/foxglove_bridge/generic_service.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/generic_service.hpp
@@ -1,0 +1,72 @@
+#pragma once
+
+#include <string>
+#include <vector>
+
+#include <ros/serialization.h>
+#include <ros/service_traits.h>
+
+namespace foxglove_bridge {
+
+struct GenericService {
+  std::string type;
+  std::string md5sum;
+  std::vector<uint8_t> data;
+
+  template <typename Stream>
+  inline void write(Stream& stream) const {
+    std::memcpy(stream.getData(), data.data(), data.size());
+  }
+
+  template <typename Stream>
+  inline void read(Stream& stream) {
+    data.resize(stream.getLength());
+    std::memcpy(data.data(), stream.getData(), stream.getLength());
+  }
+};
+
+}  // namespace foxglove_bridge
+
+namespace ros::service_traits {
+template <>
+struct MD5Sum<foxglove_bridge::GenericService> {
+  static const char* value(const foxglove_bridge::GenericService& m) {
+    return m.md5sum.c_str();
+  }
+
+  static const char* value() {
+    return "*";
+  }
+};
+
+template <>
+struct DataType<foxglove_bridge::GenericService> {
+  static const char* value(const foxglove_bridge::GenericService& m) {
+    return m.type.c_str();
+  }
+
+  static const char* value() {
+    return "*";
+  }
+};
+}  // namespace ros::service_traits
+
+namespace ros::serialization {
+
+template <>
+struct Serializer<foxglove_bridge::GenericService> {
+  template <typename Stream>
+  inline static void write(Stream& stream, const foxglove_bridge::GenericService& m) {
+    m.write(stream);
+  }
+
+  template <typename Stream>
+  inline static void read(Stream& stream, foxglove_bridge::GenericService& m) {
+    m.read(stream);
+  }
+
+  inline static uint32_t serializedLength(const foxglove_bridge::GenericService& m) {
+    return m.data.size();
+  }
+};
+}  // namespace ros::serialization

--- a/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
@@ -1,0 +1,79 @@
+#pragma once
+
+#include <future>
+#include <string>
+#include <vector>
+
+#include <ros/serialization.h>
+#include <ros/service_traits.h>
+
+namespace foxglove_bridge {
+
+struct GenericServiceType {
+  std::string type;
+  std::string md5sum;
+  std::vector<uint8_t> data;
+
+  template <typename Stream>
+  void write(Stream& stream) const {
+    std::memcpy(stream.getData(), data.data(), data.size());
+  }
+
+  template <typename Stream>
+  void read(Stream& stream) {
+    data.resize(stream.getLength());
+    std::memcpy(data.data(), stream.getData(), stream.getLength());
+  }
+};
+
+/**
+ * Opens a socket to the service server and retrieves the service type from the
+ * connection header. The service type is not stored on the ROS master.
+ */
+std::future<std::string> retrieveServiceType(const std::string& serviceName);
+
+}  // namespace foxglove_bridge
+
+namespace ros::service_traits {
+template <>
+struct MD5Sum<foxglove_bridge::GenericServiceType> {
+  static const char* value(const foxglove_bridge::GenericServiceType& m) {
+    return m.md5sum.c_str();
+  }
+
+  static const char* value() {
+    return "*";
+  }
+};
+
+template <>
+struct DataType<foxglove_bridge::GenericServiceType> {
+  static const char* value(const foxglove_bridge::GenericServiceType& m) {
+    return m.type.c_str();
+  }
+
+  static const char* value() {
+    return "*";
+  }
+};
+}  // namespace ros::service_traits
+
+namespace ros::serialization {
+
+template <>
+struct Serializer<foxglove_bridge::GenericServiceType> {
+  template <typename Stream>
+  inline static void write(Stream& stream, const foxglove_bridge::GenericServiceType& m) {
+    m.write(stream);
+  }
+
+  template <typename Stream>
+  inline static void read(Stream& stream, foxglove_bridge::GenericServiceType& m) {
+    m.read(stream);
+  }
+
+  inline static uint32_t serializedLength(const foxglove_bridge::GenericServiceType& m) {
+    return m.data.size();
+  }
+};
+}  // namespace ros::serialization

--- a/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
@@ -2,78 +2,13 @@
 
 #include <future>
 #include <string>
-#include <vector>
-
-#include <ros/serialization.h>
-#include <ros/service_traits.h>
 
 namespace foxglove_bridge {
 
-struct GenericServiceType {
-  std::string type;
-  std::string md5sum;
-  std::vector<uint8_t> data;
-
-  template <typename Stream>
-  void write(Stream& stream) const {
-    std::memcpy(stream.getData(), data.data(), data.size());
-  }
-
-  template <typename Stream>
-  void read(Stream& stream) {
-    data.resize(stream.getLength());
-    std::memcpy(data.data(), stream.getData(), stream.getLength());
-  }
-};
-
 /**
- * Opens a socket to the service server and retrieves the service type from the
- * connection header. The service type is not stored on the ROS master.
+ * Opens a socket to the service server and retrieves the service type from the connection header.
+ * This is necessary as the service type is not stored on the ROS master.
  */
 std::future<std::string> retrieveServiceType(const std::string& serviceName);
 
 }  // namespace foxglove_bridge
-
-namespace ros::service_traits {
-template <>
-struct MD5Sum<foxglove_bridge::GenericServiceType> {
-  static const char* value(const foxglove_bridge::GenericServiceType& m) {
-    return m.md5sum.c_str();
-  }
-
-  static const char* value() {
-    return "*";
-  }
-};
-
-template <>
-struct DataType<foxglove_bridge::GenericServiceType> {
-  static const char* value(const foxglove_bridge::GenericServiceType& m) {
-    return m.type.c_str();
-  }
-
-  static const char* value() {
-    return "*";
-  }
-};
-}  // namespace ros::service_traits
-
-namespace ros::serialization {
-
-template <>
-struct Serializer<foxglove_bridge::GenericServiceType> {
-  template <typename Stream>
-  inline static void write(Stream& stream, const foxglove_bridge::GenericServiceType& m) {
-    m.write(stream);
-  }
-
-  template <typename Stream>
-  inline static void read(Stream& stream, foxglove_bridge::GenericServiceType& m) {
-    m.read(stream);
-  }
-
-  inline static uint32_t serializedLength(const foxglove_bridge::GenericServiceType& m) {
-    return m.data.size();
-  }
-};
-}  // namespace ros::serialization

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -18,6 +18,7 @@
 #include <rosgraph_msgs/Clock.h>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
+#include <foxglove_bridge/generic_service.hpp>
 #include <foxglove_bridge/param_utils.hpp>
 #include <foxglove_bridge/service_utils.hpp>
 #include <foxglove_bridge/websocket_server.hpp>
@@ -741,7 +742,7 @@ private:
       return;
     }
 
-    GenericServiceType genReq, genRes;
+    GenericService genReq, genRes;
     genReq.type = genRes.type = serviceType;
     genReq.md5sum = genRes.md5sum = srvDescription->md5;
     genReq.data = request.data;

--- a/ros1_foxglove_bridge/src/service_utils.cpp
+++ b/ros1_foxglove_bridge/src/service_utils.cpp
@@ -1,0 +1,28 @@
+#include <ros/connection.h>
+#include <ros/service_manager.h>
+#include <ros/service_server_link.h>
+
+#include <foxglove_bridge/service_utils.hpp>
+
+namespace foxglove_bridge {
+
+std::future<std::string> retrieveServiceType(const std::string& serviceName) {
+  auto link = ros::ServiceManager::instance()->createServiceServerLink(serviceName, false, "*", "*",
+                                                                       {{"probe", "1"}});
+
+  auto promise = std::make_shared<std::promise<std::string>>();
+  auto future = promise->get_future();
+
+  link->getConnection()->setHeaderReceivedCallback(
+    [promise = std::move(promise)](const ros::ConnectionPtr&, const ros::Header& header) mutable {
+      std::string serviceType;
+      if (header.getValue("type", serviceType)) {
+        promise->set_value(serviceType);
+      }
+      return true;
+    });
+
+  return future;
+}
+
+}  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/service_utils.cpp
+++ b/ros1_foxglove_bridge/src/service_utils.cpp
@@ -9,7 +9,6 @@ namespace foxglove_bridge {
 std::future<std::string> retrieveServiceType(const std::string& serviceName) {
   auto link = ros::ServiceManager::instance()->createServiceServerLink(serviceName, false, "*", "*",
                                                                        {{"probe", "1"}});
-
   auto promise = std::make_shared<std::promise<std::string>>();
   auto future = promise->get_future();
 

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 #include <ros/ros.h>
 #include <std_msgs/builtin_string.h>
+#include <std_srvs/SetBool.h>
 #include <websocketpp/config/asio_client.hpp>
 
 #include <foxglove_bridge/test/test_client.hpp>
@@ -43,6 +44,28 @@ protected:
 
   ros::NodeHandle _nh;
   std::shared_ptr<foxglove::Client<websocketpp::config::asio_client>> _wsClient;
+};
+
+class ServiceTest : public ::testing::Test {
+public:
+  inline static const std::string SERVICE_NAME = "/foo_service";
+  inline static const std::vector<uint8_t> SERIALIZED_RESPONSE = {1,   5,   0,   0,   0,
+                                                                  104, 101, 108, 108, 111};
+
+protected:
+  void SetUp() override {
+    _nh = ros::NodeHandle();
+    _service = _nh.advertiseService<std_srvs::SetBool::Request, std_srvs::SetBool::Response>(
+      SERVICE_NAME, [&](auto&, auto& res) {
+        res.message = "hello";
+        res.success = true;
+        return true;
+      });
+  }
+
+private:
+  ros::NodeHandle _nh;
+  ros::ServiceServer _service;
 };
 
 TEST(SmokeTest, testConnection) {
@@ -254,6 +277,44 @@ TEST_F(ParameterTest, testGetParametersParallel) {
     std::vector<foxglove::Parameter> parameters;
     EXPECT_NO_THROW(parameters = future.get());
     EXPECT_GE(parameters.size(), 2UL);
+  }
+}
+
+TEST_F(ServiceTest, testCallServiceParallel) {
+  // Connect a few clients (in parallel) and make sure that they can all call the service
+  auto clients = {
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+    std::make_shared<foxglove::Client<websocketpp::config::asio_client>>(),
+  };
+
+  auto serviceFuture = foxglove::waitForService(*clients.begin(), SERVICE_NAME);
+  for (auto client : clients) {
+    ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(std::chrono::seconds(5)));
+  }
+  ASSERT_EQ(std::future_status::ready, serviceFuture.wait_for(std::chrono::seconds(5)));
+  const foxglove::Service service = serviceFuture.get();
+
+  foxglove::ServiceRequest request;
+  request.serviceId = service.id;
+  request.callId = 123lu;
+  request.encoding = "ros1";
+  request.data = {1};
+
+  std::vector<std::future<foxglove::ServiceResponse>> futures;
+  for (auto client : clients) {
+    futures.push_back(foxglove::waitForServiceResponse(client));
+    client->sendServiceRequest(request);
+  }
+
+  for (auto& future : futures) {
+    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    foxglove::ServiceResponse response;
+    EXPECT_NO_THROW(response = future.get());
+    EXPECT_EQ(response.serviceId, request.serviceId);
+    EXPECT_EQ(response.callId, request.callId);
+    EXPECT_EQ(response.encoding, request.encoding);
+    EXPECT_EQ(response.data, SERIALIZED_RESPONSE);
   }
 }
 


### PR DESCRIPTION
**Public-Facing Changes**
- Add ROS1 support for calling server-advertised services

**Description**
- Adds ROS1 support for advertising/unadvertising services and allowing clients to call them
  - Implements the services spec that was added in https://github.com/foxglove/ws-protocol/pull/344

Implementation details:
- The service type is unfortunately not stored on the ROS master, so for every new service, a connection to the service server has to be opened to fetch the service type from the connection header
- For ROS1, one can call services with a custom type (here `GenericService`) when one defines the `ros::service_traits` and `ros::serialization` traits


Fixes #10 (together with #142)
