### PR TITLE
Remove (clang specific) compiler flag -Wmost

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 macro(enable_strict_compiler_warnings target)
   target_compile_options(${target} PRIVATE
     $<$<CXX_COMPILER_ID:MSVC>:/WX /W4>
-    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror -Wmost -Wold-style-cast -Wfloat-equal>
+    $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:-Wall -Wextra -Wpedantic -Werror -Wold-style-cast -Wfloat-equal>
   )
 endmacro()
 


### PR DESCRIPTION
**Public-Facing Changes**
None


**Description**
Fixes #176 by removing the clang-specific compiler flag `-Wmost` which was also applied for other compilers
Fixes [FG-2237](https://linear.app/foxglove/issue/FG-2237/build-fails-with-recent-change-to-cmakeliststxt-%5Bfoxgloveros-foxglove)
