### PR TITLE
Performance improvements

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -176,7 +176,7 @@ public:
   virtual void setServiceRequestHandler(ServiceRequestHandler handler) = 0;
 
   virtual void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
-                           const uint8_t* payload, size_t payload_size) = 0;
+                           const uint8_t* payload, size_t payloadSize) = 0;
   virtual void broadcastTime(uint64_t timestamp) = 0;
   virtual void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) = 0;
 
@@ -232,7 +232,7 @@ public:
   void setServiceRequestHandler(ServiceRequestHandler handler) override;
 
   void sendMessage(ConnHandle clientHandle, ChannelId chanId, uint64_t timestamp,
-                   const uint8_t* payload, size_t payload_size) override;
+                   const uint8_t* payload, size_t payloadSize) override;
   void broadcastTime(uint64_t timestamp) override;
   void sendServiceResponse(ConnHandle clientHandle, const ServiceResponse& response) override;
 
@@ -1100,7 +1100,7 @@ inline void Server<ServerConfiguration>::removeServices(const std::vector<Servic
 template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, ChannelId chanId,
                                                      uint64_t timestamp, const uint8_t* payload,
-                                                     size_t payload_size) {
+                                                     size_t payloadSize) {
   std::error_code ec;
   const auto con = _server.get_con_from_hdl(clientHandle, ec);
   if (ec || !con) {
@@ -1140,11 +1140,11 @@ inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, Ch
   foxglove::WriteUint32LE(msgHeader.data() + 1, subId);
   foxglove::WriteUint64LE(msgHeader.data() + 5, timestamp);
 
-  const size_t messageSize = msgHeader.size() + payload_size;
+  const size_t messageSize = msgHeader.size() + payloadSize;
   auto message = con->get_message(OpCode::BINARY, messageSize);
 
   message->set_payload(msgHeader.data(), msgHeader.size());
-  message->append_payload(payload, payload_size);
+  message->append_payload(payload, payloadSize);
   con->send(message);
 }
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -712,9 +712,7 @@ private:
     const ros::MessageEvent<ros_babel_fish::BabelFishMessage const>& msgEvent) {
     const auto& msg = msgEvent.getConstMessage();
     const auto receiptTimeNs = msgEvent.getReceiptTime().toNSec();
-    _server->sendMessage(
-      clientHandle, channel.id, receiptTimeNs,
-      std::string_view(reinterpret_cast<const char*>(msg->buffer()), msg->size()));
+    _server->sendMessage(clientHandle, channel.id, receiptTimeNs, msg->buffer(), msg->size());
   }
 
   void serviceRequestHandler(const foxglove::ServiceRequest& request,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -721,10 +721,9 @@ private:
     // to `/rosout` will cause a feedback loop
     const auto timestamp = this->now().nanoseconds();
     assert(timestamp >= 0 && "Timestamp is negative");
-    const auto payload =
-      std::string_view{reinterpret_cast<const char*>(msg->get_rcl_serialized_message().buffer),
-                       msg->get_rcl_serialized_message().buffer_length};
-    _server->sendMessage(clientHandle, channel.id, static_cast<uint64_t>(timestamp), payload);
+    const auto rclSerializedMsg = msg->get_rcl_serialized_message();
+    _server->sendMessage(clientHandle, channel.id, static_cast<uint64_t>(timestamp),
+                         rclSerializedMsg.buffer, rclSerializedMsg.buffer_length);
   }
 
   void serviceRequestHandler(const foxglove::ServiceRequest& request,


### PR DESCRIPTION
**Public-Facing Changes**
- Minor performance improvements


**Description**
This PR makes some minor performance improvements:
- Use `websocketpp::endpoint< connection, config >::send(connection_hdl hdl, message_ptr msg)`
- Use fixed size `std::array<uint8_t, N>` to avoid heap allocation
- Avoid some unnecessary conversions


To measure performance improvments, I wrote a test client that prints some channel statistics: https://github.com/foxglove/ws-protocol/pull/361. The table below shows the average CPU time and data received (over 4 runs) when playing back `realsense-ros2-001.mcap`:

|                          | main (8e08af0e) | This PR   | Difference |
|--------------------------|-----------------|-----------|------------|
| total data received [kb] |       3308866.3 | 3299419.4 | -0.29%     |
| CPU time [s]             | 17.75           | 15.25     | -14.08%    |

We can see that this PR significantly reduces CPU load while the data throughput remains almost the same (statistically speaking probably not significantly different)
