### PR TITLE
add debug config for ros2 smoke test

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -47,5 +47,24 @@
         }
       ]
     },
+    {
+      "name": "ROS2 smoke test",
+      "type": "cppdbg",
+      "request": "launch",
+      "program": "/ros_ws/build_ros2/foxglove_bridge/smoke_test",
+      "args": [],
+      "stopAtEntry": false,
+      "cwd": "${fileDirname}",
+      "environment": [],
+      "externalConsole": false,
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
   ]
 }


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Adds a vscode debug config for the ROS2 smoke test
