### PR TITLE
Improve launch file documentation, add missing launch file arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,33 @@ To run the bridge node, it is recommended to use the provided launch file:
 **ROS 1**
 
 ```bash
-$ roslaunch foxglove_bridge foxglove_bridge.launch --screen
+$ roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
+```
+
+```xml
+<launch>
+  <!-- Including in another launch file -->
+  <include file="$(find foxglove_bridge)/launch/foxglove_bridge.launch">
+    <arg name="port" value="8765" />
+    <!-- ... other arguments ... -->
+  </include>
+</launch>
 ```
 
 **ROS 2**
 
 ```bash
-$ ros2 launch foxglove_bridge foxglove_bridge_launch.xml
+$ ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
+```
+
+```xml
+<launch>
+  <!-- Including in another launch file -->
+  <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml"/>
+    <arg name="port" value="8765"/>
+    <!-- ... other arguments ... -->
+  </include>
+</launch>
 ```
 
 ### Configuration

--- a/ros1_foxglove_bridge/launch/foxglove_bridge.launch
+++ b/ros1_foxglove_bridge/launch/foxglove_bridge.launch
@@ -5,8 +5,10 @@
   <arg name="certfile"                  default="" />
   <arg name="keyfile"                   default="" />
   <arg name="topic_whitelist"           default="['.*']" />
+  <arg name="param_whitelist"           default="['.*']" />
+  <arg name="service_whitelist"         default="['.*']" />
   <arg name="max_update_ms"             default="5000" />
-
+  <arg name="send_buffer_limit"         default="10000000" />
   <arg name="nodelet_manager"           default="foxglove_nodelet_manager" />
   <arg name="num_threads"               default="0" />
 
@@ -23,7 +25,10 @@
     <param name="certfile"            type="string"     value="$(arg certfile)" />
     <param name="keyfile"             type="string"     value="$(arg keyfile)" />
     <param name="max_update_ms"       type="int"        value="$(arg max_update_ms)" />
+    <param name="send_buffer_limit"   type="int"        value="$(arg send_buffer_limit)" />
 
-    <rosparam param="topic_whitelist" subst_value="True">$(arg topic_whitelist)</rosparam>
+    <rosparam param="topic_whitelist"   subst_value="True">$(arg topic_whitelist)</rosparam>
+    <rosparam param="param_whitelist"   subst_value="True">$(arg param_whitelist)</rosparam>
+    <rosparam param="service_whitelist" subst_value="True">$(arg service_whitelist)</rosparam>
   </node>
 </launch>

--- a/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
+++ b/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
@@ -5,8 +5,11 @@
   <arg name="certfile"                  default="" />
   <arg name="keyfile"                   default="" />
   <arg name="topic_whitelist"           default="'.*'" />
+  <arg name="param_whitelist"           default="'.*'" />
+  <arg name="service_whitelist"         default="'.*'" />
   <arg name="max_qos_depth"             default="10" />
   <arg name="num_threads"               default="0" />
+  <arg name="send_buffer_limit"         default="10000000" />
   <arg name="use_sim_time"              default="false" />
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge">
@@ -16,8 +19,11 @@
     <param name="certfile"              value="$(var certfile)" />
     <param name="keyfile"               value="$(var keyfile)" />
     <param name="topic_whitelist"       value="$(var topic_whitelist)"      value-sep="," />
+    <param name="service_whitelist"     value="$(var service_whitelist)"    value-sep="," />
+    <param name="param_whitelist"       value="$(var param_whitelist)"      value-sep="," />
     <param name="max_qos_depth"         value="$(var max_qos_depth)" />
     <param name="num_threads"           value="$(var num_threads)" />
+    <param name="send_buffer_limit"     value="$(var send_buffer_limit)" />
     <param name="use_sim_time"          value="$(var use_sim_time)" />
   </node>
 </launch>


### PR DESCRIPTION
**Public-Facing Changes**
- Add missing launch file arguments
- Improve launch file documentation


**Description**
Adds missing launch file arguments and adds some documentation on how to pass arguments to the launch file when launching via CLI or when included in another launch file.


Fixes #157 ([FG-1854](https://linear.app/foxglove/issue/FG-1854/docs-are-a-little-sparse-on-configuration-[foxgloveros-foxglove-bridge))
