### PR TITLE
Add support for `schemaEncoding` field

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstring>
+#include <optional>
 #include <stdint.h>
 #include <string>
 #include <vector>
@@ -50,10 +51,11 @@ struct ChannelWithoutId {
   std::string encoding;
   std::string schemaName;
   std::string schema;
+  std::optional<std::string> schemaEncoding;
 
   bool operator==(const ChannelWithoutId& other) const {
     return topic == other.topic && encoding == other.encoding && schemaName == other.schemaName &&
-           schema == other.schema;
+           schema == other.schema && schemaEncoding == other.schemaEncoding;
   }
 };
 

--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -10,14 +10,20 @@ void to_json(nlohmann::json& j, const Channel& c) {
     {"schemaName", c.schemaName},
     {"schema", c.schema},
   };
+
+  if (c.schemaEncoding.has_value()) {
+    j["schemaEncoding"] = c.schemaEncoding.value();
+  }
 }
 void from_json(const nlohmann::json& j, Channel& c) {
-  ChannelWithoutId channelWithoutId{
-    j["topic"].get<std::string>(),
-    j["encoding"].get<std::string>(),
-    j["schemaName"].get<std::string>(),
-    j["schema"].get<std::string>(),
-  };
+  const auto schemaEncoding =
+    j.find("schemaEncoding") == j.end()
+      ? std::optional<std::string>(std::nullopt)
+      : std::optional<std::string>(j["schemaEncoding"].get<std::string>());
+
+  ChannelWithoutId channelWithoutId{j["topic"].get<std::string>(), j["encoding"].get<std::string>(),
+                                    j["schemaName"].get<std::string>(),
+                                    j["schema"].get<std::string>(), schemaEncoding};
   c = Channel(j["id"].get<ChannelId>(), channelWithoutId);
 }
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -243,14 +243,12 @@ public:
           case foxglove::MessageDefinitionFormat::MSG:
             newChannel.encoding = "cdr";
             newChannel.schema = schema;
+            newChannel.schemaEncoding = "ros2msg";
             break;
           case foxglove::MessageDefinitionFormat::IDL:
-            RCLCPP_WARN(this->get_logger(),
-                        "IDL message definition format cannot be communicated over ws-protocol. "
-                        "Topic \"%s\" (%s) may not decode correctly in clients",
-                        topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str());
             newChannel.encoding = "cdr";
             newChannel.schema = schema;
+            newChannel.schemaEncoding = "ros2idl";
             break;
         }
 


### PR DESCRIPTION
### Public-Facing Changes

- Add support for `schemaEncoding` field

<!-- describe any changes to the public interface or APIs, or write "None" -->

### Description
Implements the specification update in https://github.com/foxglove/ws-protocol/pull/385
Fixes #8