### PR TITLE
Do not allow connection output buffer to exceed configured limit

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1056,7 +1056,7 @@ inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, Ch
   }
 
   const auto bufferSizeinBytes = con->get_buffered_amount();
-  if (bufferSizeinBytes >= _options.sendBufferLimitBytes) {
+  if (bufferSizeinBytes + payloadSize >= _options.sendBufferLimitBytes) {
     FOXGLOVE_DEBOUNCE(
       [this]() {
         _server.get_elog().write(


### PR DESCRIPTION
### Public-Facing Changes
- Do not allow connection output buffer to exceed configured limit

### Description
Makes sure that we only put messages in the output buffer if they do not cause the output buffer to exceed the user configured limit.

This mitigates that larger messages (images / pointclouds, ...) prevent smaller messages from being sent (see #174)