### PR TITLE
Use `--include-eol-distros` for `rosdep` to fix melodic builds

### DIFF
--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -18,7 +18,7 @@ COPY package.xml src/ros-foxglove-bridge/
 
 # Install rosdep dependencies
 RUN . /opt/ros/$ROS_DISTRO/setup.sh && \
-    apt-get update && rosdep update && rosdep install -y \
+    apt-get update && rosdep update --include-eol-distros && rosdep install -y \
       --from-paths \
         src \
       --ignore-src \


### PR DESCRIPTION
### Public-Facing Changes

Use `--include-eol-distros` for `rosdep` to fix melodic builds

### Description
Fixes melodic CI builds since melodic is EOL

See also https://github.com/foxglove/ros-foxglove-bridge/pull/243#issuecomment-1625385369