### PR TITLE
Fix ROS2 launch file install rule not installing launch subfolder

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -256,7 +256,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
       RUNTIME DESTINATION bin
     )
     install(DIRECTORY ros2_foxglove_bridge/launch/
-      DESTINATION share/${PROJECT_NAME}/
+      DESTINATION share/${PROJECT_NAME}
     )
     ament_export_libraries(foxglove_bridge_base foxglove_bridge_component)
     ament_package()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,8 +255,8 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
       LIBRARY DESTINATION lib
       RUNTIME DESTINATION bin
     )
-    install(DIRECTORY ros2_foxglove_bridge/launch/
-      DESTINATION share/${PROJECT_NAME}
+    install(DIRECTORY ros2_foxglove_bridge/launch
+      DESTINATION share/${PROJECT_NAME}/
     )
     ament_export_libraries(foxglove_bridge_base foxglove_bridge_component)
     ament_package()

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
 ```xml
 <launch>
   <!-- Including in another launch file -->
-  <include file="$(find-pkg-share foxglove_bridge)/foxglove_bridge_launch.xml"/>
+  <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml"/>
     <arg name="port" value="8765"/>
     <!-- ... other arguments ... -->
   </include>

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
 ```xml
 <launch>
   <!-- Including in another launch file -->
-  <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml"/>
+  <include file="$(find-pkg-share foxglove_bridge)/foxglove_bridge_launch.xml"/>
     <arg name="port" value="8765"/>
     <!-- ... other arguments ... -->
   </include>


### PR DESCRIPTION
### Public-Facing Changes

Fix ROS2 launch file install rule not installing launch subfolder

### Description

ROS2 launch file snippet in README.md had incorrect path to foxglove bridge launch file ` <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml">`. Path should be `  <include file="$(find-pkg-share foxglove_bridge)/foxglove_bridge_launch.xml">`

Fixes #242
Fixes FG-4181
