### PR TITLE
Notify client when Server's send buffer limit has been reached

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1064,8 +1064,7 @@ inline void Server<ServerConfiguration>::sendMessage(ConnHandle clientHandle, Ch
   const auto bufferSizeinBytes = con->get_buffered_amount();
   if (bufferSizeinBytes + payloadSize >= _options.sendBufferLimitBytes) {
     const auto logFn = [this, clientHandle]() {
-      sendStatusAndLogMsg(clientHandle, StatusLevel::Warning,
-                          "Connection send buffer limit reached, messages will be dropped...");
+      sendStatusAndLogMsg(clientHandle, StatusLevel::Warning, "Send buffer limit reached");
     };
     FOXGLOVE_DEBOUNCE(logFn, 2500);
     return;


### PR DESCRIPTION
### Public-Facing Changes

- Notify client when Server's send buffer limit has been reached

### Description
Rather than only logging a message, the client is now also informed when the server is about to drop messages due to the send buffer limit being exceeded. See https://github.com/foxglove/ros-foxglove-bridge/issues/174#issuecomment-1480438800