### PR TITLE
Add workaround for publishers not being cleaned up after they got destroyed

### DIFF
--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -733,6 +733,11 @@ private:
     if (clientPublications.empty()) {
       _clientAdvertisedTopics.erase(it);
     }
+
+    // Create a timer that immedeately goes out of scope (so it never fires) which will trigger
+    // the previously destroyed publisher to be cleaned up. This is a workaround for
+    // https://github.com/ros2/rclcpp/issues/2146
+    this->create_wall_timer(1s, []() {});
   }
 
   void clientMessage(const foxglove::ClientMessage& message, ConnectionHandle hdl) {


### PR DESCRIPTION
### Public-Facing Changes
- Add workaround for publishers not being cleaned up after they got destroyed

### Description
Fixes publishers not being fully destroyed if there is no event triggering the actual cleanup. See https://github.com/ros2/rclcpp/issues/2146#issuecomment-1507474907