### PR TITLE
Add option to use permessage-deflate compression

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,6 +20,7 @@ find_package(nlohmann_json QUIET)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
+find_package(ZLIB REQUIRED)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Debug)
@@ -76,6 +77,7 @@ target_include_directories(foxglove_bridge_base
 target_link_libraries(foxglove_bridge_base
   OpenSSL::Crypto
   OpenSSL::SSL
+  ZLIB::ZLIB
   ${CMAKE_THREAD_LIBS_INIT}
 )
 if(nlohmann_json_FOUND)

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * __service_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted service names. Defaults to `[".*"]`.
  * __param_whitelist__: List of regular expressions ([ECMAScript grammar](https://en.cppreference.com/w/cpp/regex/ecmascript)) of whitelisted parameter names. Defaults to `[".*"]`.
  * __send_buffer_limit__: Connection send buffer limit in bytes. Messages will be dropped when a connection's send buffer reaches this limit to avoid a queue of outdated messages building up. Defaults to `10000000` (10 MB).
+ * __use_compression__: Use websocket compression (permessage-deflate). Suited for connections with smaller bandwith, at the cost of additional CPU load.
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `10`.

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <websocketpp/config/asio_no_tls.hpp>
+#include <websocketpp/extensions/permessage_deflate/enabled.hpp>
 #include <websocketpp/server.hpp>
 
 #include "./websocket_logging.hpp"
@@ -35,6 +36,11 @@ struct WebSocketNoTls : public websocketpp::config::core {
   };
 
   typedef websocketpp::transport::asio::endpoint<transport_config> transport_type;
+
+  struct permessage_deflate_config {};
+
+  typedef websocketpp::extensions::permessage_deflate::enabled<permessage_deflate_config>
+    permessage_deflate_type;
 };
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -195,6 +195,7 @@ struct ServerOptions {
   std::string certfile = "";
   std::string keyfile = "";
   std::string sessionId;
+  bool useCompression = false;
 };
 
 template <typename ServerConfiguration>
@@ -1135,6 +1136,7 @@ inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, Ch
 
   const size_t messageSize = msgHeader.size() + payloadSize;
   auto message = con->get_message(OpCode::BINARY, messageSize);
+  message->set_compressed(_options.useCompression);
 
   message->set_payload(msgHeader.data(), msgHeader.size());
   message->append_payload(payload, payloadSize);

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <websocketpp/config/asio.hpp>
+#include <websocketpp/extensions/permessage_deflate/enabled.hpp>
 
 #include "./websocket_logging.hpp"
 
@@ -34,6 +35,11 @@ struct WebSocketTls : public websocketpp::config::core {
   };
 
   typedef websocketpp::transport::asio::endpoint<transport_config> transport_type;
+
+  struct permessage_deflate_config {};
+
+  typedef websocketpp::extensions::permessage_deflate::enabled<permessage_deflate_config>
+    permessage_deflate_type;
 };
 
 }  // namespace foxglove

--- a/package.xml
+++ b/package.xml
@@ -38,8 +38,10 @@
     <build_depend>libwebsocketpp-dev</build_depend>
     <build_depend>nlohmann-json-dev</build_depend>
     <build_depend>ros_environment</build_depend>
+    <build_depend>zlib</build_depend>
 
     <exec_depend>openssl</exec_depend>
+    <exec_depend>zlib</exec_depend>
 
     <depend>rosgraph_msgs</depend>
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -52,6 +52,7 @@ public:
     const auto certfile = nhp.param<std::string>("certfile", "");
     const auto keyfile = nhp.param<std::string>("keyfile", "");
     _maxUpdateMs = static_cast<size_t>(nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS));
+    const auto useCompression = nhp.param<bool>("use_compression", false);
     _useSimTime = nhp.param<bool>("/use_sim_time", false);
     const auto sessionId = nhp.param<std::string>("/run_id", std::to_string(std::time(nullptr)));
 
@@ -91,6 +92,7 @@ public:
       serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
       serverOptions.sendBufferLimitBytes = send_buffer_limit;
       serverOptions.sessionId = sessionId;
+      serverOptions.useCompression = useCompression;
 
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -18,6 +18,7 @@ constexpr char PARAM_MAX_QOS_DEPTH[] = "max_qos_depth";
 constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
 constexpr char PARAM_SERVICE_WHITELIST[] = "service_whitelist";
 constexpr char PARAM_PARAMETER_WHITELIST[] = "param_whitelist";
+constexpr char PARAM_USE_COMPRESSION[] = "use_compression";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -97,6 +97,15 @@ void declareParameters(rclcpp::Node* node) {
   paramWhiteListDescription.read_only = true;
   node->declare_parameter(PARAM_PARAMETER_WHITELIST, std::vector<std::string>({".*"}),
                           paramWhiteListDescription);
+
+  auto useCompressionDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  useCompressionDescription.name = PARAM_USE_COMPRESSION;
+  useCompressionDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  useCompressionDescription.description =
+    "Use websocket compression (permessage-deflate). Suited for connections with smaller bandwith, "
+    "at the cost of additional CPU load.";
+  useCompressionDescription.read_only = true;
+  node->declare_parameter(PARAM_USE_COMPRESSION, false, useCompressionDescription);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -52,6 +52,7 @@ public:
     _serviceWhitelistPatterns = parseRegexStrings(this, serviceWhiteList);
     const auto paramWhiteList = this->get_parameter(PARAM_PARAMETER_WHITELIST).as_string_array();
     const auto paramWhitelistPatterns = parseRegexStrings(this, paramWhiteList);
+    const auto useCompression = this->get_parameter(PARAM_USE_COMPRESSION).as_bool();
     _useSimTime = this->get_parameter("use_sim_time").as_bool();
 
     _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns);
@@ -71,6 +72,7 @@ public:
     serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
     serverOptions.sendBufferLimitBytes = send_buffer_limit;
     serverOptions.sessionId = std::to_string(std::time(nullptr));
+    serverOptions.useCompression = useCompression;
 
     if (useTLS) {
       serverOptions.certfile = certfile;


### PR DESCRIPTION
**Public-Facing Changes**
- Add option to use permessage-deflate compression


**Description**
- Add option to use permessage-deflate compression

Found out that this was possible when implementing #151. Not sure if it is really useful tho, the additional CPU load is quite high (I can provide some measurements on request)

