### PR TITLE
Reduce logging severity for parameter retrieval logs

### DIFF
--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -147,8 +147,8 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string>& para
       paramNamesByNodeName[nodeName].push_back(paramName);
     }
 
-    RCLCPP_INFO(_node->get_logger(), "Getting %zu parameters from %zu nodes...", paramNames.size(),
-                paramNamesByNodeName.size());
+    RCLCPP_DEBUG(_node->get_logger(), "Getting %zu parameters from %zu nodes...", paramNames.size(),
+                 paramNamesByNodeName.size());
   } else {
     // Make a map of node names to empty parameter lists
     // Only consider nodes that offer services to list & get parameters.
@@ -181,8 +181,8 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string>& para
     }
 
     if (!paramNamesByNodeName.empty()) {
-      RCLCPP_INFO(_node->get_logger(), "Getting all parameters from %zu nodes...",
-                  paramNamesByNodeName.size());
+      RCLCPP_DEBUG(_node->get_logger(), "Getting all parameters from %zu nodes...",
+                   paramNamesByNodeName.size());
     }
   }
 


### PR DESCRIPTION
### Public-Facing Changes

- Reduce logging severity for parameter retrieval logs

### Description
Foxglove Studio typically requests parameter values every 15s which triggers a log message being logged on the foxglove bridge side (ROS2). This PR reduces the log severity for this log message to avoid log spam.
