### PR TITLE
Assume publisher qos depth of 1 if the middleware reports the qos history as unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 1) __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * (ROS 2) __num_threads__: The number of threads to use for the ROS node executor. This controls the number of subscriptions that can be processed in parallel. 0 means one thread per CPU core. Defaults to `0`.
  * (ROS 2) __min_qos_depth__: Minimum depth used for the QoS profile of subscriptions. Defaults to `1`. This is to set a lower limit for a subscriber's QoS depth which is computed by summing up depths of all publishers. See also [#208](https://github.com/foxglove/ros-foxglove-bridge/issues/208).
- * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `10`.
+ * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `25`.
  * (ROS 2) __include_hidden__: Include hidden topics and services. Defaults to `false`.
 
 ## Building from source

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -22,6 +22,9 @@ std::future<ServiceResponse> waitForServiceResponse(std::shared_ptr<ClientInterf
 std::future<Service> waitForService(std::shared_ptr<ClientInterface> client,
                                     const std::string& serviceName);
 
+std::future<Channel> waitForChannel(std::shared_ptr<ClientInterface> client,
+                                    const std::string& topicName);
+
 extern template class Client<websocketpp::config::asio_client>;
 
 }  // namespace foxglove

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -28,7 +28,7 @@ constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";
 constexpr int64_t DEFAULT_SEND_BUFFER_LIMIT = 10000000;
 constexpr int64_t DEFAULT_MIN_QOS_DEPTH = 1;
-constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 10;
+constexpr int64_t DEFAULT_MAX_QOS_DEPTH = 25;
 
 void declareParameters(rclcpp::Node* node);
 


### PR DESCRIPTION
### Public-Facing Changes

Assume publisher qos depth of 1 if the middleware reports the qos history as unknown

### Description
Some RMWs do not report history information of a publisher endpoint in which case the history depth is reported as 0. We internally use this depth to calculate an appropriate depth for the subscription, which uses the `KeepLast(depth)` history policy.
In case a publisher's history depth is reported as 0, we assume a depth of 1 so that the final history depth is at least equal to the number of publishers. This covers the case where there are multiple transient_local publishers with a depth of 1 (e.g. multiple tf_static transform broadcasters). Before this PR, a user would have to manually specify a `min_qos_depth` of N when having N tf_static broadcasters.

This PR also increases the max qos depth default value, 10 seemed very low. I'm not sure anymore why we added an upper limit in the first place. Additionally, a warning is logged when the upper limit is reached.

Fixes #238 
See also https://github.com/foxglove/ros-foxglove-bridge/issues/208