### PR TITLE
Add support for action topic and services (ROS2)

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/message_definition_cache.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/message_definition_cache.hpp
@@ -8,6 +8,14 @@
 
 namespace foxglove {
 
+// Taken from
+// https://github.com/ros2/rosidl/blob/a57baea5/rosidl_parser/rosidl_parser/definition.py
+constexpr char SERVICE_REQUEST_MESSAGE_SUFFIX[] = "_Request";
+constexpr char SERVICE_RESPONSE_MESSAGE_SUFFIX[] = "_Response";
+constexpr char ACTION_GOAL_SERVICE_SUFFIX[] = "_SendGoal";
+constexpr char ACTION_RESULT_SERVICE_SUFFIX[] = "_GetResult";
+constexpr char ACTION_FEEDBACK_MESSAGE_SUFFIX[] = "_FeedbackMessage";
+
 enum struct MessageDefinitionFormat {
   IDL,
   MSG,

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -123,7 +123,7 @@ static std::vector<std::string> split_string(const std::string& str,
 /// @return A tuple holding goal, result and feedback definitions
 static std::tuple<std::string, std::string, std::string> split_action_msg_definition(
   const std::string& action_definition) {
-  constexpr char SEP[] = "---";
+  constexpr char SEP[] = "\n---\n";
 
   const auto definitions = split_string(action_definition, SEP);
   if (definitions.size() != 3) {

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -14,38 +14,11 @@
 #include <ament_index_cpp/get_resources.hpp>
 #include <rcutils/logging_macros.h>
 
-namespace {
-
-/// @brief Split an action definition into individual goal, result and feedback definitions.
-/// @param action_definition The full action definition as read from a .action file
-/// @return A tuple holding goal, result and feedback definitions
-std::tuple<std::string, std::string, std::string> split_action_msg_definition(
-  const std::string& action_definition) {
-  constexpr char SEP[] = "---";
-  constexpr size_t SEP_SIZE = sizeof(SEP);
-  const auto first_sep_idx = action_definition.find(SEP);
-  const auto last_sep_idx = action_definition.find(SEP, first_sep_idx + SEP_SIZE);
-  const size_t size_result_def = last_sep_idx - first_sep_idx;
-
-  if (first_sep_idx == std::string::npos || last_sep_idx == std::string::npos ||
-      first_sep_idx == last_sep_idx) {
-    throw std::invalid_argument("Invalid action definition:\n" + action_definition);
-  }
-
-  const std::string goal_def = action_definition.substr(0UL, first_sep_idx);
-  const std::string result_def =
-    action_definition.substr(first_sep_idx + SEP_SIZE, size_result_def - SEP_SIZE);
-  const std::string feedback_def = action_definition.substr(last_sep_idx + SEP_SIZE);
-  return {goal_def, result_def, feedback_def};
-}
-
-}  // namespace
-
 namespace foxglove {
 
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar or foo_msgs/srv/Bar)
 static const std::regex PACKAGE_TYPENAME_REGEX{
-  R"(^([a-zA-Z0-9_]+)/((?:msg|srv|action)?)/?([a-zA-Z0-9_]+)$)"};
+  R"(^([a-zA-Z0-9_]+)/(?:(msg|srv|action)/)?([a-zA-Z0-9_]+)$)"};
 
 // Match field types from .msg definitions ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
 static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
@@ -145,6 +118,44 @@ static std::vector<std::string> split_string(const std::string& str,
   return strings;
 }
 
+/// @brief Split an action definition into individual goal, result and feedback definitions.
+/// @param action_definition The full action definition as read from a .action file
+/// @return A tuple holding goal, result and feedback definitions
+static std::tuple<std::string, std::string, std::string> split_action_msg_definition(
+  const std::string& action_definition) {
+  constexpr char SEP[] = "---";
+
+  const auto definitions = split_string(action_definition, SEP);
+  if (definitions.size() != 3) {
+    throw std::invalid_argument("Invalid action definition:\n" + action_definition);
+  }
+
+  return {definitions[0], definitions[1], definitions[2]};
+}
+
+inline bool ends_with(const std::string& str, const std::string& suffix) {
+  return str.size() >= suffix.size() &&
+         0 == str.compare(str.size() - suffix.size(), suffix.size(), suffix);
+}
+
+std::string remove_action_subtype(const std::string action_type) {
+  const auto action_subtype_suffixes = {
+    std::string(ACTION_FEEDBACK_MESSAGE_SUFFIX),
+    std::string(ACTION_RESULT_SERVICE_SUFFIX) + SERVICE_REQUEST_MESSAGE_SUFFIX,
+    std::string(ACTION_RESULT_SERVICE_SUFFIX) + SERVICE_RESPONSE_MESSAGE_SUFFIX,
+    std::string(ACTION_GOAL_SERVICE_SUFFIX) + SERVICE_REQUEST_MESSAGE_SUFFIX,
+    std::string(ACTION_GOAL_SERVICE_SUFFIX) + SERVICE_RESPONSE_MESSAGE_SUFFIX,
+  };
+
+  for (const auto& suffix : action_subtype_suffixes) {
+    if (ends_with(action_type, suffix)) {
+      return action_type.substr(0, action_type.length() - suffix.length());
+    }
+  }
+
+  return action_type;
+}
+
 MessageSpec::MessageSpec(MessageDefinitionFormat format, std::string text,
                          const std::string& package_context)
     : dependencies(parse_dependencies(format, text, package_context))
@@ -170,7 +181,7 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
 
   // The action type name includes the subtype which we have to remove to get the action name.
   // Type name: Fibonacci_FeedbackMessage -> Action name: Fibonacci
-  const std::string action_name = type_name.substr(0UL, type_name.find('_'));
+  const std::string action_name = is_action_type ? remove_action_subtype(type_name) : "";
   const std::string filename = is_action_type
                                  ? action_name + ".action"
                                  : type_name + extension_for_format(definition_identifier.format);
@@ -210,20 +221,23 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
       // These type definitions may include additional fields such as the goal_id.
       // See also https://design.ros2.org/articles/actions.html
       const std::map<std::string, std::string> action_type_definitions = {
-        {"_FeedbackMessage", "unique_identifier_msgs/UUID goal_id\n" + feedbackDef},
-        {"_GetResult_Request", "unique_identifier_msgs/UUID goal_id\n"},
-        {"_GetResult_Response", "int8 status\n" + resultDef},
-        {"_SendGoal_Request", "unique_identifier_msgs/UUID goal_id\n" + goalDef},
-        {"_SendGoal_Response", "bool accepted\nbuiltin_interfaces/msg/Time stamp"}};
+        {ACTION_FEEDBACK_MESSAGE_SUFFIX, "unique_identifier_msgs/UUID goal_id\n" + feedbackDef},
+        {std::string(ACTION_RESULT_SERVICE_SUFFIX) + SERVICE_REQUEST_MESSAGE_SUFFIX,
+         "unique_identifier_msgs/UUID goal_id\n"},
+        {std::string(ACTION_RESULT_SERVICE_SUFFIX) + SERVICE_RESPONSE_MESSAGE_SUFFIX,
+         "int8 status\n" + resultDef},
+        {std::string(ACTION_GOAL_SERVICE_SUFFIX) + SERVICE_REQUEST_MESSAGE_SUFFIX,
+         "unique_identifier_msgs/UUID goal_id\n" + goalDef},
+        {std::string(ACTION_GOAL_SERVICE_SUFFIX) + SERVICE_RESPONSE_MESSAGE_SUFFIX,
+         "bool accepted\nbuiltin_interfaces/msg/Time stamp"}};
 
       // Create a MessageSpec instance for every action subtype and add it to the cache.
       for (const auto& [action_suffix, definition] : action_type_definitions) {
-        DefinitionIdentifier definitionIdentifier;
-        definitionIdentifier.format = definition_identifier.format;
-        definitionIdentifier.package_resource_name =
-          package + "/action/" + action_name + action_suffix;
+        DefinitionIdentifier definition_id;
+        definition_id.format = definition_identifier.format;
+        definition_id.package_resource_name = package + "/action/" + action_name + action_suffix;
         msg_specs_by_definition_identifier_.emplace(
-          definitionIdentifier, MessageSpec(definitionIdentifier.format, definition, package));
+          definition_id, MessageSpec(definition_id.format, definition, package));
       }
 
       // Find the the subtype that was originally requested and return it.

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -14,11 +14,38 @@
 #include <ament_index_cpp/get_resources.hpp>
 #include <rcutils/logging_macros.h>
 
+namespace {
+
+/// @brief Split an action definition into individual goal, result and feedback definitions.
+/// @param action_definition The full action definition as read from a .action file
+/// @return A tuple holding goal, result and feedback definitions
+std::tuple<std::string, std::string, std::string> split_action_msg_definition(
+  const std::string& action_definition) {
+  constexpr char SEP[] = "---";
+  constexpr size_t SEP_SIZE = sizeof(SEP);
+  const auto first_sep_idx = action_definition.find(SEP);
+  const auto last_sep_idx = action_definition.find(SEP, first_sep_idx + SEP_SIZE);
+  const size_t size_result_def = last_sep_idx - first_sep_idx;
+
+  if (first_sep_idx == std::string::npos || last_sep_idx == std::string::npos ||
+      first_sep_idx == last_sep_idx) {
+    throw std::invalid_argument("Invalid action definition:\n" + action_definition);
+  }
+
+  const std::string goal_def = action_definition.substr(0UL, first_sep_idx);
+  const std::string result_def =
+    action_definition.substr(first_sep_idx + SEP_SIZE, size_result_def - SEP_SIZE);
+  const std::string feedback_def = action_definition.substr(last_sep_idx + SEP_SIZE);
+  return {goal_def, result_def, feedback_def};
+}
+
+}  // namespace
+
 namespace foxglove {
 
 // Match datatype names (foo_msgs/Bar or foo_msgs/msg/Bar or foo_msgs/srv/Bar)
 static const std::regex PACKAGE_TYPENAME_REGEX{
-  R"(^([a-zA-Z0-9_]+)/(?:msg/|srv/|action/)?([a-zA-Z0-9_]+)$)"};
+  R"(^([a-zA-Z0-9_]+)/((?:msg|srv|action)?)/?([a-zA-Z0-9_]+)$)"};
 
 // Match field types from .msg definitions ("foo_msgs/Bar" in "foo_msgs/Bar[] bar")
 static const std::regex MSG_FIELD_TYPE_REGEX{R"((?:^|\n)\s*([a-zA-Z0-9_/]+)(?:\[[^\]]*\])?\s+)"};
@@ -137,7 +164,16 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
                                 definition_identifier.package_resource_name);
   }
   const std::string package = match[1].str();
-  const std::string filename = match[2].str() + extension_for_format(definition_identifier.format);
+  const std::string subfolder = match[2].str();
+  const std::string type_name = match[3].str();
+  const bool is_action_type = subfolder == "action";
+
+  // The action type name includes the subtype which we have to remove to get the action name.
+  // Type name: Fibonacci_FeedbackMessage -> Action name: Fibonacci
+  const std::string action_name = type_name.substr(0UL, type_name.find('_'));
+  const std::string filename = is_action_type
+                                 ? action_name + ".action"
+                                 : type_name + extension_for_format(definition_identifier.format);
 
   // Get the package share directory, or throw a PackageNotFoundError
   const std::string share_dir = ament_index_cpp::get_package_share_directory(package);
@@ -166,15 +202,53 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   }
   const std::string contents{std::istreambuf_iterator(file), {}};
 
-  const MessageSpec& spec =
-    msg_specs_by_definition_identifier_
-      .emplace(definition_identifier,
-               MessageSpec(definition_identifier.format, std::move(contents), package))
-      .first->second;
+  if (is_action_type) {
+    if (definition_identifier.format == MessageDefinitionFormat::MSG) {
+      const auto [goalDef, resultDef, feedbackDef] = split_action_msg_definition(contents);
 
-  // "References and pointers to data stored in the container are only invalidated by erasing that
-  // element, even when the corresponding iterator is invalidated."
-  return spec;
+      // Define type definitions for each action subtype.
+      // These type definitions may include additional fields such as the goal_id.
+      // See also https://design.ros2.org/articles/actions.html
+      const std::map<std::string, std::string> action_type_definitions = {
+        {"_FeedbackMessage", "unique_identifier_msgs/UUID goal_id\n" + feedbackDef},
+        {"_GetResult_Request", "unique_identifier_msgs/UUID goal_id\n"},
+        {"_GetResult_Response", "int8 status\n" + resultDef},
+        {"_SendGoal_Request", "unique_identifier_msgs/UUID goal_id\n" + goalDef},
+        {"_SendGoal_Response", "bool accepted\nbuiltin_interfaces/msg/Time stamp"}};
+
+      // Create a MessageSpec instance for every action subtype and add it to the cache.
+      for (const auto& [action_suffix, definition] : action_type_definitions) {
+        DefinitionIdentifier definitionIdentifier;
+        definitionIdentifier.format = definition_identifier.format;
+        definitionIdentifier.package_resource_name =
+          package + "/action/" + action_name + action_suffix;
+        msg_specs_by_definition_identifier_.emplace(
+          definitionIdentifier, MessageSpec(definitionIdentifier.format, definition, package));
+      }
+
+      // Find the the subtype that was originally requested and return it.
+      const auto it = msg_specs_by_definition_identifier_.find(definition_identifier);
+      if (it == msg_specs_by_definition_identifier_.end()) {
+        throw DefinitionNotFoundError(definition_identifier.package_resource_name);
+      }
+      return it->second;
+    } else {
+      RCUTILS_LOG_ERROR_NAMED("foxglove_bridge",
+                              "Action IDL definitions are currently not supported");
+      throw DefinitionNotFoundError(definition_identifier.package_resource_name);
+    }
+  } else {
+    // Normal message type.
+    const MessageSpec& spec =
+      msg_specs_by_definition_identifier_
+        .emplace(definition_identifier,
+                 MessageSpec(definition_identifier.format, std::move(contents), package))
+        .first->second;
+
+    // "References and pointers to data stored in the container are only invalidated by erasing that
+    // element, even when the corresponding iterator is invalidated."
+    return spec;
+  }
 }
 
 std::pair<MessageDefinitionFormat, std::string> MessageDefinitionCache::get_full_text(

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -336,8 +336,10 @@ public:
       service.type = datatypes.front();
 
       try {
-        auto [format, reqSchema] = _messageDefinitionCache.get_full_text(service.type + "_Request");
-        auto resSchema = _messageDefinitionCache.get_full_text(service.type + "_Response").second;
+        const auto requestTypeName = service.type + foxglove::SERVICE_REQUEST_MESSAGE_SUFFIX;
+        const auto responseTypeName = service.type + foxglove::SERVICE_RESPONSE_MESSAGE_SUFFIX;
+        const auto [format, reqSchema] = _messageDefinitionCache.get_full_text(requestTypeName);
+        const auto resSchema = _messageDefinitionCache.get_full_text(responseTypeName).second;
         switch (format) {
           case foxglove::MessageDefinitionFormat::MSG:
             service.requestSchema = reqSchema;


### PR DESCRIPTION
### Public-Facing Changes
- Add support for action topic and services (ROS2)

### Description
Adds support for parsing .action files to retrieve message definitions for the following action subtypes:
- feedback topic (`_FeedbackMessage`) *
- SendGoal
  - request (`_SendGoal_Request`) *
  - response (`_SendGoal_Response`)
- GetResult
  - request (`_GetResult_Request`)
  - response (`_GetResult_Response`) *

Unfortunately, the action definition in the .action file does not include other fields such as the goal_id which are sent as part of the feedback message or SendGoal_Request and GetResult_Response. These types are therefore added to the message definition such that the entire schema is generated correctly.

Parsing IDL action definitions is currently not supported.

Example usage in Studio:
![image](https://user-images.githubusercontent.com/9250155/231853814-06533812-4c1f-449c-9d9a-68885ad54ebb.png)



