### PR TITLE
Make ROS1 service type retrieval more robust

### DIFF
--- a/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <chrono>
 #include <string>
 
 namespace foxglove_bridge {
@@ -8,6 +9,7 @@ namespace foxglove_bridge {
  * Opens a socket to the service server and retrieves the service type from the connection header.
  * This is necessary as the service type is not stored on the ROS master.
  */
-std::string retrieveServiceType(const std::string& serviceName, int timeout_ms);
+std::string retrieveServiceType(const std::string& serviceName,
+                                std::chrono::milliseconds timeout_ms);
 
 }  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/service_utils.hpp
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <future>
 #include <string>
 
 namespace foxglove_bridge {
@@ -9,6 +8,6 @@ namespace foxglove_bridge {
  * Opens a socket to the service server and retrieves the service type from the connection header.
  * This is necessary as the service type is not stored on the ROS master.
  */
-std::future<std::string> retrieveServiceType(const std::string& serviceName);
+std::string retrieveServiceType(const std::string& serviceName, int timeout_ms);
 
 }  // namespace foxglove_bridge

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -605,7 +605,8 @@ private:
       }
 
       try {
-        const auto serviceType = retrieveServiceType(serviceName, _serviceRetrievalTimeoutMs);
+        const auto serviceType =
+          retrieveServiceType(serviceName, std::chrono::milliseconds(_serviceRetrievalTimeoutMs));
         const auto srvDescription = _rosTypeInfoProvider.getServiceDescription(serviceType);
 
         foxglove::ServiceWithoutId service;

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -47,7 +47,7 @@ constexpr char ROS1_CHANNEL_ENCODING[] = "ros1";
 constexpr uint32_t SUBSCRIPTION_QUEUE_LENGTH = 10;
 constexpr double MIN_UPDATE_PERIOD_MS = 100.0;
 constexpr uint32_t PUBLICATION_QUEUE_LENGTH = 10;
-constexpr int SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS = 250;
+constexpr int DEFAULT_SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS = 250;
 
 using ConnectionHandle = websocketpp::connection_hdl;
 using TopicAndDatatype = std::pair<std::string, std::string>;
@@ -75,6 +75,8 @@ public:
     _capabilities = nhp.param<std::vector<std::string>>(
       "capabilities", std::vector<std::string>(foxglove::DEFAULT_CAPABILITIES.begin(),
                                                foxglove::DEFAULT_CAPABILITIES.end()));
+    _serviceRetrievalTimeoutMs = nhp.param<int>("service_type_retrieval_timeout_ms",
+                                                DEFAULT_SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS);
 
     const auto topicWhitelistPatterns =
       nhp.param<std::vector<std::string>>("topic_whitelist", {".*"});
@@ -602,15 +604,8 @@ private:
         continue;  // Already advertised
       }
 
-      auto serviceTypeFuture = retrieveServiceType(serviceName);
-      if (serviceTypeFuture.wait_for(std::chrono::milliseconds(
-            SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS)) != std::future_status::ready) {
-        ROS_WARN("Failed to retrieve type of service %s", serviceName.c_str());
-        continue;
-      }
-
       try {
-        const auto serviceType = serviceTypeFuture.get();
+        const auto serviceType = retrieveServiceType(serviceName, _serviceRetrievalTimeoutMs);
         const auto srvDescription = _rosTypeInfoProvider.getServiceDescription(serviceType);
 
         foxglove::ServiceWithoutId service;
@@ -919,6 +914,7 @@ private:
   ros::Subscriber _clockSubscription;
   bool _useSimTime = false;
   std::vector<std::string> _capabilities;
+  int _serviceRetrievalTimeoutMs = DEFAULT_SERVICE_TYPE_RETRIEVAL_TIMEOUT_MS;
   std::atomic<bool> _subscribeGraphUpdates = false;
   std::unique_ptr<foxglove::CallbackQueue> _fetchAssetQueue;
 };

--- a/ros1_foxglove_bridge/src/service_utils.cpp
+++ b/ros1_foxglove_bridge/src/service_utils.cpp
@@ -9,7 +9,7 @@
 
 namespace foxglove_bridge {
 
-std::string retrieveServiceType(const std::string& serviceName, int timeout_ms) {
+std::string retrieveServiceType(const std::string& serviceName, std::chrono::milliseconds timeout) {
   auto link = ros::ServiceManager::instance()->createServiceServerLink(serviceName, false, "*", "*",
                                                                        {{"probe", "1"}});
   std::promise<std::string> promise;
@@ -27,8 +27,8 @@ std::string retrieveServiceType(const std::string& serviceName, int timeout_ms) 
       return true;
     });
 
-  if (future.wait_for(std::chrono::milliseconds(timeout_ms)) != std::future_status::ready) {
-    throw std::runtime_error("Failed to retrieve service type");
+  if (future.wait_for(timeout) != std::future_status::ready) {
+    throw std::runtime_error("Timed out when retrieving service type");
   }
 
   return future.get();

--- a/ros1_foxglove_bridge/src/service_utils.cpp
+++ b/ros1_foxglove_bridge/src/service_utils.cpp
@@ -1,3 +1,6 @@
+#include <chrono>
+#include <future>
+
 #include <ros/connection.h>
 #include <ros/service_manager.h>
 #include <ros/service_server_link.h>
@@ -6,25 +9,29 @@
 
 namespace foxglove_bridge {
 
-std::future<std::string> retrieveServiceType(const std::string& serviceName) {
+std::string retrieveServiceType(const std::string& serviceName, int timeout_ms) {
   auto link = ros::ServiceManager::instance()->createServiceServerLink(serviceName, false, "*", "*",
                                                                        {{"probe", "1"}});
-  auto promise = std::make_shared<std::promise<std::string>>();
-  auto future = promise->get_future();
+  std::promise<std::string> promise;
+  auto future = promise.get_future();
 
   link->getConnection()->setHeaderReceivedCallback(
-    [promise = std::move(promise)](const ros::ConnectionPtr&, const ros::Header& header) mutable {
+    [&promise](const ros::ConnectionPtr&, const ros::Header& header) {
       std::string serviceType;
       if (header.getValue("type", serviceType)) {
-        promise->set_value(serviceType);
+        promise.set_value(serviceType);
       } else {
-        promise->set_exception(std::make_exception_ptr(
+        promise.set_exception(std::make_exception_ptr(
           std::runtime_error("Key 'type' not found in service connection header")));
       }
       return true;
     });
 
-  return future;
+  if (future.wait_for(std::chrono::milliseconds(timeout_ms)) != std::future_status::ready) {
+    throw std::runtime_error("Failed to retrieve service type");
+  }
+
+  return future.get();
 }
 
 }  // namespace foxglove_bridge


### PR DESCRIPTION
### Public-Facing Changes

Make ROS1 service type retrieval more robust

### Description
For ROS1, foxglove bridge has to retrieve the service type from the service server (by opening a connection) as the ROS master does not store the service type.

This patch makes service type retrieval more robust by
- Fixing the service link object getting out of scope too early
- Better exception handling
- Allowing users to set a custom timeout for service type retrieval

Fixes #262 
