### PR TITLE
Always --pull when building docker images in the makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,35 +2,35 @@ default: ros2
 
 .PHONY: ros1
 ros1:
-	docker build -t foxglove_bridge_ros1 -f Dockerfile.ros1 .
+	docker build -t foxglove_bridge_ros1 --pull -f Dockerfile.ros1 .
 
 .PHONY: ros2
 ros2:
-	docker build -t foxglove_bridge_ros2 -f Dockerfile.ros2 .
+	docker build -t foxglove_bridge_ros2 --pull -f Dockerfile.ros2 .
 
 .PHONY: melodic
 melodic:
-	docker build -t foxglove_bridge_melodic -f Dockerfile.ros1 --build-arg ROS_DISTRIBUTION=melodic .
+	docker build -t foxglove_bridge_melodic --pull -f Dockerfile.ros1 --build-arg ROS_DISTRIBUTION=melodic .
 
 .PHONY: noetic
 noetic:
-	docker build -t foxglove_bridge_noetic -f Dockerfile.ros1 --build-arg ROS_DISTRIBUTION=noetic .
+	docker build -t foxglove_bridge_noetic --pull -f Dockerfile.ros1 --build-arg ROS_DISTRIBUTION=noetic .
 
 .PHONY: galactic
 galactic:
-	docker build -t foxglove_bridge_galactic -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=galactic .
+	docker build -t foxglove_bridge_galactic --pull -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=galactic .
 
 .PHONY: humble
 humble:
-	docker build -t foxglove_bridge_humble -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=humble .
+	docker build -t foxglove_bridge_humble --pull -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=humble .
 
 .PHONY: rolling
 rolling:
-	docker build -t foxglove_bridge_rolling -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=rolling .
+	docker build -t foxglove_bridge_rolling --pull -f Dockerfile.ros2 --build-arg ROS_DISTRIBUTION=rolling .
 
 .PHONY: rosdev
 rosdev:
-	docker build -t foxglove_bridge_rosdev -f .devcontainer/Dockerfile .
+	docker build -t foxglove_bridge_rosdev --pull -f .devcontainer/Dockerfile .
 
 clean:
 	docker rmi -f foxglove_bridge_ros1

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include <chrono>
+#include <future>
 #include <string>
 #include <vector>
 
@@ -14,9 +14,8 @@ namespace foxglove {
 std::vector<uint8_t> connectClientAndReceiveMsg(const std::string& uri,
                                                 const std::string& topic_name);
 
-std::vector<Parameter> waitForParameters(
-  std::shared_ptr<ClientInterface> client, const std::string& requestId = std::string(),
-  const std::chrono::duration<double>& timeout = std::chrono::seconds(5));
+std::future<std::vector<Parameter>> waitForParameters(std::shared_ptr<ClientInterface> client,
+                                                      const std::string& requestId = std::string());
 
 extern template class Client<websocketpp::config::asio_client>;
 

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -18,6 +18,9 @@ constexpr char URI[] = "ws://localhost:9876";
 constexpr uint8_t HELLO_WORLD_BINARY[] = {11,  0,  0,   0,   104, 101, 108, 108,
                                           111, 32, 119, 111, 114, 108, 100};
 
+constexpr auto ONE_SECOND = std::chrono::seconds(1);
+constexpr auto FIVE_SECONDS = std::chrono::seconds(5);
+
 class ParameterTest : public ::testing::Test {
 public:
   using PARAM_1_TYPE = std::string;
@@ -35,7 +38,7 @@ protected:
     _nh.setParam(PARAM_2_NAME, PARAM_2_DEFAULT_VALUE);
 
     _wsClient = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
-    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(FIVE_SECONDS));
   }
 
   ros::NodeHandle _nh;
@@ -44,7 +47,7 @@ protected:
 
 TEST(SmokeTest, testConnection) {
   foxglove::Client<websocketpp::config::asio_client> wsClient;
-  EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
+  EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(FIVE_SECONDS));
 }
 
 TEST(SmokeTest, testSubscription) {
@@ -80,7 +83,7 @@ TEST(SmokeTest, testSubscriptionParallel) {
   }
 
   for (auto& future : futures) {
-    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
     auto msgData = future.get();
     ASSERT_EQ(sizeof(HELLO_WORLD_BINARY), msgData.size());
     EXPECT_EQ(0, std::memcmp(HELLO_WORLD_BINARY, msgData.data(), msgData.size()));
@@ -106,40 +109,46 @@ TEST(SmokeTest, testPublishing) {
     });
 
   // Set up the client, advertise and publish the binary message
-  ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
+  ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(FIVE_SECONDS));
   wsClient.advertise({advertisement});
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::this_thread::sleep_for(ONE_SECOND);
   wsClient.publish(advertisement.channelId, HELLO_WORLD_BINARY, sizeof(HELLO_WORLD_BINARY));
   wsClient.unadvertise({advertisement.channelId});
 
   // Ensure that we have received the correct message via our ROS subscriber
-  const auto msgResult = msgFuture.wait_for(std::chrono::seconds(1));
+  const auto msgResult = msgFuture.wait_for(ONE_SECOND);
   ASSERT_EQ(std::future_status::ready, msgResult);
   EXPECT_EQ("hello world", msgFuture.get());
 }
 
 TEST_F(ParameterTest, testGetAllParams) {
   const std::string requestId = "req-testGetAllParams";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_GE(params.size(), 2UL);
 }
 
 TEST_F(ParameterTest, testGetNonExistingParameters) {
   const std::string requestId = "req-testGetNonExistingParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters(
     {"/foo_1/non_existing_parameter", "/foo_2/non_existing/nested_parameter"}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_TRUE(params.empty());
 }
 
 TEST_F(ParameterTest, testGetParameters) {
   const std::string requestId = "req-testGetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({PARAM_1_NAME, PARAM_2_NAME}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(2UL, params.size());
   auto p1Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
     return param.getName() == PARAM_1_NAME;
@@ -164,9 +173,11 @@ TEST_F(ParameterTest, testSetParameters) {
 
   _wsClient->setParameters(parameters);
   const std::string requestId = "req-testSetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({PARAM_1_NAME, PARAM_2_NAME}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(2UL, params.size());
   auto p1Iter = std::find_if(params.begin(), params.end(), [](const auto& param) {
     return param.getName() == PARAM_1_NAME;
@@ -187,24 +198,30 @@ TEST_F(ParameterTest, testSetParametersWithReqId) {
   };
 
   const std::string requestId = "req-testSetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->setParameters(parameters, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(1UL, params.size());
 }
 
 TEST_F(ParameterTest, testParameterSubscription) {
+  auto future = foxglove::waitForParameters(_wsClient);
+
   _wsClient->subscribeParameterUpdates({PARAM_1_NAME});
   _wsClient->setParameters({foxglove::Parameter(PARAM_1_NAME, "foo")});
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, "", std::chrono::seconds(5)));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   ASSERT_EQ(1UL, params.size());
   EXPECT_EQ(params.front().getName(), PARAM_1_NAME);
 
   _wsClient->unsubscribeParameterUpdates({PARAM_1_NAME});
   _wsClient->setParameters({foxglove::Parameter(PARAM_1_NAME, "bar")});
-  EXPECT_THROW((void)foxglove::waitForParameters(_wsClient, "", std::chrono::seconds(5)),
-               std::runtime_error);
+
+  future = foxglove::waitForParameters(_wsClient);
+  ASSERT_EQ(std::future_status::timeout, future.wait_for(ONE_SECOND));
 }
 
 TEST_F(ParameterTest, testGetParametersParallel) {
@@ -219,19 +236,21 @@ TEST_F(ParameterTest, testGetParametersParallel) {
   for (auto client : clients) {
     futures.push_back(
       std::async(std::launch::async, [client]() -> std::vector<foxglove::Parameter> {
-        if (std::future_status::ready == client->connect(URI).wait_for(std::chrono::seconds(5))) {
+        if (std::future_status::ready == client->connect(URI).wait_for(FIVE_SECONDS)) {
           const std::string requestId = "req-123";
+          auto future = foxglove::waitForParameters(client, requestId);
           client->getParameters({}, requestId);
-          const auto parameters =
-            foxglove::waitForParameters(client, requestId, std::chrono::seconds(5));
-          return parameters;
+          future.wait_for(FIVE_SECONDS);
+          if (future.valid()) {
+            return future.get();
+          }
         }
         return {};
       }));
   }
 
   for (auto& future : futures) {
-    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
     std::vector<foxglove::Parameter> parameters;
     EXPECT_NO_THROW(parameters = future.get());
     EXPECT_GE(parameters.size(), 2UL);

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -289,8 +289,8 @@ void ParameterInterface::setNodeParameters(rclcpp::AsyncParametersClient::Shared
 
   auto future = paramClient->set_parameters(params);
   if (std::future_status::ready != future.wait_for(timeout)) {
-    throw std::runtime_error("Param client failed to set parameters for node '" + nodeName +
-                             "' within the given timeout");
+    throw std::runtime_error("Param client failed to set " + std::to_string(params.size()) +
+                             " parameter(s) for node '" + nodeName + "' within the given timeout");
   }
 
   const auto setParamResults = future.get();

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -18,6 +18,9 @@ constexpr char URI[] = "ws://localhost:8765";
 constexpr uint8_t HELLO_WORLD_BINARY[] = {0,   1,   0,   0,  12,  0,   0,   0,   104, 101,
                                           108, 108, 111, 32, 119, 111, 114, 108, 100, 0};
 
+constexpr auto ONE_SECOND = std::chrono::seconds(1);
+constexpr auto FIVE_SECONDS = std::chrono::seconds(5);
+
 class ParameterTest : public ::testing::Test {
 public:
   using PARAM_1_TYPE = std::string;
@@ -53,7 +56,7 @@ protected:
     });
 
     _wsClient = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
-    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, _wsClient->connect(URI).wait_for(FIVE_SECONDS));
   }
 
   void TearDown() override {
@@ -70,7 +73,7 @@ protected:
 
 TEST(SmokeTest, testConnection) {
   foxglove::Client<websocketpp::config::asio_client> wsClient;
-  EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
+  EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(FIVE_SECONDS));
 }
 
 TEST(SmokeTest, testSubscription) {
@@ -116,7 +119,7 @@ TEST(SmokeTest, testSubscriptionParallel) {
   }
 
   for (auto& future : futures) {
-    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
     auto msgData = future.get();
     ASSERT_EQ(sizeof(HELLO_WORLD_BINARY), msgData.size());
     EXPECT_EQ(0, std::memcmp(HELLO_WORLD_BINARY, msgData.data(), msgData.size()));
@@ -143,32 +146,36 @@ TEST(SmokeTest, testPublishing) {
 
   // Set up the client, advertise and publish the binary message
   foxglove::Client<websocketpp::config::asio_client> wsClient;
-  ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(std::chrono::seconds(5)));
+  ASSERT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(FIVE_SECONDS));
   wsClient.advertise({advertisement});
-  std::this_thread::sleep_for(std::chrono::seconds(1));
+  std::this_thread::sleep_for(ONE_SECOND);
   wsClient.publish(advertisement.channelId, HELLO_WORLD_BINARY, sizeof(HELLO_WORLD_BINARY));
   wsClient.unadvertise({advertisement.channelId});
 
   // Ensure that we have received the correct message via our ROS subscriber
-  const auto ret = executor.spin_until_future_complete(msgFuture, std::chrono::seconds(1));
+  const auto ret = executor.spin_until_future_complete(msgFuture, ONE_SECOND);
   ASSERT_EQ(rclcpp::FutureReturnCode::SUCCESS, ret);
   EXPECT_EQ("hello world", msgFuture.get());
 }
 
 TEST_F(ParameterTest, testGetAllParams) {
   const std::string requestId = "req-testGetAllParams";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_GE(params.size(), 2UL);
 }
 
 TEST_F(ParameterTest, testGetNonExistingParameters) {
   const std::string requestId = "req-testGetNonExistingParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters(
     {"/foo_1.non_existing_parameter", "/foo_2.non_existing.nested_parameter"}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_TRUE(params.empty());
 }
 
@@ -177,9 +184,11 @@ TEST_F(ParameterTest, testGetParameters) {
   const auto p2 = NODE_2_NAME + "." + PARAM_2_NAME;
 
   const std::string requestId = "req-testGetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({p1, p2}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(2UL, params.size());
   auto p1Iter = std::find_if(params.begin(), params.end(), [&p1](const auto& param) {
     return param.getName() == p1;
@@ -206,9 +215,11 @@ TEST_F(ParameterTest, testSetParameters) {
 
   _wsClient->setParameters(parameters);
   const std::string requestId = "req-testSetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->getParameters({p1, p2}, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(2UL, params.size());
   auto p1Iter = std::find_if(params.begin(), params.end(), [&p1](const auto& param) {
     return param.getName() == p1;
@@ -230,9 +241,11 @@ TEST_F(ParameterTest, testSetParametersWithReqId) {
   };
 
   const std::string requestId = "req-testSetParameters";
+  auto future = foxglove::waitForParameters(_wsClient, requestId);
   _wsClient->setParameters(parameters, requestId);
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient, requestId));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   EXPECT_EQ(1UL, params.size());
 }
 
@@ -240,16 +253,19 @@ TEST_F(ParameterTest, testParameterSubscription) {
   const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
 
   _wsClient->subscribeParameterUpdates({p1});
+  auto future = foxglove::waitForParameters(_wsClient);
   _wsClient->setParameters({foxglove::Parameter(p1, "foo")});
-  std::vector<foxglove::Parameter> params;
-  ASSERT_NO_THROW(params = foxglove::waitForParameters(_wsClient));
+  ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
+  std::vector<foxglove::Parameter> params = future.get();
+
   ASSERT_EQ(1UL, params.size());
   EXPECT_EQ(params.front().getName(), p1);
 
   _wsClient->unsubscribeParameterUpdates({p1});
   _wsClient->setParameters({foxglove::Parameter(p1, "bar")});
-  EXPECT_THROW((void)foxglove::waitForParameters(_wsClient, "", std::chrono::seconds(5)),
-               std::runtime_error);
+
+  future = foxglove::waitForParameters(_wsClient);
+  ASSERT_EQ(std::future_status::timeout, future.wait_for(ONE_SECOND));
 }
 
 TEST_F(ParameterTest, testGetParametersParallel) {
@@ -264,19 +280,21 @@ TEST_F(ParameterTest, testGetParametersParallel) {
   for (auto client : clients) {
     futures.push_back(
       std::async(std::launch::async, [client]() -> std::vector<foxglove::Parameter> {
-        if (std::future_status::ready == client->connect(URI).wait_for(std::chrono::seconds(5))) {
+        if (std::future_status::ready == client->connect(URI).wait_for(FIVE_SECONDS)) {
           const std::string requestId = "req-123";
+          auto future = foxglove::waitForParameters(client, requestId);
           client->getParameters({}, requestId);
-          const auto parameters =
-            foxglove::waitForParameters(client, requestId, std::chrono::seconds(5));
-          return parameters;
+          future.wait_for(FIVE_SECONDS);
+          if (future.valid()) {
+            return future.get();
+          }
         }
         return {};
       }));
   }
 
   for (auto& future : futures) {
-    ASSERT_EQ(std::future_status::ready, future.wait_for(std::chrono::seconds(5)));
+    ASSERT_EQ(std::future_status::ready, future.wait_for(FIVE_SECONDS));
     std::vector<foxglove::Parameter> parameters;
     EXPECT_NO_THROW(parameters = future.get());
     EXPECT_GE(parameters.size(), 2UL);


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
Previously, running a test command through the Makefile such as `make rolling-test` would use a previously cached ROS docker image if available. This means the tests would 
execute with an arbitrarily old version of the ROS distro. This adds `--pull` to the build commands so new ROS base images are always pulled if available before building 
and running tests.
