### PR TITLE
Avoid usage of tmpnam() for creating random filename

### DIFF
--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -1,8 +1,8 @@
 #include <chrono>
-#include <filesystem>
 #include <future>
 #include <thread>
 
+#include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
 #include <ros/ros.h>
 #include <std_msgs/builtin_string.h>
@@ -351,7 +351,7 @@ TEST(FetchAssetTest, fetchExistingAsset) {
   const auto millisSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(
     std::chrono::system_clock::now().time_since_epoch());
   const auto tmpFilePath =
-    std::filesystem::temp_directory_path() / std::to_string(millisSinceEpoch.count());
+    boost::filesystem::temp_directory_path() / std::to_string(millisSinceEpoch.count());
   constexpr char content[] = "Hello, world";
   FILE* tmpAssetFile = std::fopen(tmpFilePath.c_str(), "w");
   std::fputs(content, tmpAssetFile);

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -1,4 +1,5 @@
 #include <chrono>
+#include <filesystem>
 #include <future>
 #include <thread>
 
@@ -545,13 +546,16 @@ TEST(FetchAssetTest, fetchExistingAsset) {
   auto wsClient = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
   EXPECT_EQ(std::future_status::ready, wsClient->connect(URI).wait_for(DEFAULT_TIMEOUT));
 
-  const auto tmpFilePath = std::tmpnam(nullptr) + std::string(".txt");
+  const auto millisSinceEpoch = std::chrono::duration_cast<std::chrono::milliseconds>(
+    std::chrono::system_clock::now().time_since_epoch());
+  const auto tmpFilePath =
+    std::filesystem::temp_directory_path() / std::to_string(millisSinceEpoch.count());
   constexpr char content[] = "Hello, world";
   FILE* tmpAssetFile = std::fopen(tmpFilePath.c_str(), "w");
   std::fputs(content, tmpAssetFile);
   std::fclose(tmpAssetFile);
 
-  const std::string uri = std::string("file://") + tmpFilePath;
+  const std::string uri = std::string("file://") + tmpFilePath.string();
   const uint32_t requestId = 123;
 
   auto future = foxglove::waitForFetchAssetResponse(wsClient);


### PR DESCRIPTION
### Public-Facing Changes

Avoid usage of tmpnam() for creating random filename

### Description
Follow up of #232. ROS build farm complained about usage of `tmpnam`. This PR replaces it by using the epoch time in milliseconds to create a somewhat random filename (used for tests only)

https://build.ros2.org/job/Idev__foxglove_bridge__ubuntu_jammy_amd64/9/
