### PR TITLE
Reduce smoke test flakiness

### DIFF
--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -84,7 +84,7 @@ TEST(SmokeTest, testSubscription) {
     auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
     auto channelFuture = foxglove::waitForChannel(client, topic_name);
     ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
-    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(ONE_SECOND));
+    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(DEFAULT_TIMEOUT));
     const foxglove::Channel channel = channelFuture.get();
     const foxglove::SubscriptionId subscriptionId = 1;
 
@@ -124,7 +124,7 @@ TEST(SmokeTest, testSubscriptionParallel) {
   for (auto client : clients) {
     auto channelFuture = foxglove::waitForChannel(client, topic_name);
     ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
-    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(ONE_SECOND));
+    ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(DEFAULT_TIMEOUT));
     const foxglove::Channel channel = channelFuture.get();
     client->subscribe({{subscriptionId, channel.id}});
   }


### PR DESCRIPTION
### Public-Facing Changes

Reduce smoke test flakiness

### Description
Attempt to fix flaky smoke tests:

**ROS 1**
- Increased timeouts when waiting for channel to be communicated by the server
  - The ROS 1 server does not listen on graph changes, but instead periodically queries the ROS master for changes regarding available topics or services. The max. period between two consecutive ROS master queries is 5 seconds (default), hence we have to use the same timeout in the test.

**ROS 2**
- Use std::atomic for message handler that may be called concurrently
- Other minor improvements

