### PR TITLE
Fix QoS history being unknown when copied from existing publisher

### DIFF
--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -580,11 +580,11 @@ void FoxgloveBridge::clientAdvertise(const foxglove::ClientAdvertisement& advert
                      return endpoint.node_name() != this->get_name() ||
                             endpoint.node_namespace() != this->get_namespace();
                    });
-    const rclcpp::QoS qos = otherPublisherIt == otherPublishers.end()
-                              ? rclcpp::SystemDefaultsQoS()
-                              : rclcpp::QoS(otherPublisherIt->qos_profile())
-                                  // Override the history policy as it can be `unknown`
-                                  .history(rclcpp::HistoryPolicy::SystemDefault);
+    rclcpp::QoS qos = otherPublisherIt == otherPublishers.end() ? rclcpp::SystemDefaultsQoS()
+                                                                : otherPublisherIt->qos_profile();
+    if (qos.history() == rclcpp::HistoryPolicy::Unknown) {
+      qos.history(rclcpp::HistoryPolicy::SystemDefault);
+    }
     rclcpp::PublisherOptions publisherOptions{};
     publisherOptions.callback_group = _clientPublishCallbackGroup;
     auto publisher = this->create_generic_publisher(topicName, topicType, qos, publisherOptions);

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -582,7 +582,9 @@ void FoxgloveBridge::clientAdvertise(const foxglove::ClientAdvertisement& advert
                    });
     const rclcpp::QoS qos = otherPublisherIt == otherPublishers.end()
                               ? rclcpp::SystemDefaultsQoS()
-                              : otherPublisherIt->qos_profile();
+                              : rclcpp::QoS(otherPublisherIt->qos_profile())
+                                  // Override the history policy as it can be `unknown`
+                                  .history(rclcpp::HistoryPolicy::SystemDefault);
     rclcpp::PublisherOptions publisherOptions{};
     publisherOptions.callback_group = _clientPublishCallbackGroup;
     auto publisher = this->create_generic_publisher(topicName, topicType, qos, publisherOptions);

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -582,6 +582,10 @@ void FoxgloveBridge::clientAdvertise(const foxglove::ClientAdvertisement& advert
                    });
     rclcpp::QoS qos = otherPublisherIt == otherPublishers.end() ? rclcpp::SystemDefaultsQoS()
                                                                 : otherPublisherIt->qos_profile();
+
+    // When the QoS profile is copied from another existing publisher, it can happen that the
+    // history policy is Unknown, leading to an error when subsequently trying to create a publisher
+    // with that QoS profile. As a fix, we explicitly set the history policy to the system default.
     if (qos.history() == rclcpp::HistoryPolicy::Unknown) {
       qos.history(rclcpp::HistoryPolicy::SystemDefault);
     }


### PR DESCRIPTION
### Public-Facing Changes
Fix QoS history being unknown when copied from existing publisher

### Description
When the QoS profile is copied from another existing publisher, it can happen that the history policy is `Unknown`, leading to an error when subsequently trying to create a publisher with that QoS profile. As a fix, we explicitly set the history policy to the system default.

Fixes https://github.com/foxglove/ros-foxglove-bridge/issues/200