### PR TITLE
Allow subscribing to connection graph updates

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -13,6 +13,7 @@ constexpr char CAPABILITY_TIME[] = "time";
 constexpr char CAPABILITY_PARAMETERS[] = "parameters";
 constexpr char CAPABILITY_PARAMETERS_SUBSCRIBE[] = "parametersSubscribe";
 constexpr char CAPABILITY_SERVICES[] = "services";
+constexpr char CAPABILITY_CONNECTION_GRAPH[] = "connectionGraph";
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -14,7 +14,7 @@ namespace foxglove {
 
 constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
 
-typedef std::unordered_map<std::string, std::unordered_set<std::string>> MapOfSets;
+using MapOfSets = std::unordered_map<std::string, std::unordered_set<std::string>>;
 
 struct ServerOptions {
   std::vector<std::string> capabilities;

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -4,6 +4,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 #include "common.hpp"
@@ -12,6 +13,8 @@
 namespace foxglove {
 
 constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
+
+typedef std::unordered_map<std::string, std::unordered_set<std::string>> MapOfSets;
 
 struct ServerOptions {
   std::vector<std::string> capabilities;
@@ -42,6 +45,7 @@ struct ServerHandlers {
                      ConnectionHandle)>
     parameterSubscriptionHandler;
   std::function<void(const ServiceRequest&, ConnectionHandle)> serviceRequestHandler;
+  std::function<void(bool)> subscribeConnectionGraphHandler;
 };
 
 template <typename ConnectionHandle>
@@ -68,6 +72,9 @@ public:
   virtual void broadcastTime(uint64_t timestamp) = 0;
   virtual void sendServiceResponse(ConnectionHandle clientHandle,
                                    const ServiceResponse& response) = 0;
+  virtual void updateConnectionGraph(const MapOfSets& publishedTopics,
+                                     const MapOfSets& subscribedTopics,
+                                     const MapOfSets& advertisedServices) = 0;
 
   virtual uint16_t getPort() = 0;
   virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;

--- a/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <regex>
+#include <stdexcept>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace foxglove_bridge {
+
+inline std::pair<std::string, std::string> getNodeAndNodeNamespace(const std::string& fqnNodeName) {
+  const std::size_t found = fqnNodeName.find_last_of("/");
+  if (found == std::string::npos) {
+    throw std::runtime_error("Invalid fully qualified node name: " + fqnNodeName);
+  }
+  return std::make_pair(fqnNodeName.substr(0, found), fqnNodeName.substr(found + 1));
+}
+
+inline bool isWhitelisted(const std::string& name, const std::vector<std::regex>& regexPatterns) {
+  return std::find_if(regexPatterns.begin(), regexPatterns.end(), [name](const auto& regex) {
+           return std::regex_match(name, regex);
+         }) != regexPatterns.end();
+}
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -2,17 +2,11 @@
 
 #include <nlohmann/json.hpp>
 
+#include "foxglove_bridge/utils.hpp"
+
 namespace {
 
 constexpr char PARAM_SEP = '.';
-
-static std::pair<std::string, std::string> getNodeAndNodeNamespace(const std::string& fqnNodeName) {
-  const std::size_t found = fqnNodeName.find_last_of("/");
-  if (found == std::string::npos) {
-    throw std::runtime_error("Invalid fully qualified node name: " + fqnNodeName);
-  }
-  return std::make_pair(fqnNodeName.substr(0, found), fqnNodeName.substr(found + 1));
-}
 
 static std::pair<std::string, std::string> getNodeAndParamName(
   const std::string& nodeNameAndParamName) {
@@ -181,7 +175,7 @@ void ParameterInterface::setParams(const ParameterList& parameters,
 
   rclcpp::ParameterMap paramsByNode;
   for (const auto& param : parameters) {
-    if (!isWhitelistedParam(param.getName())) {
+    if (!isWhitelisted(param.getName(), _paramWhitelistPatterns)) {
       return;
     }
 
@@ -219,7 +213,7 @@ void ParameterInterface::subscribeParams(const std::vector<std::string>& paramNa
 
   std::unordered_set<std::string> nodesToSubscribe;
   for (const auto& paramName : paramNames) {
-    if (!isWhitelistedParam(paramName)) {
+    if (!isWhitelisted(paramName, _paramWhitelistPatterns)) {
       return;
     }
 
@@ -317,7 +311,7 @@ ParameterList ParameterInterface::getNodeParameters(
   ParameterList result;
   for (const auto& param : params) {
     const auto fullParamName = prependNodeNameToParamName(param.get_name(), nodeName);
-    if (isWhitelistedParam(fullParamName)) {
+    if (isWhitelisted(fullParamName, _paramWhitelistPatterns)) {
       result.push_back(fromRosParam(rclcpp::Parameter(fullParamName, param.get_parameter_value())));
     }
   }
@@ -363,13 +357,6 @@ void ParameterInterface::setNodeParameters(rclcpp::AsyncParametersClient::Shared
                   nodeName.c_str(), result.reason.c_str());
     }
   }
-}
-
-bool ParameterInterface::isWhitelistedParam(const std::string& paramName) {
-  return std::find_if(_paramWhitelistPatterns.begin(), _paramWhitelistPatterns.end(),
-                      [paramName](const auto& regex) {
-                        return std::regex_match(paramName, regex);
-                      }) != _paramWhitelistPatterns.end();
 }
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -493,7 +493,7 @@ private:
   }
 
   void subscribeConnectionGraphHandler(bool subscribe) {
-    if (_subscribeGraphUpdates = subscribe) {
+    if ((_subscribeGraphUpdates = subscribe)) {
       _handlerCallbackQueue->addCallback([this]() {
         updateConnectionGraph(get_topic_names_and_types());
       });

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -15,6 +15,7 @@
 #include <foxglove_bridge/param_utils.hpp>
 #include <foxglove_bridge/parameter_interface.hpp>
 #include <foxglove_bridge/server_factory.hpp>
+#include <foxglove_bridge/utils.hpp>
 
 using namespace std::chrono_literals;
 using namespace std::placeholders;
@@ -173,10 +174,7 @@ public:
       const auto& datatypes = topicNamesAndType.second;
 
       // Ignore the topic if it is not on the topic whitelist
-      if (std::find_if(_topicWhitelistPatterns.begin(), _topicWhitelistPatterns.end(),
-                       [&topicName](const auto& regex) {
-                         return std::regex_match(topicName, regex);
-                       }) != _topicWhitelistPatterns.end()) {
+      if (isWhitelisted(topicName, _topicWhitelistPatterns)) {
         for (const auto& datatype : datatypes) {
           latestTopics.emplace(topicName, datatype);
         }
@@ -318,10 +316,7 @@ public:
       }
 
       // Ignore the service if it is not on the service whitelist
-      if (std::find_if(_serviceWhitelistPatterns.begin(), _serviceWhitelistPatterns.end(),
-                       [&serviceName](const auto& regex) {
-                         return std::regex_match(serviceName, regex);
-                       }) == _serviceWhitelistPatterns.end()) {
+      if (!isWhitelisted(serviceName, _serviceWhitelistPatterns)) {
         continue;
       }
 


### PR DESCRIPTION
**Public-Facing Changes**
- Allow subscribing to connection graph updates (https://github.com/foxglove/ws-protocol/pull/368)

**Description**
Implements https://github.com/foxglove/ws-protocol/pull/368

This PR will allow using the TopicGraph panel in Foxglove Studio

