### PR TITLE
Decouple server implementation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,6 +67,7 @@ add_library(foxglove_bridge_base SHARED
   foxglove_bridge_base/src/foxglove_bridge.cpp
   foxglove_bridge_base/src/parameter.cpp
   foxglove_bridge_base/src/serialization.cpp
+  foxglove_bridge_base/src/server_factory.cpp
   foxglove_bridge_base/src/test/test_client.cpp
 )
 target_include_directories(foxglove_bridge_base

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -29,6 +29,14 @@ enum class ClientBinaryOpcode : uint8_t {
   SERVICE_CALL_REQUEST = 2,
 };
 
+enum class WebSocketLogLevel {
+  Debug,
+  Info,
+  Warn,
+  Error,
+  Critical,
+};
+
 struct ChannelWithoutId {
   std::string topic;
   std::string encoding;

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -29,12 +29,64 @@ enum class ClientBinaryOpcode : uint8_t {
   SERVICE_CALL_REQUEST = 2,
 };
 
+struct ChannelWithoutId {
+  std::string topic;
+  std::string encoding;
+  std::string schemaName;
+  std::string schema;
+
+  bool operator==(const ChannelWithoutId& other) const {
+    return topic == other.topic && encoding == other.encoding && schemaName == other.schemaName &&
+           schema == other.schema;
+  }
+};
+
+struct Channel : ChannelWithoutId {
+  ChannelId id;
+
+  Channel() = default;  // requirement for json conversions.
+  Channel(ChannelId id, ChannelWithoutId ch)
+      : ChannelWithoutId(std::move(ch))
+      , id(id) {}
+
+  bool operator==(const Channel& other) const {
+    return id == other.id && ChannelWithoutId::operator==(other);
+  }
+};
+
 struct ClientAdvertisement {
   ClientChannelId channelId;
   std::string topic;
   std::string encoding;
   std::string schemaName;
   std::vector<uint8_t> schema;
+};
+
+struct ClientMessage {
+  uint64_t logTime;
+  uint64_t publishTime;
+  uint32_t sequence;
+  const ClientAdvertisement& advertisement;
+  size_t dataLength;
+  const uint8_t* data;
+
+  ClientMessage(uint64_t logTime, uint64_t publishTime, uint32_t sequence,
+                const ClientAdvertisement& advertisement, size_t dataLength, const uint8_t* data)
+      : logTime(logTime)
+      , publishTime(publishTime)
+      , sequence(sequence)
+      , advertisement(advertisement)
+      , dataLength(dataLength)
+      , data(data) {}
+
+  static const size_t MSG_PAYLOAD_OFFSET = 5;
+
+  const uint8_t* getData() const {
+    return data + MSG_PAYLOAD_OFFSET;
+  }
+  std::size_t getLength() const {
+    return dataLength - MSG_PAYLOAD_OFFSET;
+  }
 };
 
 struct ServiceWithoutId {

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -35,6 +35,17 @@ inline void WriteUint32LE(uint8_t* buf, uint32_t val) {
 #endif
 }
 
+inline uint32_t ReadUint32LE(const uint8_t* buf) {
+#ifdef ARCH_IS_BIG_ENDIAN
+  uint32_t val = (bytes[0] << 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3];
+  return val;
+#else
+  return reinterpret_cast<const uint32_t*>(buf)[0];
+#endif
+}
+
+void to_json(nlohmann::json& j, const Channel& c);
+void from_json(const nlohmann::json& j, Channel& c);
 void to_json(nlohmann::json& j, const Parameter& p);
 void from_json(const nlohmann::json& j, Parameter& p);
 void to_json(nlohmann::json& j, const Service& p);

--- a/foxglove_bridge_base/include/foxglove_bridge/server_factory.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_factory.hpp
@@ -1,0 +1,21 @@
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include <websocketpp/common/connection_hdl.hpp>
+
+#include "common.hpp"
+#include "server_interface.hpp"
+
+namespace foxglove {
+
+class ServerFactory {
+public:
+  template <typename ConnectionHandle>
+  static std::unique_ptr<ServerInterface<ConnectionHandle>> createServer(
+    const std::string& name, const std::function<void(WebSocketLogLevel, char const*)>& logHandler,
+    const ServerOptions& options);
+};
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -1,0 +1,75 @@
+#pragma once
+
+#include <functional>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+#include "common.hpp"
+#include "parameter.hpp"
+
+namespace foxglove {
+
+constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
+
+struct ServerOptions {
+  std::vector<std::string> capabilities;
+  std::vector<std::string> supportedEncodings;
+  std::unordered_map<std::string, std::string> metadata;
+  size_t sendBufferLimitBytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES;
+  std::string certfile = "";
+  std::string keyfile = "";
+  std::string sessionId;
+  bool useCompression = false;
+};
+
+template <typename ConnectionHandle>
+struct ServerHandlers {
+  std::function<void(ChannelId, ConnectionHandle)> subscribeHandler;
+  std::function<void(ChannelId, ConnectionHandle)> unsubscribeHandler;
+  std::function<void(const ClientAdvertisement&, ConnectionHandle)> clientAdvertiseHandler;
+  std::function<void(ClientChannelId, ConnectionHandle)> clientUnadvertiseHandler;
+  std::function<void(const ClientMessage&, ConnectionHandle)> clientMessageHandler;
+  std::function<void(const std::vector<std::string>&, const std::optional<std::string>&,
+                     ConnectionHandle)>
+    parameterRequestHandler;
+  std::function<void(const std::vector<Parameter>&, const std::optional<std::string>&,
+                     ConnectionHandle)>
+    parameterChangeHandler;
+  std::function<void(const std::vector<std::string>&, ParameterSubscriptionOperation,
+                     ConnectionHandle)>
+    parameterSubscriptionHandler;
+  std::function<void(const ServiceRequest&, ConnectionHandle)> serviceRequestHandler;
+};
+
+template <typename ConnectionHandle>
+class ServerInterface {
+public:
+  virtual ~ServerInterface() {}
+  virtual void start(const std::string& host, uint16_t port) = 0;
+  virtual void stop() = 0;
+
+  virtual ChannelId addChannel(ChannelWithoutId channel) = 0;
+  virtual void removeChannel(ChannelId chanId) = 0;
+  virtual void broadcastChannels() = 0;
+  virtual void publishParameterValues(ConnectionHandle clientHandle,
+                                      const std::vector<Parameter>& parameters,
+                                      const std::optional<std::string>& requestId) = 0;
+  virtual void updateParameterValues(const std::vector<Parameter>& parameters) = 0;
+  virtual std::vector<ServiceId> addServices(const std::vector<ServiceWithoutId>& services) = 0;
+  virtual void removeServices(const std::vector<ServiceId>& serviceIds) = 0;
+
+  virtual void setHandlers(ServerHandlers<ConnectionHandle>&& handlers) = 0;
+
+  virtual void sendMessage(ConnectionHandle clientHandle, ChannelId chanId, uint64_t timestamp,
+                           const uint8_t* payload, size_t payloadSize) = 0;
+  virtual void broadcastTime(uint64_t timestamp) = 0;
+  virtual void sendServiceResponse(ConnectionHandle clientHandle,
+                                   const ServiceResponse& response) = 0;
+
+  virtual uint16_t getPort() = 0;
+  virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;
+};
+
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -18,6 +18,7 @@ struct ServerOptions {
   std::vector<std::string> supportedEncodings;
   std::unordered_map<std::string, std::string> metadata;
   size_t sendBufferLimitBytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES;
+  bool useTls = false;
   std::string certfile = "";
   std::string keyfile = "";
   std::string sessionId;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
@@ -5,15 +5,9 @@
 #include <asio/ip/address.hpp>
 #include <websocketpp/logger/levels.hpp>
 
-namespace foxglove {
+#include "common.hpp"
 
-enum class WebSocketLogLevel {
-  Debug,
-  Info,
-  Warn,
-  Error,
-  Critical,
-};
+namespace foxglove {
 
 using LogCallback = std::function<void(WebSocketLogLevel, char const*)>;
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1109,7 +1109,4 @@ inline void Server<WebSocketTls>::setupTlsHandler() {
   });
 }
 
-extern template class Server<WebSocketTls>;
-extern template class Server<WebSocketNoTls>;
-
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -56,67 +56,6 @@ constexpr uint32_t Integer(const std::string_view str) {
   return result;
 }
 
-struct ChannelWithoutId {
-  std::string topic;
-  std::string encoding;
-  std::string schemaName;
-  std::string schema;
-
-  bool operator==(const ChannelWithoutId& other) const {
-    return topic == other.topic && encoding == other.encoding && schemaName == other.schemaName &&
-           schema == other.schema;
-  }
-};
-
-struct Channel : ChannelWithoutId {
-  ChannelId id;
-
-  explicit Channel(ChannelId id, ChannelWithoutId ch)
-      : ChannelWithoutId(std::move(ch))
-      , id(id) {}
-
-  friend void to_json(json& j, const Channel& channel) {
-    j = {
-      {"id", channel.id},
-      {"topic", channel.topic},
-      {"encoding", channel.encoding},
-      {"schemaName", channel.schemaName},
-      {"schema", channel.schema},
-    };
-  }
-
-  bool operator==(const Channel& other) const {
-    return id == other.id && ChannelWithoutId::operator==(other);
-  }
-};
-
-struct ClientMessage {
-  uint64_t logTime;
-  uint64_t publishTime;
-  uint32_t sequence;
-  const ClientAdvertisement& advertisement;
-  size_t dataLength;
-  const uint8_t* data;
-
-  ClientMessage(uint64_t logTime, uint64_t publishTime, uint32_t sequence,
-                const ClientAdvertisement& advertisement, size_t dataLength, const uint8_t* data)
-      : logTime(logTime)
-      , publishTime(publishTime)
-      , sequence(sequence)
-      , advertisement(advertisement)
-      , dataLength(dataLength)
-      , data(data) {}
-
-  static const size_t MSG_PAYLOAD_OFFSET = 5;
-
-  const uint8_t* getData() const {
-    return data + MSG_PAYLOAD_OFFSET;
-  }
-  std::size_t getLength() const {
-    return dataLength - MSG_PAYLOAD_OFFSET;
-  }
-};
-
 enum class StatusLevel : uint8_t {
   Info = 0,
   Warning = 1,

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -19,6 +19,7 @@
 #include "common.hpp"
 #include "parameter.hpp"
 #include "serialization.hpp"
+#include "server_interface.hpp"
 #include "websocket_logging.hpp"
 #include "websocket_notls.hpp"
 #include "websocket_tls.hpp"
@@ -46,8 +47,6 @@ static const websocketpp::log::level APP = websocketpp::log::alevel::app;
 static const websocketpp::log::level WARNING = websocketpp::log::elevel::warn;
 static const websocketpp::log::level RECOVERABLE = websocketpp::log::elevel::rerror;
 
-constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
-
 constexpr uint32_t Integer(const std::string_view str) {
   uint32_t result = 0x811C9DC5;  // FNV-1a 32-bit algorithm
   for (char c : str) {
@@ -74,65 +73,6 @@ constexpr const char* StatusLevelToString(StatusLevel level) {
       return "UNKNOWN";
   }
 }
-
-template <typename ConnectionHandle>
-struct ServerHandlers {
-  std::function<void(ChannelId, ConnectionHandle)> subscribeHandler;
-  std::function<void(ChannelId, ConnectionHandle)> unsubscribeHandler;
-  std::function<void(const ClientAdvertisement&, ConnectionHandle)> clientAdvertiseHandler;
-  std::function<void(ClientChannelId, ConnectionHandle)> clientUnadvertiseHandler;
-  std::function<void(const ClientMessage&, ConnectionHandle)> clientMessageHandler;
-  std::function<void(const std::vector<std::string>&, const std::optional<std::string>&,
-                     ConnectionHandle)>
-    parameterRequestHandler;
-  std::function<void(const std::vector<Parameter>&, const std::optional<std::string>&,
-                     ConnectionHandle)>
-    parameterChangeHandler;
-  std::function<void(const std::vector<std::string>&, ParameterSubscriptionOperation,
-                     ConnectionHandle)>
-    parameterSubscriptionHandler;
-  std::function<void(const ServiceRequest&, ConnectionHandle)> serviceRequestHandler;
-};
-
-template <typename ConnectionHandle>
-class ServerInterface {
-public:
-  virtual ~ServerInterface() {}
-  virtual void start(const std::string& host, uint16_t port) = 0;
-  virtual void stop() = 0;
-
-  virtual ChannelId addChannel(ChannelWithoutId channel) = 0;
-  virtual void removeChannel(ChannelId chanId) = 0;
-  virtual void broadcastChannels() = 0;
-  virtual void publishParameterValues(ConnectionHandle clientHandle,
-                                      const std::vector<Parameter>& parameters,
-                                      const std::optional<std::string>& requestId) = 0;
-  virtual void updateParameterValues(const std::vector<Parameter>& parameters) = 0;
-  virtual std::vector<ServiceId> addServices(const std::vector<ServiceWithoutId>& services) = 0;
-  virtual void removeServices(const std::vector<ServiceId>& serviceIds) = 0;
-
-  virtual void setHandlers(ServerHandlers<ConnectionHandle>&& handlers) = 0;
-
-  virtual void sendMessage(ConnectionHandle clientHandle, ChannelId chanId, uint64_t timestamp,
-                           const uint8_t* payload, size_t payloadSize) = 0;
-  virtual void broadcastTime(uint64_t timestamp) = 0;
-  virtual void sendServiceResponse(ConnectionHandle clientHandle,
-                                   const ServiceResponse& response) = 0;
-
-  virtual uint16_t getPort() = 0;
-  virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;
-};
-
-struct ServerOptions {
-  std::vector<std::string> capabilities;
-  std::vector<std::string> supportedEncodings;
-  std::unordered_map<std::string, std::string> metadata;
-  size_t sendBufferLimitBytes = DEFAULT_SEND_BUFFER_LIMIT_BYTES;
-  std::string certfile = "";
-  std::string keyfile = "";
-  std::string sessionId;
-  bool useCompression = false;
-};
 
 template <typename ServerConfiguration>
 class Server final : public ServerInterface<ConnHandle> {

--- a/foxglove_bridge_base/src/foxglove_bridge.cpp
+++ b/foxglove_bridge_base/src/foxglove_bridge.cpp
@@ -1,18 +1,11 @@
 #include "foxglove_bridge/foxglove_bridge.hpp"
 
-#define ASIO_STANDALONE
-#include "foxglove_bridge/websocket_notls.hpp"
-#include "foxglove_bridge/websocket_server.hpp"
-#include "foxglove_bridge/websocket_tls.hpp"
+#include "websocketpp/version.hpp"
 
 namespace foxglove {
 
 const char* WebSocketUserAgent() {
   return websocketpp::user_agent;
 }
-
-// Explicit template instantiation for common server configurations
-template class Server<WebSocketTls>;
-template class Server<WebSocketNoTls>;
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -2,6 +2,25 @@
 
 namespace foxglove {
 
+void to_json(nlohmann::json& j, const Channel& c) {
+  j = {
+    {"id", c.id},
+    {"topic", c.topic},
+    {"encoding", c.encoding},
+    {"schemaName", c.schemaName},
+    {"schema", c.schema},
+  };
+}
+void from_json(const nlohmann::json& j, Channel& c) {
+  ChannelWithoutId channelWithoutId{
+    j["topic"].get<std::string>(),
+    j["encoding"].get<std::string>(),
+    j["schemaName"].get<std::string>(),
+    j["schema"].get<std::string>(),
+  };
+  c = Channel(j["id"].get<ChannelId>(), channelWithoutId);
+}
+
 void to_json(nlohmann::json& j, const Parameter& p) {
   const auto paramType = p.getType();
   if (paramType == ParameterType::PARAMETER_BOOL) {
@@ -88,15 +107,6 @@ void from_json(const nlohmann::json& j, Service& p) {
   p.type = j["type"].get<std::string>();
   p.requestSchema = j["requestSchema"].get<std::string>();
   p.responseSchema = j["responseSchema"].get<std::string>();
-}
-
-inline uint32_t ReadUint32LE(const uint8_t* buf) {
-#ifdef ARCH_IS_BIG_ENDIAN
-  uint32_t val = (bytes[0] << 24) + (bytes[1] << 16) + (bytes[2] << 8) + bytes[3];
-  return val;
-#else
-  return reinterpret_cast<const uint32_t*>(buf)[0];
-#endif
 }
 
 void ServiceResponse::read(const uint8_t* data, size_t dataLength) {

--- a/foxglove_bridge_base/src/server_factory.cpp
+++ b/foxglove_bridge_base/src/server_factory.cpp
@@ -1,0 +1,21 @@
+#include <websocketpp/common/connection_hdl.hpp>
+
+#include <foxglove_bridge/server_factory.hpp>
+
+#define ASIO_STANDALONE
+#include <foxglove_bridge/websocket_server.hpp>
+
+namespace foxglove {
+
+template <>
+std::unique_ptr<ServerInterface<websocketpp::connection_hdl>> ServerFactory::createServer(
+  const std::string& name, const std::function<void(WebSocketLogLevel, char const*)>& logHandler,
+  const ServerOptions& options) {
+  if (options.useTls) {
+    return std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(name, logHandler, options);
+  } else {
+    return std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(name, logHandler, options);
+  }
+}
+
+}  // namespace foxglove

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -106,7 +106,7 @@ public:
           "foxglove_bridge", std::move(logHandler), serverOptions);
       }
 
-      foxglove::ServerHandlers hdlrs;
+      foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
       hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this,
                                          std::placeholders::_1, std::placeholders::_2);
       hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this,
@@ -763,7 +763,7 @@ private:
     }
   }
 
-  std::unique_ptr<foxglove::ServerInterface> _server;
+  std::unique_ptr<foxglove::ServerInterface<foxglove::ConnHandle>> _server;
   ros_babel_fish::IntegratedDescriptionProvider _rosTypeInfoProvider;
   std::vector<std::regex> _topicWhitelistPatterns;
   std::vector<std::regex> _paramWhitelistPatterns;

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -106,28 +106,29 @@ public:
           "foxglove_bridge", std::move(logHandler), serverOptions);
       }
 
-      _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this,
-                                             std::placeholders::_1, std::placeholders::_2));
-      _server->setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this,
-                                               std::placeholders::_1, std::placeholders::_2));
-      _server->setClientAdvertiseHandler(std::bind(&FoxgloveBridge::clientAdvertiseHandler, this,
-                                                   std::placeholders::_1, std::placeholders::_2));
-      _server->setClientUnadvertiseHandler(std::bind(&FoxgloveBridge::clientUnadvertiseHandler,
-                                                     this, std::placeholders::_1,
-                                                     std::placeholders::_2));
-      _server->setClientMessageHandler(std::bind(&FoxgloveBridge::clientMessageHandler, this,
-                                                 std::placeholders::_1, std::placeholders::_2));
-      _server->setParameterRequestHandler(std::bind(&FoxgloveBridge::parameterRequestHandler, this,
-                                                    std::placeholders::_1, std::placeholders::_2,
-                                                    std::placeholders::_3));
-      _server->setParameterChangeHandler(std::bind(&FoxgloveBridge::parameterChangeHandler, this,
-                                                   std::placeholders::_1, std::placeholders::_2,
-                                                   std::placeholders::_3));
-      _server->setParameterSubscriptionHandler(
+      foxglove::ServerHandlers hdlrs;
+      hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this,
+                                         std::placeholders::_1, std::placeholders::_2);
+      hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this,
+                                           std::placeholders::_1, std::placeholders::_2);
+      hdlrs.clientAdvertiseHandler = std::bind(&FoxgloveBridge::clientAdvertiseHandler, this,
+                                               std::placeholders::_1, std::placeholders::_2);
+      hdlrs.clientUnadvertiseHandler = std::bind(&FoxgloveBridge::clientUnadvertiseHandler, this,
+                                                 std::placeholders::_1, std::placeholders::_2);
+      hdlrs.clientMessageHandler = std::bind(&FoxgloveBridge::clientMessageHandler, this,
+                                             std::placeholders::_1, std::placeholders::_2);
+      hdlrs.parameterRequestHandler =
+        std::bind(&FoxgloveBridge::parameterRequestHandler, this, std::placeholders::_1,
+                  std::placeholders::_2, std::placeholders::_3);
+      hdlrs.parameterChangeHandler =
+        std::bind(&FoxgloveBridge::parameterChangeHandler, this, std::placeholders::_1,
+                  std::placeholders::_2, std::placeholders::_3);
+      hdlrs.parameterSubscriptionHandler =
         std::bind(&FoxgloveBridge::parameterSubscriptionHandler, this, std::placeholders::_1,
-                  std::placeholders::_2, std::placeholders::_3));
-      _server->setServiceRequestHandler(std::bind(&FoxgloveBridge::serviceRequestHandler, this,
-                                                  std::placeholders::_1, std::placeholders::_2));
+                  std::placeholders::_2, std::placeholders::_3);
+      hdlrs.serviceRequestHandler = std::bind(&FoxgloveBridge::serviceRequestHandler, this,
+                                              std::placeholders::_1, std::placeholders::_2);
+      _server->setHandlers(std::move(hdlrs));
 
       _server->start(address, static_cast<uint16_t>(port));
 

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -1,5 +1,3 @@
-#define ASIO_STANDALONE
-
 #include <functional>
 #include <memory>
 #include <mutex>
@@ -16,10 +14,12 @@
 #include <ros_babel_fish/babel_fish_message.h>
 #include <ros_babel_fish/generation/providers/integrated_description_provider.h>
 #include <rosgraph_msgs/Clock.h>
+#include <websocketpp/common/connection_hdl.hpp>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
 #include <foxglove_bridge/generic_service.hpp>
 #include <foxglove_bridge/param_utils.hpp>
+#include <foxglove_bridge/server_factory.hpp>
 #include <foxglove_bridge/service_utils.hpp>
 #include <foxglove_bridge/websocket_server.hpp>
 
@@ -34,10 +34,11 @@ constexpr double MIN_UPDATE_PERIOD_MS = 100.0;
 constexpr uint32_t PUBLICATION_QUEUE_LENGTH = 10;
 constexpr int SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS = 250;
 
+using ConnectionHandle = websocketpp::connection_hdl;
 using TopicAndDatatype = std::pair<std::string, std::string>;
-using SubscriptionsByClient = std::map<foxglove::ConnHandle, ros::Subscriber, std::owner_less<>>;
+using SubscriptionsByClient = std::map<ConnectionHandle, ros::Subscriber, std::owner_less<>>;
 using ClientPublications = std::unordered_map<foxglove::ClientChannelId, ros::Publisher>;
-using PublicationsByClient = std::map<foxglove::ConnHandle, ClientPublications, std::owner_less<>>;
+using PublicationsByClient = std::map<ConnectionHandle, ClientPublications, std::owner_less<>>;
 
 class FoxgloveBridge : public nodelet::Nodelet {
 public:
@@ -92,21 +93,18 @@ public:
       serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
       serverOptions.sendBufferLimitBytes = send_buffer_limit;
       serverOptions.sessionId = sessionId;
+      serverOptions.useTls = useTLS;
+      serverOptions.certfile = certfile;
+      serverOptions.keyfile = keyfile;
       serverOptions.useCompression = useCompression;
 
       const auto logHandler =
         std::bind(&FoxgloveBridge::logHandler, this, std::placeholders::_1, std::placeholders::_2);
-      if (useTLS) {
-        serverOptions.certfile = certfile;
-        serverOptions.keyfile = keyfile;
-        _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-          "foxglove_bridge", std::move(logHandler), serverOptions);
-      } else {
-        _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-          "foxglove_bridge", std::move(logHandler), serverOptions);
-      }
 
-      foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
+      _server = foxglove::ServerFactory::createServer<ConnectionHandle>("foxglove_bridge",
+                                                                        logHandler, serverOptions);
+
+      foxglove::ServerHandlers<ConnectionHandle> hdlrs;
       hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this,
                                          std::placeholders::_1, std::placeholders::_2);
       hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this,
@@ -165,7 +163,7 @@ private:
     }
   };
 
-  void subscribeHandler(foxglove::ChannelId channelId, foxglove::ConnHandle clientHandle) {
+  void subscribeHandler(foxglove::ChannelId channelId, ConnectionHandle clientHandle) {
     std::lock_guard<std::mutex> lock(_subscriptionsMutex);
 
     auto it = _channelToTopicAndDatatype.find(channelId);
@@ -215,7 +213,7 @@ private:
     }
   }
 
-  void unsubscribeHandler(foxglove::ChannelId channelId, foxglove::ConnHandle clientHandle) {
+  void unsubscribeHandler(foxglove::ChannelId channelId, ConnectionHandle clientHandle) {
     std::lock_guard<std::mutex> lock(_subscriptionsMutex);
 
     auto it = _channelToTopicAndDatatype.find(channelId);
@@ -258,7 +256,7 @@ private:
   }
 
   void clientAdvertiseHandler(const foxglove::ClientAdvertisement& channel,
-                              foxglove::ConnHandle clientHandle) {
+                              ConnectionHandle clientHandle) {
     if (channel.encoding != ROS1_CHANNEL_ENCODING) {
       ROS_ERROR("Unsupported encoding. Only '%s' encoding is supported at the moment.",
                 ROS1_CHANNEL_ENCODING);
@@ -309,7 +307,7 @@ private:
   }
 
   void clientUnadvertiseHandler(foxglove::ClientChannelId channelId,
-                                foxglove::ConnHandle clientHandle) {
+                                ConnectionHandle clientHandle) {
     std::unique_lock<std::shared_mutex> lock(_publicationsMutex);
 
     auto clientPublicationsIt = _clientAdvertisedTopics.find(clientHandle);
@@ -344,7 +342,7 @@ private:
   }
 
   void clientMessageHandler(const foxglove::ClientMessage& clientMsg,
-                            foxglove::ConnHandle clientHandle) {
+                            ConnectionHandle clientHandle) {
     ros_babel_fish::BabelFishMessage::Ptr msg(new ros_babel_fish::BabelFishMessage);
     msg->read(clientMsg);
 
@@ -574,8 +572,7 @@ private:
   }
 
   void parameterRequestHandler(const std::vector<std::string>& parameters,
-                               const std::optional<std::string>& requestId,
-                               foxglove::ConnHandle hdl) {
+                               const std::optional<std::string>& requestId, ConnectionHandle hdl) {
     std::vector<std::string> parameterNames = parameters;
     if (parameterNames.empty()) {
       getMTNodeHandle().getParamNames(parameterNames);
@@ -601,8 +598,7 @@ private:
   }
 
   void parameterChangeHandler(const std::vector<foxglove::Parameter>& parameters,
-                              const std::optional<std::string>& requestId,
-                              foxglove::ConnHandle hdl) {
+                              const std::optional<std::string>& requestId, ConnectionHandle hdl) {
     using foxglove::ParameterType;
     auto nh = this->getMTNodeHandle();
     for (const auto& param : parameters) {
@@ -647,8 +643,7 @@ private:
   }
 
   void parameterSubscriptionHandler(const std::vector<std::string>& parameters,
-                                    foxglove::ParameterSubscriptionOperation op,
-                                    foxglove::ConnHandle) {
+                                    foxglove::ParameterSubscriptionOperation op, ConnectionHandle) {
     for (const auto& paramName : parameters) {
       if (!isWhitelisted(paramName, _paramWhitelistPatterns)) {
         ROS_WARN("Parameter '%s' is not whitelisted", paramName.c_str());
@@ -714,7 +709,7 @@ private:
   }
 
   void rosMessageHandler(
-    const foxglove::Channel& channel, foxglove::ConnHandle clientHandle,
+    const foxglove::Channel& channel, ConnectionHandle clientHandle,
     const ros::MessageEvent<ros_babel_fish::BabelFishMessage const>& msgEvent) {
     const auto& msg = msgEvent.getConstMessage();
     const auto receiptTimeNs = msgEvent.getReceiptTime().toNSec();
@@ -722,7 +717,7 @@ private:
   }
 
   void serviceRequestHandler(const foxglove::ServiceRequest& request,
-                             foxglove::ConnHandle clientHandle) {
+                             ConnectionHandle clientHandle) {
     std::shared_lock<std::shared_mutex> lock(_servicesMutex);
     const auto serviceIt = _advertisedServices.find(request.serviceId);
     if (serviceIt == _advertisedServices.end()) {
@@ -763,7 +758,7 @@ private:
     }
   }
 
-  std::unique_ptr<foxglove::ServerInterface<foxglove::ConnHandle>> _server;
+  std::unique_ptr<foxglove::ServerInterface<ConnectionHandle>> _server;
   ros_babel_fish::IntegratedDescriptionProvider _rosTypeInfoProvider;
   std::vector<std::regex> _topicWhitelistPatterns;
   std::vector<std::regex> _paramWhitelistPatterns;

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -83,22 +83,22 @@ public:
       _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
         "foxglove_bridge", std::move(logHandler), serverOptions);
     }
-    _server->setSubscribeHandler(std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2));
-    _server->setUnsubscribeHandler(std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2));
-    _server->setClientAdvertiseHandler(
-      std::bind(&FoxgloveBridge::clientAdvertiseHandler, this, _1, _2));
-    _server->setClientUnadvertiseHandler(
-      std::bind(&FoxgloveBridge::clientUnadvertiseHandler, this, _1, _2));
-    _server->setClientMessageHandler(
-      std::bind(&FoxgloveBridge::clientMessageHandler, this, _1, _2));
-    _server->setParameterRequestHandler(
-      std::bind(&FoxgloveBridge::parameterRequestHandler, this, _1, _2, _3));
-    _server->setParameterChangeHandler(
-      std::bind(&FoxgloveBridge::parameterChangeHandler, this, _1, _2, _3));
-    _server->setParameterSubscriptionHandler(
-      std::bind(&FoxgloveBridge::parameterSubscriptionHandler, this, _1, _2, _3));
-    _server->setServiceRequestHandler(
-      std::bind(&FoxgloveBridge::serviceRequestHandler, this, _1, _2));
+
+    foxglove::ServerHandlers hdlrs;
+    hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2);
+    hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2);
+    hdlrs.clientAdvertiseHandler = std::bind(&FoxgloveBridge::clientAdvertiseHandler, this, _1, _2);
+    hdlrs.clientUnadvertiseHandler =
+      std::bind(&FoxgloveBridge::clientUnadvertiseHandler, this, _1, _2);
+    hdlrs.clientMessageHandler = std::bind(&FoxgloveBridge::clientMessageHandler, this, _1, _2);
+    hdlrs.parameterRequestHandler =
+      std::bind(&FoxgloveBridge::parameterRequestHandler, this, _1, _2, _3);
+    hdlrs.parameterChangeHandler =
+      std::bind(&FoxgloveBridge::parameterChangeHandler, this, _1, _2, _3);
+    hdlrs.parameterSubscriptionHandler =
+      std::bind(&FoxgloveBridge::parameterSubscriptionHandler, this, _1, _2, _3);
+    hdlrs.serviceRequestHandler = std::bind(&FoxgloveBridge::serviceRequestHandler, this, _1, _2);
+    _server->setHandlers(std::move(hdlrs));
 
     _paramInterface->setParamUpdateCallback(std::bind(&FoxgloveBridge::parameterUpdates, this, _1));
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -6,24 +6,24 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
-
-#define ASIO_STANDALONE
+#include <websocketpp/common/connection_hdl.hpp>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
 #include <foxglove_bridge/generic_client.hpp>
 #include <foxglove_bridge/message_definition_cache.hpp>
 #include <foxglove_bridge/param_utils.hpp>
 #include <foxglove_bridge/parameter_interface.hpp>
-#include <foxglove_bridge/websocket_server.hpp>
+#include <foxglove_bridge/server_factory.hpp>
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
+using ConnectionHandle = websocketpp::connection_hdl;
 using LogLevel = foxglove::WebSocketLogLevel;
 using Subscription = rclcpp::GenericSubscription::SharedPtr;
-using SubscriptionsByClient = std::map<foxglove::ConnHandle, Subscription, std::owner_less<>>;
+using SubscriptionsByClient = std::map<ConnectionHandle, Subscription, std::owner_less<>>;
 using Publication = rclcpp::GenericPublisher::SharedPtr;
 using ClientPublications = std::unordered_map<foxglove::ClientChannelId, Publication>;
-using PublicationsByClient = std::map<foxglove::ConnHandle, ClientPublications, std::owner_less<>>;
+using PublicationsByClient = std::map<ConnectionHandle, ClientPublications, std::owner_less<>>;
 
 namespace foxglove_bridge {
 
@@ -73,18 +73,14 @@ public:
     serverOptions.sendBufferLimitBytes = send_buffer_limit;
     serverOptions.sessionId = std::to_string(std::time(nullptr));
     serverOptions.useCompression = useCompression;
+    serverOptions.useTls = useTLS;
+    serverOptions.certfile = certfile;
+    serverOptions.keyfile = keyfile;
 
-    if (useTLS) {
-      serverOptions.certfile = certfile;
-      serverOptions.keyfile = keyfile;
-      _server = std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(
-        "foxglove_bridge", std::move(logHandler), serverOptions);
-    } else {
-      _server = std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(
-        "foxglove_bridge", std::move(logHandler), serverOptions);
-    }
+    _server = foxglove::ServerFactory::createServer<ConnectionHandle>("foxglove_bridge", logHandler,
+                                                                      serverOptions);
 
-    foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
+    foxglove::ServerHandlers<ConnectionHandle> hdlrs;
     hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2);
     hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2);
     hdlrs.clientAdvertiseHandler = std::bind(&FoxgloveBridge::clientAdvertiseHandler, this, _1, _2);
@@ -377,7 +373,7 @@ private:
     }
   };
 
-  std::unique_ptr<foxglove::ServerInterface<foxglove::ConnHandle>> _server;
+  std::unique_ptr<foxglove::ServerInterface<ConnectionHandle>> _server;
   foxglove::MessageDefinitionCache _messageDefinitionCache;
   std::vector<std::regex> _topicWhitelistPatterns;
   std::vector<std::regex> _serviceWhitelistPatterns;
@@ -399,7 +395,7 @@ private:
   std::shared_ptr<rclcpp::Subscription<rosgraph_msgs::msg::Clock>> _clockSubscription;
   bool _useSimTime = false;
 
-  void subscribeHandler(foxglove::ChannelId channelId, foxglove::ConnHandle clientHandle) {
+  void subscribeHandler(foxglove::ChannelId channelId, ConnectionHandle clientHandle) {
     std::lock_guard<std::mutex> lock(_subscriptionsMutex);
     auto it = _channelToTopicAndDatatype.find(channelId);
     if (it == _channelToTopicAndDatatype.end()) {
@@ -509,7 +505,7 @@ private:
     }
   }
 
-  void unsubscribeHandler(foxglove::ChannelId channelId, foxglove::ConnHandle clientHandle) {
+  void unsubscribeHandler(foxglove::ChannelId channelId, ConnectionHandle clientHandle) {
     std::lock_guard<std::mutex> lock(_subscriptionsMutex);
 
     auto it = _channelToTopicAndDatatype.find(channelId);
@@ -557,7 +553,7 @@ private:
   }
 
   void clientAdvertiseHandler(const foxglove::ClientAdvertisement& advertisement,
-                              foxglove::ConnHandle hdl) {
+                              ConnectionHandle hdl) {
     std::lock_guard<std::mutex> lock(_clientAdvertisementsMutex);
 
     // Get client publications or insert an empty map.
@@ -590,7 +586,7 @@ private:
     clientPublications.emplace(advertisement.channelId, std::move(publisher));
   }
 
-  void clientUnadvertiseHandler(foxglove::ChannelId channelId, foxglove::ConnHandle hdl) {
+  void clientUnadvertiseHandler(foxglove::ChannelId channelId, ConnectionHandle hdl) {
     std::lock_guard<std::mutex> lock(_clientAdvertisementsMutex);
 
     auto it = _clientAdvertisedTopics.find(hdl);
@@ -624,7 +620,7 @@ private:
     }
   }
 
-  void clientMessageHandler(const foxglove::ClientMessage& message, foxglove::ConnHandle hdl) {
+  void clientMessageHandler(const foxglove::ClientMessage& message, ConnectionHandle hdl) {
     // Get the publisher
     rclcpp::GenericPublisher::SharedPtr publisher;
     {
@@ -664,8 +660,7 @@ private:
   }
 
   void parameterChangeHandler(const std::vector<foxglove::Parameter>& parameters,
-                              const std::optional<std::string>& requestId,
-                              foxglove::ConnHandle hdl) {
+                              const std::optional<std::string>& requestId, ConnectionHandle hdl) {
     _paramInterface->setParams(parameters, std::chrono::seconds(5));
 
     // If a request Id was given, send potentially updated parameters back to client
@@ -679,15 +674,13 @@ private:
   }
 
   void parameterRequestHandler(const std::vector<std::string>& parameters,
-                               const std::optional<std::string>& requestId,
-                               foxglove::ConnHandle hdl) {
+                               const std::optional<std::string>& requestId, ConnectionHandle hdl) {
     const auto params = _paramInterface->getParams(parameters, std::chrono::seconds(5));
     _server->publishParameterValues(hdl, params, requestId);
   }
 
   void parameterSubscriptionHandler(const std::vector<std::string>& parameters,
-                                    foxglove::ParameterSubscriptionOperation op,
-                                    foxglove::ConnHandle) {
+                                    foxglove::ParameterSubscriptionOperation op, ConnectionHandle) {
     if (op == foxglove::ParameterSubscriptionOperation::SUBSCRIBE) {
       _paramInterface->subscribeParams(parameters);
     } else {
@@ -719,7 +712,7 @@ private:
     }
   }
 
-  void rosMessageHandler(const foxglove::Channel& channel, foxglove::ConnHandle clientHandle,
+  void rosMessageHandler(const foxglove::Channel& channel, ConnectionHandle clientHandle,
                          std::shared_ptr<rclcpp::SerializedMessage> msg) {
     // NOTE: Do not call any RCLCPP_* logging functions from this function. Otherwise, subscribing
     // to `/rosout` will cause a feedback loop
@@ -731,7 +724,7 @@ private:
   }
 
   void serviceRequestHandler(const foxglove::ServiceRequest& request,
-                             foxglove::ConnHandle clientHandle) {
+                             ConnectionHandle clientHandle) {
     RCLCPP_DEBUG(this->get_logger(), "Received a request for service %d", request.serviceId);
 
     std::lock_guard<std::mutex> lock(_servicesMutex);

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -84,7 +84,7 @@ public:
         "foxglove_bridge", std::move(logHandler), serverOptions);
     }
 
-    foxglove::ServerHandlers hdlrs;
+    foxglove::ServerHandlers<foxglove::ConnHandle> hdlrs;
     hdlrs.subscribeHandler = std::bind(&FoxgloveBridge::subscribeHandler, this, _1, _2);
     hdlrs.unsubscribeHandler = std::bind(&FoxgloveBridge::unsubscribeHandler, this, _1, _2);
     hdlrs.clientAdvertiseHandler = std::bind(&FoxgloveBridge::clientAdvertiseHandler, this, _1, _2);
@@ -377,7 +377,7 @@ private:
     }
   };
 
-  std::unique_ptr<foxglove::ServerInterface> _server;
+  std::unique_ptr<foxglove::ServerInterface<foxglove::ConnHandle>> _server;
   foxglove::MessageDefinitionCache _messageDefinitionCache;
   std::vector<std::regex> _topicWhitelistPatterns;
   std::vector<std::regex> _serviceWhitelistPatterns;

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -105,7 +105,7 @@ public:
     _server->start(address, port);
 
     // Get the actual port we bound to
-    uint16_t listeningPort = _server->localEndpoint()->port();
+    uint16_t listeningPort = _server->getPort();
     if (port != listeningPort) {
       RCLCPP_DEBUG(this->get_logger(), "Reassigning \"port\" parameter from %d to %d", port,
                    listeningPort);


### PR DESCRIPTION
**Public-Facing Changes**
None

**Description**
This PR is a major refactoring that reduces the coupling between the websocket server implementation (websocketpp / nlohmann::json) and the ROS node side. The main benefits are:
  - Reduced compilation times
  - More abstract ServerInterface (makes it easier to use another websocket library, if we ever want to do that)
  - Cleaner code (IMO)

For reviewing, I would recommend to view the diff of each commit individually rather than viewing the full diff