### PR TITLE
Fix flaky parameter test (noetic)

### DIFF
--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -487,7 +487,7 @@ private:
 
       try {
         XmlRpc::XmlRpcValue value;
-        getMTNodeHandle().getParamCached(paramName, value);
+        getMTNodeHandle().getParam(paramName, value);
         params.push_back(fromRosParam(paramName, value));
       } catch (const std::exception& ex) {
         ROS_ERROR("Invalid parameter: %s", ex.what());


### PR DESCRIPTION
**Public-Facing Changes**
- Fixes flaky parameter test (noetic)


**Description**
Instead of using the cached value, we now always query the ROS master for the latest parameter value.

I am actually not sure why it does not work when using [getParamCached](http://docs.ros.org/en/noetic/api/roscpp/html/classros_1_1NodeHandle.html#a29e8424c7760136ad5b9294ed1de84e7). I propose to merge this PR now and investigate using `getParamCached` later on again

