### PR TITLE
Catch exceptions thrown in handler functions, send status to client

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
@@ -8,14 +8,15 @@
 #include <thread>
 #include <vector>
 
-#include <rclcpp/logging.hpp>
+#include "websocket_logging.hpp"
 
-namespace foxglove_bridge {
+namespace foxglove {
 
 class CallbackQueue {
 public:
-  CallbackQueue(size_t numThreads = 1)
-      : _quit(false) {
+  CallbackQueue(LogCallback logCallback, size_t numThreads = 1)
+      : _logCallback(logCallback)
+      , _quit(false) {
     for (size_t i = 0; i < numThreads; ++i) {
       _workerThreads.push_back(std::thread(&CallbackQueue::doWork, this));
     }
@@ -59,13 +60,15 @@ private:
           cb();
         } catch (const std::exception& ex) {
           // Should never get here if we catch all exceptions in the callbacks.
-          RCLCPP_ERROR(rclcpp::get_logger("foxglove_bridge"),
-                       "Caught unhandled exception in calback_queue: %s", ex.what());
+          const std::string msg =
+            std::string("Caught unhandled exception in calback_queue") + ex.what();
+          _logCallback(WebSocketLogLevel::Error, msg.c_str());
         }
       }
     }
   }
 
+  LogCallback _logCallback;
   std::atomic<bool> _quit;
   std::mutex _mutex;
   std::condition_variable _cv;
@@ -73,4 +76,4 @@ private:
   std::vector<std::thread> _workerThreads;
 };
 
-}  // namespace foxglove_bridge
+}  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
@@ -63,6 +63,8 @@ private:
           const std::string msg =
             std::string("Caught unhandled exception in calback_queue") + ex.what();
           _logCallback(WebSocketLogLevel::Error, msg.c_str());
+        } catch (...) {
+          _logCallback(WebSocketLogLevel::Error, "Caught unhandled exception in calback_queue");
         }
       }
     }

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -17,6 +17,31 @@ constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
 
 using MapOfSets = std::unordered_map<std::string, std::unordered_set<std::string>>;
 
+template <typename IdType>
+class ExeptionWithId : public std::runtime_error {
+public:
+  explicit ExeptionWithId(IdType id, const std::string& what_arg)
+      : std::runtime_error(what_arg)
+      , _id(id) {}
+
+  IdType id() const {
+    return _id;
+  }
+
+private:
+  IdType _id;
+};
+
+class ChannelError : public ExeptionWithId<ChannelId> {
+  using ExeptionWithId::ExeptionWithId;
+};
+class ClientChannelError : public ExeptionWithId<ClientChannelId> {
+  using ExeptionWithId::ExeptionWithId;
+};
+class ServiceError : public ExeptionWithId<ServiceId> {
+  using ExeptionWithId::ExeptionWithId;
+};
+
 struct ServerOptions {
   std::vector<std::string> capabilities;
   std::vector<std::string> supportedEncodings;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -561,6 +561,9 @@ inline void Server<ServerConfiguration>::handleMessage(ConnHandle hdl, MessagePt
             handleTextMessage(hdl, msg);
           } catch (const std::exception& e) {
             sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
+          } catch (...) {
+            sendStatusAndLogMsg(hdl, StatusLevel::Error,
+                                "Exception occurred when executing text message handler");
           }
         });
       } break;
@@ -570,6 +573,9 @@ inline void Server<ServerConfiguration>::handleMessage(ConnHandle hdl, MessagePt
             handleBinaryMessage(hdl, msg);
           } catch (const std::exception& e) {
             sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
+          } catch (...) {
+            sendStatusAndLogMsg(hdl, StatusLevel::Error,
+                                "Exception occurred when executing binary message handler");
           }
         });
       } break;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -709,8 +709,8 @@ inline void Server<ServerConfiguration>::handleTextMessage(ConnHandle hdl, Messa
           continue;
         }
         clientPublications.erase(channelIt);
-        if (const auto advertisedChannelIt = clientInfo.advertisedChannels.find(channelId) !=
-                                             clientInfo.advertisedChannels.end()) {
+        const auto advertisedChannelIt = clientInfo.advertisedChannels.find(channelId);
+        if (advertisedChannelIt != clientInfo.advertisedChannels.end()) {
           clientInfo.advertisedChannels.erase(advertisedChannelIt);
         }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -197,6 +197,7 @@ private:
   void sendJson(ConnHandle hdl, json&& payload);
   void sendJsonRaw(ConnHandle hdl, const std::string& payload);
   void sendBinary(ConnHandle hdl, const uint8_t* payload, size_t payloadSize);
+  void sendStatus(ConnHandle clientHandle, const StatusLevel level, const std::string& message);
   void sendStatusAndLogMsg(ConnHandle clientHandle, const StatusLevel level,
                            const std::string& message);
   void unsubscribeParamsWithoutSubscriptions(ConnHandle hdl,
@@ -533,6 +534,17 @@ inline void Server<ServerConfiguration>::sendBinary(ConnHandle hdl, const uint8_
 }
 
 template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendStatus(ConnHandle clientHandle,
+                                                    const StatusLevel level,
+                                                    const std::string& message) {
+  sendJson(clientHandle, json{
+                           {"op", "status"},
+                           {"level", static_cast<uint8_t>(level)},
+                           {"message", message},
+                         });
+}
+
+template <typename ServerConfiguration>
 inline void Server<ServerConfiguration>::sendStatusAndLogMsg(ConnHandle clientHandle,
                                                              const StatusLevel level,
                                                              const std::string& message) {
@@ -542,11 +554,7 @@ inline void Server<ServerConfiguration>::sendStatusAndLogMsg(ConnHandle clientHa
   auto logger = level == StatusLevel::Error ? _server.get_elog() : _server.get_alog();
   logger.write(logLevel, logMessage);
 
-  sendJson(clientHandle, json{
-                           {"op", "status"},
-                           {"level", static_cast<uint8_t>(level)},
-                           {"message", message},
-                         });
+  sendStatus(clientHandle, level, message);
 }
 
 template <typename ServerConfiguration>


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
- Refactors the way handler functions are run in a separate thread. It's better to do that in a unified way in the server rather than doing that for ROS 1 & 2 differently as it was implemented in #165
- Catch exeptions thrown in handler functions and send status message to client

Fixes #148 