### PR TITLE
Log version and commit hash when node is started

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,20 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
+# Get git commit hash and replace variables in version.cpp.in
+find_program(GIT_SCM git DOC "Git version control")
+if (GIT_SCM)
+  execute_process(
+    COMMAND ${GIT_SCM} describe --always --dirty --abbrev=10 --match="NoTagWithThisName"
+    WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
+    OUTPUT_VARIABLE FOXGLOVE_BRIDGE_GIT_HASH
+    OUTPUT_STRIP_TRAILING_WHITESPACE
+  )
+endif()
+set(FOXGLOVE_BRIDGE_VERSION "${CMAKE_PROJECT_VERSION}")
+configure_file(foxglove_bridge_base/src/version.cpp.in
+               foxglove_bridge_base/src/version.cpp @ONLY)
+
 # Build the foxglove_bridge_base library
 add_library(foxglove_bridge_base SHARED
   foxglove_bridge_base/src/base64.cpp
@@ -49,6 +63,8 @@ add_library(foxglove_bridge_base SHARED
   foxglove_bridge_base/src/serialization.cpp
   foxglove_bridge_base/src/server_factory.cpp
   foxglove_bridge_base/src/test/test_client.cpp
+  # Generated:
+  ${CMAKE_CURRENT_BINARY_DIR}/foxglove_bridge_base/src/version.cpp
 )
 target_include_directories(foxglove_bridge_base
   PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,7 +45,7 @@ endif()
 find_program(GIT_SCM git DOC "Git version control")
 if (GIT_SCM)
   execute_process(
-    COMMAND ${GIT_SCM} describe --always --dirty --abbrev=10 --match="NoTagWithThisName"
+    COMMAND ${GIT_SCM} describe --always --dirty --exclude="*"
     WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     OUTPUT_VARIABLE FOXGLOVE_BRIDGE_GIT_HASH
     OUTPUT_STRIP_TRAILING_WHITESPACE

--- a/foxglove_bridge_base/include/foxglove_bridge/foxglove_bridge.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/foxglove_bridge.hpp
@@ -4,4 +4,8 @@ namespace foxglove {
 
 const char* WebSocketUserAgent();
 
+extern const char FOXGLOVE_BRIDGE_VERSION[];
+
+extern const char FOXGLOVE_BRIDGE_GIT_HASH[];
+
 }  // namespace foxglove

--- a/foxglove_bridge_base/src/version.cpp.in
+++ b/foxglove_bridge_base/src/version.cpp.in
@@ -1,0 +1,9 @@
+#include <foxglove_bridge/foxglove_bridge.hpp>
+
+namespace foxglove {
+
+const char FOXGLOVE_BRIDGE_VERSION[] = "@FOXGLOVE_BRIDGE_VERSION@";
+
+const char FOXGLOVE_BRIDGE_GIT_HASH[] = "@FOXGLOVE_BRIDGE_GIT_HASH@";
+
+}  // namespace foxglove

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -115,7 +115,9 @@ public:
       ROS_ERROR("Failed to parse one or more service whitelist patterns");
     }
 
-    ROS_INFO("Starting %s with %s", ros::this_node::getName().c_str(),
+    const char* rosDistro = std::getenv("ROS_DISTRO");
+    ROS_INFO("Starting foxglove_bridge (%s, %s@%s) with %s", rosDistro,
+             foxglove::FOXGLOVE_BRIDGE_VERSION, foxglove::FOXGLOVE_BRIDGE_GIT_HASH,
              foxglove::WebSocketUserAgent());
 
     try {
@@ -125,7 +127,7 @@ public:
         serverOptions.capabilities.push_back(foxglove::CAPABILITY_TIME);
       }
       serverOptions.supportedEncodings = {ROS1_CHANNEL_ENCODING};
-      serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
+      serverOptions.metadata = {{"ROS_DISTRO", rosDistro}};
       serverOptions.sendBufferLimitBytes = send_buffer_limit;
       serverOptions.sessionId = sessionId;
       serverOptions.useTls = useTLS;

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -38,7 +38,9 @@ public:
 
   FoxgloveBridge(const rclcpp::NodeOptions& options = rclcpp::NodeOptions())
       : Node("foxglove_bridge", options) {
-    RCLCPP_INFO(this->get_logger(), "Starting %s with %s", this->get_name(),
+    const char* rosDistro = std::getenv("ROS_DISTRO");
+    RCLCPP_INFO(this->get_logger(), "Starting foxglove_bridge (%s, %s@%s) with %s", rosDistro,
+                foxglove::FOXGLOVE_BRIDGE_VERSION, foxglove::FOXGLOVE_BRIDGE_GIT_HASH,
                 foxglove::WebSocketUserAgent());
 
     declareParameters(this);
@@ -71,7 +73,7 @@ public:
       serverOptions.capabilities.push_back(foxglove::CAPABILITY_TIME);
     }
     serverOptions.supportedEncodings = {"cdr"};
-    serverOptions.metadata = {{"ROS_DISTRO", std::getenv("ROS_DISTRO")}};
+    serverOptions.metadata = {{"ROS_DISTRO", rosDistro}};
     serverOptions.sendBufferLimitBytes = send_buffer_limit;
     serverOptions.sessionId = std::to_string(std::time(nullptr));
     serverOptions.useCompression = useCompression;


### PR DESCRIPTION
### Public-Facing Changes

- Log ROS distro, version and git commit hash when starting node

### Description
Logs additional version information to make it easier to debug user problems

Examples:
```sh
# With uncommited changes
Starting foxglove_bridge (galactic, 0.5.3@83cc834577-dirty) with WebSocket++/0.8.1
Starting foxglove_bridge (noetic, 0.5.3@83cc834577-dirty) with WebSocket++/0.8.1

# Without changes
Starting foxglove_bridge (galactic, 0.5.3@a685b31baf) with WebSocket++/0.8.1
```

Fixes #197 