### PR TITLE
Communicate double / double array parameters with type info, explicitly cast when set from integer

### DIFF
--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -77,6 +77,13 @@ void to_json(nlohmann::json& j, const Parameter& p) {
   j["name"] = p.getName();
   if (p.getType() == ParameterType::PARAMETER_BYTE_ARRAY) {
     j["type"] = "byte_array";
+  } else if (p.getType() == ParameterType::PARAMETER_DOUBLE) {
+    j["type"] = "float64";
+  } else if (p.getType() == ParameterType::PARAMETER_ARRAY) {
+    const auto& vec = p.getValue().getValue<std::vector<ParameterValue>>();
+    if (!vec.empty() && vec.front().getType() == ParameterType::PARAMETER_DOUBLE) {
+      j["type"] = "float64_array";
+    }
   }
 }
 
@@ -90,10 +97,26 @@ void from_json(const nlohmann::json& j, Parameter& p) {
 
   ParameterValue pValue;
   from_json(j["value"], pValue);
+  const auto typeIt = j.find("type");
+  const std::string type = typeIt != j.end() ? typeIt->get<std::string>() : "";
 
-  if (j.find("type") != j.end() && j["type"] == "byte_array" &&
-      pValue.getType() == ParameterType::PARAMETER_STRING) {
+  if (pValue.getType() == ParameterType::PARAMETER_STRING && type == "byte_array") {
     p = Parameter(name, base64Decode(pValue.getValue<std::string>()));
+  } else if (pValue.getType() == ParameterType::PARAMETER_INTEGER && type == "float64") {
+    // Explicitly cast integer value to double.
+    p = Parameter(name, static_cast<double>(pValue.getValue<int64_t>()));
+  } else if (pValue.getType() == ParameterType::PARAMETER_ARRAY && type == "float64_array") {
+    // Explicitly cast elements to double, if possible.
+    auto values = pValue.getValue<std::vector<ParameterValue>>();
+    for (ParameterValue& value : values) {
+      if (value.getType() == ParameterType::PARAMETER_INTEGER) {
+        value = ParameterValue(static_cast<double>(value.getValue<int64_t>()));
+      } else if (value.getType() != ParameterType::PARAMETER_DOUBLE) {
+        throw std::runtime_error("Parameter '" + name +
+                                 "' (float64_array) contains non-float elements.");
+      }
+    }
+    p = Parameter(name, values);
   } else {
     p = Parameter(name, pValue);
   }

--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -113,7 +113,7 @@ void from_json(const nlohmann::json& j, Parameter& p) {
         value = ParameterValue(static_cast<double>(value.getValue<int64_t>()));
       } else if (value.getType() != ParameterType::PARAMETER_DOUBLE) {
         throw std::runtime_error("Parameter '" + name +
-                                 "' (float64_array) contains non-float elements.");
+                                 "' (float64_array) contains non-numeric elements.");
       }
     }
     p = Parameter(name, values);


### PR DESCRIPTION
### Public-Facing Changes
Communicate double / double array parameters with type info, explicitly cast when set from integer 

### Description
Implements https://github.com/foxglove/ws-protocol/pull/519

- When sending parameter values to the client, the server will include type information in case a parameter is of type `PARAMETER_DOUBLE` (`"type": "float64"`) or an `PARAMETER_ARRAY` of `PARAMETER_DOUBLE` (`"type": "float64_array"`)
- When receiving a `setParameters` request from the client, the server checks if the parameter `type` field is present and attempts to cast the parameter value (or values in case it's an array) to a `double` in case the type is `float64` / `float64_array`. This is mainly relevant for ROS2 as setting a double parameter to an integer will raise an exception. In ROS1, one can change the parameter type on the fly


