### PR TITLE
Run client handler functions in separate thread

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <cstring>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -74,26 +75,28 @@ struct ClientMessage {
   uint64_t logTime;
   uint64_t publishTime;
   uint32_t sequence;
-  const ClientAdvertisement& advertisement;
+  ClientAdvertisement advertisement;
   size_t dataLength;
-  const uint8_t* data;
+  std::vector<uint8_t> data;
 
   ClientMessage(uint64_t logTime, uint64_t publishTime, uint32_t sequence,
-                const ClientAdvertisement& advertisement, size_t dataLength, const uint8_t* data)
+                const ClientAdvertisement& advertisement, size_t dataLength, const uint8_t* rawData)
       : logTime(logTime)
       , publishTime(publishTime)
       , sequence(sequence)
       , advertisement(advertisement)
       , dataLength(dataLength)
-      , data(data) {}
+      , data(dataLength) {
+    std::memcpy(data.data(), rawData, dataLength);
+  }
 
   static const size_t MSG_PAYLOAD_OFFSET = 5;
 
   const uint8_t* getData() const {
-    return data + MSG_PAYLOAD_OFFSET;
+    return data.data() + MSG_PAYLOAD_OFFSET;
   }
   std::size_t getLength() const {
-    return dataLength - MSG_PAYLOAD_OFFSET;
+    return data.size() - MSG_PAYLOAD_OFFSET;
   }
 };
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/callback_queue.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/callback_queue.hpp
@@ -1,0 +1,68 @@
+#pragma once
+
+#include <atomic>
+#include <condition_variable>
+#include <deque>
+#include <functional>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+namespace foxglove_bridge {
+
+class CallbackQueue {
+public:
+  CallbackQueue(size_t numThreads = 1)
+      : _quit(false) {
+    for (size_t i = 0; i < numThreads; ++i) {
+      _workerThreads.push_back(std::thread(&CallbackQueue::doWork, this));
+    }
+  }
+
+  ~CallbackQueue() {
+    stop();
+  }
+
+  void stop() {
+    _quit = true;
+    _cv.notify_all();
+    for (auto& thread : _workerThreads) {
+      thread.join();
+    }
+  }
+
+  void addCallback(std::function<void(void)> cb) {
+    if (_quit) {
+      return;
+    }
+    std::unique_lock<std::mutex> lock(_mutex);
+    _callbackQueue.push_back(cb);
+    _cv.notify_one();
+  }
+
+private:
+  void doWork() {
+    while (!_quit) {
+      std::unique_lock<std::mutex> lock(_mutex);
+      _cv.wait(lock, [this] {
+        return (_quit || !_callbackQueue.empty());
+      });
+      if (_quit) {
+        break;
+      } else if (!_callbackQueue.empty()) {
+        std::function<void(void)> cb = _callbackQueue.front();
+        _callbackQueue.pop_front();
+        lock.unlock();
+        cb();
+      }
+    }
+  }
+
+  std::atomic<bool> _quit;
+  std::mutex _mutex;
+  std::condition_variable _cv;
+  std::deque<std::function<void(void)>> _callbackQueue;
+  std::vector<std::thread> _workerThreads;
+};
+
+}  // namespace foxglove_bridge


### PR DESCRIPTION
**Public-Facing Changes**
- Run client handlers in separate thread


**Description**
Builds on top of #156 

So far we have executed client handler functions in the websocket server thread. This could cause issues with clients not receiving messages anymore while a longer-running handler function was executing. This PR fixes this by handler functions being executed in a separate thread.

Fixes #164 
Fixes FG-2029

