### PR TITLE
Replaced set_difference to copy_if because it is used on unordered_set

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1291,10 +1291,14 @@ inline void Server<ServerConfiguration>::updateConnectionGraph(
   }
 
   std::vector<std::string> removedTopics, removedServices;
-  std::set_difference(knownTopicNames.begin(), knownTopicNames.end(), topicNames.begin(),
-                      topicNames.end(), std::back_inserter(removedTopics));
-  std::set_difference(knownServiceNames.begin(), knownServiceNames.end(), serviceNames.begin(),
-                      serviceNames.end(), std::back_inserter(removedServices));
+  std::copy_if(knownTopicNames.begin(), knownTopicNames.end(), std::back_inserter(removedTopics),
+               [&topicNames](const std::string& topic) {
+                 return topicNames.find(topic) == topicNames.end();
+               });
+  std::copy_if(knownServiceNames.begin(), knownServiceNames.end(),
+               std::back_inserter(removedServices), [&serviceNames](const std::string& service) {
+                 return serviceNames.find(service) == serviceNames.end();
+               });
 
   if (publisherDiff.empty() && subscriberDiff.empty() && servicesDiff.empty() &&
       removedTopics.empty() && removedServices.empty()) {


### PR DESCRIPTION
### Public-Facing Changes

- Correct calculation of removed topics and services while updating connection graph.

### Description
Originally commit: https://github.com/foxglove/ws-protocol/pull/437

> Now in websocket_server.hpp we have:
> 
> https://github.com/foxglove/ws-protocol/blob/5cdda39d9ed4e8287a5d27406f5e4f368bd0e1fc/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp#L1158-L1159
> 
> And to find difference between them function set_difference is used:
> 
> https://github.com/foxglove/ws-protocol/blob/5cdda39d9ed4e8287a5d27406f5e4f368bd0e1fc/cpp/foxglove-websocket/include/foxglove/websocket/websocket_server.hpp#L1203-L1206
> 
> According to documentation of [std::set_difference](https://en.cppreference.com/w/cpp/algorithm/set_difference) it can be used only for sorted ranges (which is not a case when we use unorderd_set).
> 
> To have O(1) complexity for insert and search operations on unordered_set, I suggest to use std::copy_if function to find difference between two unordered sets.


