### PR TITLE
Fix warning messages not being logged

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -539,7 +539,7 @@ inline void Server<ServerConfiguration>::sendStatusAndLogMsg(ConnHandle clientHa
   const std::string endpoint = remoteEndpointString(clientHandle);
   const std::string logMessage = endpoint + ": " + message;
   const auto logLevel = StatusLevelToLogLevel(level);
-  auto logger = level == StatusLevel::Error ? _server.get_elog() : _server.get_alog();
+  auto logger = level == StatusLevel::Info ? _server.get_alog() : _server.get_elog();
   logger.write(logLevel, logMessage);
 
   sendJson(clientHandle, json{


### PR DESCRIPTION
### Public-Facing Changes

- Fix warning messages not being logged

### Description
Warning messages were erroneously written to websocketpp's access logger and got [effectively ignored](https://github.com/foxglove/ros-foxglove-bridge/blob/5ac9b6dd7beb21dedd9d9b296c923ac775a29277/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp#L61-L64) as [we limit](https://github.com/foxglove/ros-foxglove-bridge/blob/5ac9b6dd7beb21dedd9d9b296c923ac775a29277/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp#L225) what is logged through the access logger. This caused important warning messages such as e.g. the `Send buffer limit reached` warning not being made visible to the user. This PR fixes this by using the error logger for logging warning messages.


