### PR TITLE
Add support for nested parameters (ROS1)

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
@@ -3,6 +3,7 @@
 #include <any>
 #include <stdint.h>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 namespace foxglove {
@@ -18,33 +19,23 @@ enum class ParameterType {
   PARAMETER_INTEGER,
   PARAMETER_DOUBLE,
   PARAMETER_STRING,
-  PARAMETER_BYTE_ARRAY,
-  PARAMETER_BOOL_ARRAY,
-  PARAMETER_INTEGER_ARRAY,
-  PARAMETER_DOUBLE_ARRAY,
-  PARAMETER_STRING_ARRAY,
+  PARAMETER_ARRAY,
+  PARAMETER_STRUCT,      // ROS 1 only
+  PARAMETER_BYTE_ARRAY,  // ROS 2 only
 };
 
-class Parameter {
+class ParameterValue {
 public:
-  Parameter();
-  Parameter(const std::string& name);
-  Parameter(const std::string& name, bool value);
-  Parameter(const std::string& name, int value);
-  Parameter(const std::string& name, int64_t value);
-  Parameter(const std::string& name, double value);
-  Parameter(const std::string& name, std::string value);
-  Parameter(const std::string& name, const char* value);
-  Parameter(const std::string& name, const std::vector<unsigned char>& value);
-  Parameter(const std::string& name, const std::vector<bool>& value);
-  Parameter(const std::string& name, const std::vector<int>& value);
-  Parameter(const std::string& name, const std::vector<int64_t>& value);
-  Parameter(const std::string& name, const std::vector<double>& value);
-  Parameter(const std::string& name, const std::vector<std::string>& value);
-
-  inline const std::string& getName() const {
-    return _name;
-  }
+  ParameterValue();
+  ParameterValue(bool value);
+  ParameterValue(int value);
+  ParameterValue(int64_t value);
+  ParameterValue(double value);
+  ParameterValue(const std::string& value);
+  ParameterValue(const char* value);
+  ParameterValue(const std::vector<unsigned char>& value);
+  ParameterValue(const std::vector<ParameterValue>& value);
+  ParameterValue(const std::unordered_map<std::string, ParameterValue>& value);
 
   inline ParameterType getType() const {
     return _type;
@@ -56,9 +47,31 @@ public:
   }
 
 private:
-  std::string _name;
   ParameterType _type;
   std::any _value;
+};
+
+class Parameter {
+public:
+  Parameter();
+  Parameter(const std::string& name);
+  Parameter(const std::string& name, const ParameterValue& value);
+
+  inline const std::string& getName() const {
+    return _name;
+  }
+
+  inline ParameterType getType() const {
+    return _value.getType();
+  }
+
+  inline const ParameterValue& getValue() const {
+    return _value;
+  }
+
+private:
+  std::string _name;
+  ParameterValue _value;
 };
 
 }  // namespace foxglove

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -46,6 +46,8 @@ inline uint32_t ReadUint32LE(const uint8_t* buf) {
 
 void to_json(nlohmann::json& j, const Channel& c);
 void from_json(const nlohmann::json& j, Channel& c);
+void to_json(nlohmann::json& j, const ParameterValue& p);
+void from_json(const nlohmann::json& j, ParameterValue& p);
 void to_json(nlohmann::json& j, const Parameter& p);
 void from_json(const nlohmann::json& j, Parameter& p);
 void to_json(nlohmann::json& j, const Service& p);

--- a/foxglove_bridge_base/src/parameter.cpp
+++ b/foxglove_bridge_base/src/parameter.cpp
@@ -2,70 +2,42 @@
 
 namespace foxglove {
 
-Parameter::Parameter()
-    : _name("")
-    , _type(ParameterType::PARAMETER_NOT_SET)
-    , _value() {}
+ParameterValue::ParameterValue()
+    : _type(ParameterType::PARAMETER_NOT_SET) {}
+ParameterValue::ParameterValue(bool value)
+    : _type(ParameterType::PARAMETER_BOOL)
+    , _value(value) {}
+ParameterValue::ParameterValue(int value)
+    : _type(ParameterType::PARAMETER_INTEGER)
+    , _value(static_cast<int64_t>(value)) {}
+ParameterValue::ParameterValue(int64_t value)
+    : _type(ParameterType::PARAMETER_INTEGER)
+    , _value(value) {}
+ParameterValue::ParameterValue(double value)
+    : _type(ParameterType::PARAMETER_DOUBLE)
+    , _value(value) {}
+ParameterValue::ParameterValue(const std::string& value)
+    : _type(ParameterType::PARAMETER_STRING)
+    , _value(value) {}
+ParameterValue::ParameterValue(const char* value)
+    : _type(ParameterType::PARAMETER_STRING)
+    , _value(std::string(value)) {}
+ParameterValue::ParameterValue(const std::vector<unsigned char>& value)
+    : _type(ParameterType::PARAMETER_BYTE_ARRAY)
+    , _value(value) {}
+ParameterValue::ParameterValue(const std::vector<ParameterValue>& value)
+    : _type(ParameterType::PARAMETER_ARRAY)
+    , _value(value) {}
+ParameterValue::ParameterValue(const std::unordered_map<std::string, ParameterValue>& value)
+    : _type(ParameterType::PARAMETER_STRUCT)
+    , _value(value) {}
 
+Parameter::Parameter() {}
 Parameter::Parameter(const std::string& name)
     : _name(name)
-    , _type(ParameterType::PARAMETER_NOT_SET)
-    , _value() {}
-
-Parameter::Parameter(const std::string& name, bool value)
+    , _value(ParameterValue()) {}
+Parameter::Parameter(const std::string& name, const ParameterValue& value)
     : _name(name)
-    , _type(ParameterType::PARAMETER_BOOL)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, int value)
-    : Parameter(name, static_cast<int64_t>(value)) {}
-
-Parameter::Parameter(const std::string& name, int64_t value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_INTEGER)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, double value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_DOUBLE)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const char* value)
-    : Parameter(name, std::string(value)) {}
-
-Parameter::Parameter(const std::string& name, std::string value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_STRING)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<unsigned char>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_BYTE_ARRAY)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<bool>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_BOOL_ARRAY)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<int>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_INTEGER_ARRAY)
-    , _value(std::vector<int64_t>(value.begin(), value.end())) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<int64_t>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_INTEGER_ARRAY)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<double>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_DOUBLE_ARRAY)
-    , _value(value) {}
-
-Parameter::Parameter(const std::string& name, const std::vector<std::string>& value)
-    : _name(name)
-    , _type(ParameterType::PARAMETER_STRING_ARRAY)
     , _value(value) {}
 
 }  // namespace foxglove

--- a/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -11,6 +11,7 @@
 namespace foxglove_bridge {
 
 foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value);
+XmlRpc::XmlRpcValue toRosParam(const foxglove::ParameterValue& param);
 
 std::vector<std::regex> parseRegexPatterns(const std::vector<std::string>& strings);
 

--- a/ros1_foxglove_bridge/src/param_utils.cpp
+++ b/ros1_foxglove_bridge/src/param_utils.cpp
@@ -1,61 +1,75 @@
 
+#include <iostream>
 #include <stdexcept>
 
 #include <foxglove_bridge/param_utils.hpp>
 
-namespace {
-
-template <typename T>
-std::vector<T> toVector(const XmlRpc::XmlRpcValue& value) {
-  std::vector<T> arr;
-  arr.reserve(static_cast<size_t>(value.size()));
-  for (int i = 0; i < value.size(); i++) {
-    arr.push_back(static_cast<T>(value[i]));
-  }
-  return arr;
-}
-
-}  // namespace
-
 namespace foxglove_bridge {
 
-foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value) {
+foxglove::ParameterValue fromRosParam(const XmlRpc::XmlRpcValue& value) {
   const auto type = value.getType();
 
   if (type == XmlRpc::XmlRpcValue::Type::TypeBoolean) {
-    return foxglove::Parameter(name, static_cast<bool>(value));
+    return foxglove::ParameterValue(static_cast<bool>(value));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeInt) {
-    return foxglove::Parameter(name, static_cast<int64_t>(static_cast<int>(value)));
+    return foxglove::ParameterValue(static_cast<int64_t>(static_cast<int>(value)));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeDouble) {
-    return foxglove::Parameter(name, static_cast<double>(value));
+    return foxglove::ParameterValue(static_cast<double>(value));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeString) {
-    return foxglove::Parameter(name, static_cast<std::string>(value));
-  } else if (type == XmlRpc::XmlRpcValue::Type::TypeArray) {
-    if (value.size() == 0) {
-      // We can't defer the type in this case so we simply treat it as a int list
-      return foxglove::Parameter(name, std::vector<int>());
-    } else {
-      const auto firstElement = value[0];
-      const auto firstElementType = firstElement.getType();
-      if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeBoolean) {
-        return foxglove::Parameter(name, toVector<bool>(value));
-      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeInt) {
-        return foxglove::Parameter(name, toVector<int>(value));
-      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeDouble) {
-        return foxglove::Parameter(name, toVector<double>(value));
-      } else if (firstElementType == XmlRpc::XmlRpcValue::Type::TypeString) {
-        return foxglove::Parameter(name, toVector<std::string>(value));
-      } else {
-        throw std::runtime_error("Parameter '" + name + "': Unsupported parameter array type");
-      }
+    return foxglove::ParameterValue(static_cast<std::string>(value));
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeStruct) {
+    std::unordered_map<std::string, foxglove::ParameterValue> paramMap;
+    for (const auto& [elementName, elementVal] : value) {
+      paramMap.insert({elementName, fromRosParam(elementVal)});
     }
+    return foxglove::ParameterValue(paramMap);
+  } else if (type == XmlRpc::XmlRpcValue::Type::TypeArray) {
+    std::vector<foxglove::ParameterValue> paramVec;
+    for (int i = 0; i < value.size(); ++i) {
+      paramVec.push_back(fromRosParam(value[i]));
+    }
+    return foxglove::ParameterValue(paramVec);
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeInvalid) {
-    throw std::runtime_error("Parameter '" + name + "': Not set");
+    throw std::runtime_error("Parameter not set");
   } else {
-    throw std::runtime_error("Parameter '" + name + "': Unsupported parameter type");
+    throw std::runtime_error("Unsupported parameter type: " + std::to_string(type));
+  }
+}
+
+foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value) {
+  return foxglove::Parameter(name, fromRosParam(value));
+}
+
+XmlRpc::XmlRpcValue toRosParam(const foxglove::ParameterValue& param) {
+  const auto paramType = param.getType();
+  if (paramType == foxglove::ParameterType::PARAMETER_BOOL) {
+    return param.getValue<bool>();
+  } else if (paramType == foxglove::ParameterType::PARAMETER_INTEGER) {
+    return static_cast<int>(param.getValue<int64_t>());
+  } else if (paramType == foxglove::ParameterType::PARAMETER_DOUBLE) {
+    return param.getValue<double>();
+  } else if (paramType == foxglove::ParameterType::PARAMETER_STRING) {
+    return param.getValue<std::string>();
+  } else if (paramType == foxglove::ParameterType::PARAMETER_STRUCT) {
+    XmlRpc::XmlRpcValue valueStruct;
+    const auto& paramMap =
+      param.getValue<std::unordered_map<std::string, foxglove::ParameterValue>>();
+    for (const auto& [paramName, paramElement] : paramMap) {
+      valueStruct[paramName] = toRosParam(paramElement);
+    }
+    return valueStruct;
+  } else if (paramType == foxglove::ParameterType::PARAMETER_ARRAY) {
+    XmlRpc::XmlRpcValue arr;
+    const auto vec = param.getValue<std::vector<foxglove::ParameterValue>>();
+    for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
+      arr[i] = toRosParam(vec[i]);
+    }
+    return arr;
+  } else {
+    throw std::runtime_error("Unsupported parameter type");
   }
 
-  return foxglove::Parameter();
+  return XmlRpc::XmlRpcValue();
 }
 
 std::vector<std::regex> parseRegexPatterns(const std::vector<std::string>& patterns) {

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -685,29 +685,20 @@ private:
 
       try {
         const auto paramType = param.getType();
-        if (paramType == ParameterType::PARAMETER_BOOL) {
-          nh.setParam(paramName, param.getValue<bool>());
-        } else if (paramType == ParameterType::PARAMETER_INTEGER) {
-          nh.setParam(paramName, static_cast<int>(param.getValue<int64_t>()));
-        } else if (paramType == ParameterType::PARAMETER_DOUBLE) {
-          nh.setParam(paramName, param.getValue<double>());
-        } else if (paramType == ParameterType::PARAMETER_STRING) {
-          nh.setParam(paramName, param.getValue<std::string>());
-        } else if (paramType == ParameterType::PARAMETER_BOOL_ARRAY) {
-          nh.setParam(paramName, param.getValue<std::vector<bool>>());
-        } else if (paramType == ParameterType::PARAMETER_INTEGER_ARRAY) {
-          const auto int64Vec = param.getValue<std::vector<int64_t>>();
-          std::vector<int> intVec(int64Vec.begin(), int64Vec.end());
-          nh.setParam(paramName, intVec);
-        } else if (paramType == ParameterType::PARAMETER_DOUBLE_ARRAY) {
-          nh.setParam(paramName, param.getValue<std::vector<double>>());
-        } else if (paramType == ParameterType::PARAMETER_STRING_ARRAY) {
-          nh.setParam(paramName, param.getValue<std::vector<std::string>>());
-        } else if (paramType == ParameterType::PARAMETER_NOT_SET) {
+        const auto paramValue = param.getValue();
+        if (paramType == ParameterType::PARAMETER_NOT_SET) {
           nh.deleteParam(paramName);
+        } else {
+          nh.setParam(paramName, toRosParam(paramValue));
         }
       } catch (const std::exception& ex) {
         ROS_ERROR("Failed to set parameter '%s': %s", paramName.c_str(), ex.what());
+        success = false;
+      } catch (const XmlRpc::XmlRpcException& ex) {
+        ROS_ERROR("Failed to set parameter '%s': %s", paramName.c_str(), ex.getMessage().c_str());
+        success = false;
+      } catch (...) {
+        ROS_ERROR("Failed to set parameter '%s'", paramName.c_str());
         success = false;
       }
     }

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -178,14 +178,20 @@ TEST_F(ParameterTest, testGetParameters) {
     return param.getName() == PARAM_2_NAME;
   });
   ASSERT_NE(p1Iter, params.end());
-  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue<PARAM_1_TYPE>());
+  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue().getValue<PARAM_1_TYPE>());
   ASSERT_NE(p2Iter, params.end());
-  EXPECT_EQ(PARAM_2_DEFAULT_VALUE, p2Iter->getValue<PARAM_2_TYPE>());
+
+  std::vector<double> double_array_val;
+  const auto array_params = p2Iter->getValue().getValue<std::vector<foxglove::ParameterValue>>();
+  for (const auto& paramValue : array_params) {
+    double_array_val.push_back(paramValue.getValue<double>());
+  }
+  EXPECT_EQ(double_array_val, PARAM_2_DEFAULT_VALUE);
 }
 
 TEST_F(ParameterTest, testSetParameters) {
   const PARAM_1_TYPE newP1value = "world";
-  const PARAM_2_TYPE newP2value = {4.1, 5.5, 6.6};
+  const std::vector<foxglove::ParameterValue> newP2value = {4.1, 5.5, 6.6};
 
   const std::vector<foxglove::Parameter> parameters = {
     foxglove::Parameter(PARAM_1_NAME, newP1value),
@@ -207,9 +213,16 @@ TEST_F(ParameterTest, testSetParameters) {
     return param.getName() == PARAM_2_NAME;
   });
   ASSERT_NE(p1Iter, params.end());
-  EXPECT_EQ(newP1value, p1Iter->getValue<PARAM_1_TYPE>());
+  EXPECT_EQ(newP1value, p1Iter->getValue().getValue<PARAM_1_TYPE>());
   ASSERT_NE(p2Iter, params.end());
-  EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
+
+  std::vector<double> double_array_val;
+  const auto array_params = p2Iter->getValue().getValue<std::vector<foxglove::ParameterValue>>();
+  for (const auto& paramValue : array_params) {
+    double_array_val.push_back(paramValue.getValue<double>());
+  }
+  const std::vector<double> expected_value = {4.1, 5.5, 6.6};
+  EXPECT_EQ(double_array_val, expected_value);
 }
 
 TEST_F(ParameterTest, testSetParametersWithReqId) {

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -254,16 +254,22 @@ TEST_F(ParameterTest, testGetParameters) {
     return param.getName() == p2;
   });
   ASSERT_NE(p1Iter, params.end());
-  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue<PARAM_1_TYPE>());
+  EXPECT_EQ(PARAM_1_DEFAULT_VALUE, p1Iter->getValue().getValue<PARAM_1_TYPE>());
   ASSERT_NE(p2Iter, params.end());
-  EXPECT_EQ(PARAM_2_DEFAULT_VALUE, p2Iter->getValue<PARAM_2_TYPE>());
+
+  std::vector<int64_t> int_array_val;
+  const auto array_params = p2Iter->getValue().getValue<std::vector<foxglove::ParameterValue>>();
+  for (const auto& paramValue : array_params) {
+    int_array_val.push_back(paramValue.getValue<int64_t>());
+  }
+  EXPECT_EQ(int_array_val, PARAM_2_DEFAULT_VALUE);
 }
 
 TEST_F(ParameterTest, testSetParameters) {
   const auto p1 = NODE_1_NAME + "." + PARAM_1_NAME;
   const auto p2 = NODE_2_NAME + "." + PARAM_2_NAME;
   const PARAM_1_TYPE newP1value = "world";
-  const PARAM_2_TYPE newP2value = {4, 5, 6};
+  const std::vector<foxglove::ParameterValue> newP2value = {4, 5, 6};
 
   const std::vector<foxglove::Parameter> parameters = {
     foxglove::Parameter(p1, newP1value),
@@ -285,9 +291,16 @@ TEST_F(ParameterTest, testSetParameters) {
     return param.getName() == p2;
   });
   ASSERT_NE(p1Iter, params.end());
-  EXPECT_EQ(newP1value, p1Iter->getValue<PARAM_1_TYPE>());
+  EXPECT_EQ(newP1value, p1Iter->getValue().getValue<PARAM_1_TYPE>());
   ASSERT_NE(p2Iter, params.end());
-  EXPECT_EQ(newP2value, p2Iter->getValue<PARAM_2_TYPE>());
+
+  std::vector<int64_t> int_array_val;
+  const auto array_params = p2Iter->getValue().getValue<std::vector<foxglove::ParameterValue>>();
+  for (const auto& paramValue : array_params) {
+    int_array_val.push_back(paramValue.getValue<int64_t>());
+  }
+  const std::vector<int64_t> expected_value = {4, 5, 6};
+  EXPECT_EQ(int_array_val, expected_value);
 }
 
 TEST_F(ParameterTest, testSetParametersWithReqId) {


### PR DESCRIPTION
### Public-Facing Changes

- Add support for nested parameters (ROS1)

### Description
This PR adds support for parameter maps and arrays of parameter maps (ROS 1 only). To accomplish that, the existing `Parameter` class has been split up into a `ParameterValue` class which facilitates conversion to/from `xmlrpc::XmlRpcValue`.

Spec update: https://github.com/foxglove/ws-protocol/pull/434

Fixes #219 
