### PR TITLE
Add sessionId to serverInfo

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -194,6 +194,7 @@ struct ServerOptions {
   size_t sendBufferLimitBytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES;
   std::string certfile = "";
   std::string keyfile = "";
+  std::string sessionId;
 };
 
 template <typename ServerConfiguration>
@@ -376,6 +377,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
                    {"capabilities", _options.capabilities},
                    {"supportedEncodings", _options.supportedEncodings},
                    {"metadata", _options.metadata},
+                   {"sessionId", _options.sessionId},
                  })
               .dump());
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -53,6 +53,7 @@ public:
     const auto keyfile = nhp.param<std::string>("keyfile", "");
     _maxUpdateMs = static_cast<size_t>(nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS));
     _useSimTime = nhp.param<bool>("/use_sim_time", false);
+    const auto sessionId = nhp.param<std::string>("/run_id", std::to_string(std::time(0)));
 
     const auto topicWhitelistPatterns =
       nhp.param<std::vector<std::string>>("topic_whitelist", {".*"});
@@ -89,6 +90,7 @@ public:
       serverOptions.supportedEncodings = {ROS1_CHANNEL_ENCODING};
       serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
       serverOptions.sendBufferLimitBytes = send_buffer_limit;
+      serverOptions.sessionId = sessionId;
 
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -526,7 +526,7 @@ private:
 
     // Advertise new services
     std::vector<foxglove::ServiceWithoutId> newServices;
-    for (const auto serviceName : serviceNames) {
+    for (const auto& serviceName : serviceNames) {
       if (std::find_if(_advertisedServices.begin(), _advertisedServices.end(),
                        [&serviceName](const auto& idWithService) {
                          return idWithService.second.name == serviceName;

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -53,7 +53,7 @@ public:
     const auto keyfile = nhp.param<std::string>("keyfile", "");
     _maxUpdateMs = static_cast<size_t>(nhp.param<int>("max_update_ms", DEFAULT_MAX_UPDATE_MS));
     _useSimTime = nhp.param<bool>("/use_sim_time", false);
-    const auto sessionId = nhp.param<std::string>("/run_id", std::to_string(std::time(0)));
+    const auto sessionId = nhp.param<std::string>("/run_id", std::to_string(std::time(nullptr)));
 
     const auto topicWhitelistPatterns =
       nhp.param<std::vector<std::string>>("topic_whitelist", {".*"});

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -57,27 +57,28 @@ public:
     _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns);
 
     const auto logHandler = std::bind(&FoxgloveBridge::logHandler, this, _1, _2);
-    std::vector<std::string> serverCapabilities = {
+    foxglove::ServerOptions serverOptions;
+    serverOptions.capabilities = {
       foxglove::CAPABILITY_CLIENT_PUBLISH,
       foxglove::CAPABILITY_PARAMETERS,
       foxglove::CAPABILITY_PARAMETERS_SUBSCRIBE,
       foxglove::CAPABILITY_SERVICES,
     };
     if (_useSimTime) {
-      serverCapabilities.push_back(foxglove::CAPABILITY_TIME);
+      serverOptions.capabilities.push_back(foxglove::CAPABILITY_TIME);
     }
-    const std::vector<std::string> supportedEncodings = {"cdr"};
-    const std::unordered_map<std::string, std::string> metadata = {
-      {"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
+    serverOptions.supportedEncodings = {"cdr"};
+    serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
+    serverOptions.sendBufferLimitBytes = send_buffer_limit;
 
     if (useTLS) {
+      serverOptions.certfile = certfile;
+      serverOptions.keyfile = keyfile;
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings, metadata,
-        send_buffer_limit, certfile, keyfile);
+        "foxglove_bridge", std::move(logHandler), serverOptions);
     } else {
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-        "foxglove_bridge", std::move(logHandler), serverCapabilities, supportedEncodings, metadata,
-        send_buffer_limit);
+        "foxglove_bridge", std::move(logHandler), serverOptions);
     }
     _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));
     _server->setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2));

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -70,7 +70,7 @@ public:
     serverOptions.supportedEncodings = {"cdr"};
     serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
     serverOptions.sendBufferLimitBytes = send_buffer_limit;
-    serverOptions.sessionId = std::to_string(std::time(0));
+    serverOptions.sessionId = std::to_string(std::time(nullptr));
 
     if (useTLS) {
       serverOptions.certfile = certfile;

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -70,6 +70,7 @@ public:
     serverOptions.supportedEncodings = {"cdr"};
     serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
     serverOptions.sendBufferLimitBytes = send_buffer_limit;
+    serverOptions.sessionId = std::to_string(std::time(0));
 
     if (useTLS) {
       serverOptions.certfile = certfile;


### PR DESCRIPTION
**Public-Facing Changes**
- Add `sessionId` to `serverInfo`

**Description**
- Simplifies passing options to the server constructor (struct instead of individual params)
- Fixes a minor clang compilation error
- Add `sessionId` to `serverInfo`
  - ROS1: Use `/run_id` parameter and `std::time(0)` if the parameter is not set
  - ROS2: `std::time(0)`