### PR TITLE
devcontainer: Use `--include-eol-distros` for `rosdep update`

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -60,7 +60,7 @@ USER $USERNAME
 COPY --chown=$USERNAME:$USERNAME package.xml /ros_ws/src/ros-foxglove-bridge/package.xml
 
 # Initialize rosdep
-RUN sudo rosdep init && rosdep update
+RUN sudo rosdep init && rosdep update --include-eol-distros
 
 # Install rosdep dependencies for ROS 1
 RUN . /opt/ros/noetic/setup.sh && \
@@ -71,7 +71,7 @@ RUN . /opt/ros/noetic/setup.sh && \
 
 # Install rosdep dependencies for ROS 2
 RUN . /opt/ros/galactic/setup.sh && \
-    sudo apt-get update && rosdep update && rosdep install -y \
+    sudo apt-get update && rosdep update --include-eol-distros && rosdep install -y \
       --from-paths /ros_ws/src \
       --ignore-src \
     && sudo rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Our CI still runs builds for ROS distros that are end of life (such as `galactic`). The [lint](https://github.com/foxglove/ros-foxglove-bridge/blob/29ac3989383dc9f2e1d6862c73738422a87d8736/Makefile#L74-L76) job runs in a docker container build from `.devcontainer/Dockerfile` (galactic based). This PR adds `--include-eol-distros` for `rosdep update` such that the docker image build does not fail when new dependencies are added.
