### PR TITLE
Make server capabilities configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `10`.
+ * (ROS 2) __capabilities__: List of supported [server capabilities](https://github.com/foxglove/ws-protocol/blob/main/docs/spec.md). Defaults to `[clientPublish,parameters,parametersSubscribe,services,connectionGraph]`.
 
 ## Building from source
 

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <array>
 #include <cstring>
 #include <stdint.h>
 #include <string>
@@ -14,6 +15,11 @@ constexpr char CAPABILITY_PARAMETERS[] = "parameters";
 constexpr char CAPABILITY_PARAMETERS_SUBSCRIBE[] = "parametersSubscribe";
 constexpr char CAPABILITY_SERVICES[] = "services";
 constexpr char CAPABILITY_CONNECTION_GRAPH[] = "connectionGraph";
+
+constexpr std::array<const char*, 5> DEFAULT_CAPABILITIES = {
+  CAPABILITY_CLIENT_PUBLISH, CAPABILITY_CONNECTION_GRAPH, CAPABILITY_PARAMETERS_SUBSCRIBE,
+  CAPABILITY_PARAMETERS,     CAPABILITY_SERVICES,
+};
 
 using ChannelId = uint32_t;
 using ClientChannelId = uint32_t;

--- a/ros1_foxglove_bridge/launch/foxglove_bridge.launch
+++ b/ros1_foxglove_bridge/launch/foxglove_bridge.launch
@@ -11,6 +11,7 @@
   <arg name="send_buffer_limit"         default="10000000" />
   <arg name="nodelet_manager"           default="foxglove_nodelet_manager" />
   <arg name="num_threads"               default="0" />
+  <arg name="capabilities"              default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph]" />
 
   <node pkg="nodelet" type="nodelet" name="foxglove_nodelet_manager" args="manager"
         if="$(eval nodelet_manager == 'foxglove_nodelet_manager')">
@@ -30,5 +31,6 @@
     <rosparam param="topic_whitelist"   subst_value="True">$(arg topic_whitelist)</rosparam>
     <rosparam param="param_whitelist"   subst_value="True">$(arg param_whitelist)</rosparam>
     <rosparam param="service_whitelist" subst_value="True">$(arg service_whitelist)</rosparam>
+    <rosparam param="capabilities"      subst_value="True">$(arg capabilities)</rosparam>
   </node>
 </launch>

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -19,6 +19,7 @@ constexpr char PARAM_TOPIC_WHITELIST[] = "topic_whitelist";
 constexpr char PARAM_SERVICE_WHITELIST[] = "service_whitelist";
 constexpr char PARAM_PARAMETER_WHITELIST[] = "param_whitelist";
 constexpr char PARAM_USE_COMPRESSION[] = "use_compression";
+constexpr char PARAM_CAPABILITIES[] = "capabilities";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
+++ b/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
@@ -11,6 +11,7 @@
   <arg name="num_threads"               default="0" />
   <arg name="send_buffer_limit"         default="10000000" />
   <arg name="use_sim_time"              default="false" />
+  <arg name="capabilities"              default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph]" />
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge">
     <param name="port"                  value="$(var port)" />
@@ -25,5 +26,6 @@
     <param name="num_threads"           value="$(var num_threads)" />
     <param name="send_buffer_limit"     value="$(var send_buffer_limit)" />
     <param name="use_sim_time"          value="$(var use_sim_time)" />
+    <param name="capabilities"          value="$(var capabilities)" />
   </node>
 </launch>

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -1,5 +1,6 @@
 
 
+#include <foxglove_bridge/common.hpp>
 #include <foxglove_bridge/param_utils.hpp>
 
 namespace foxglove_bridge {
@@ -106,6 +107,17 @@ void declareParameters(rclcpp::Node* node) {
     "at the cost of additional CPU load.";
   useCompressionDescription.read_only = true;
   node->declare_parameter(PARAM_USE_COMPRESSION, false, useCompressionDescription);
+
+  auto paramCapabilities = rcl_interfaces::msg::ParameterDescriptor{};
+  paramCapabilities.name = PARAM_CAPABILITIES;
+  paramCapabilities.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  paramCapabilities.description = "Server capabilities";
+  paramCapabilities.read_only = true;
+  node->declare_parameter(
+    PARAM_CAPABILITIES,
+    std::vector<std::string>(std::vector<std::string>(foxglove::DEFAULT_CAPABILITIES.begin(),
+                                                      foxglove::DEFAULT_CAPABILITIES.end())),
+    paramCapabilities);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,


### PR DESCRIPTION
### Public-Facing Changes

- Make server capabilities configurable

### Description
Allows the user to configure server capabilities via a ROS parameter. By default, all capabilities are enabled. Note that the `time` capability is not configurable as it depends solely on `/use_sim_time`. 

Example usage:

```bash
roslaunch foxglove_bridge foxglove_bridge.launch capabilities:=[parameters,connectionGraph]
```

Fixes #180