### PR TITLE
Add websocket throughput test server / client

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,6 +87,13 @@ target_link_libraries(foxglove_bridge_base
   ZLIB::ZLIB
   ${CMAKE_THREAD_LIBS_INIT}
 )
+
+find_package(Boost COMPONENTS program_options REQUIRED)
+add_executable(perf_test_server foxglove_bridge_base/src/perf_test_server.cpp)
+target_link_libraries(perf_test_server foxglove_bridge_base Boost::program_options)
+add_executable(perf_test_client foxglove_bridge_base/src/perf_test_client.cpp)
+target_link_libraries(perf_test_client foxglove_bridge_base Boost::program_options)
+
 if(nlohmann_json_FOUND)
   target_link_libraries(foxglove_bridge_base nlohmann_json::nlohmann_json)
 else()
@@ -241,7 +248,7 @@ endif()
 #### INSTALL ###################################################################
 
 if(ROS_BUILD_TYPE STREQUAL "catkin")
-    install(TARGETS foxglove_bridge
+    install(TARGETS foxglove_bridge perf_test_server perf_test_client
       RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
     )
     install(TARGETS foxglove_bridge_base foxglove_bridge_nodelet
@@ -259,7 +266,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     install(FILES ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
       DESTINATION include/${PROJECT_NAME}/
     )
-    install(TARGETS foxglove_bridge
+    install(TARGETS foxglove_bridge perf_test_server perf_test_client
       DESTINATION lib/${PROJECT_NAME}
     )
     install(TARGETS foxglove_bridge_base foxglove_bridge_component

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -122,7 +122,8 @@ public:
       return;  // Already disconnected
     }
 
-    _endpoint.close(_con, websocketpp::close::status::going_away, "");
+    websocketpp::lib::error_code ec;
+    _endpoint.close(_con, websocketpp::close::status::going_away, "", ec);
     _con.reset();
   }
 

--- a/foxglove_bridge_base/src/perf_test_client.cpp
+++ b/foxglove_bridge_base/src/perf_test_client.cpp
@@ -1,12 +1,12 @@
+#include <atomic>
 #include <chrono>
 #include <iostream>
 #include <memory>
 #include <regex>
 #include <unordered_map>
 
-#include <websocketpp/config/asio_client.hpp>
-
 #include <foxglove_bridge/websocket_client.hpp>
+#include <foxglove_bridge/websocket_notls.hpp>
 
 struct ChannelStats {
   std::string topic;
@@ -19,7 +19,7 @@ struct ChannelStats {
 constexpr char DEFAULT_URI[] = "ws://localhost:8765";
 constexpr auto DEFAULT_TIMEOUT = std::chrono::seconds(5);
 
-bool doAbort = false;
+std::atomic<bool> doAbort = false;
 
 void signal_handler(int) {
   doAbort = true;
@@ -31,7 +31,7 @@ int main(int argc, char** argv) {
   std::unordered_map<foxglove::SubscriptionId, ChannelStats> channelStatsBySubId;
   std::unordered_map<foxglove::ChannelId, foxglove::SubscriptionId> subIdByChannelId;
   foxglove::SubscriptionId nextSubId = 0;
-  foxglove::Client<websocketpp::config::asio_client> client;
+  foxglove::Client<foxglove::WebSocketNoTls> client;
   size_t maxTopicCharLength = 0;
 
   client.setBinaryMessageHandler([&](const uint8_t* data, size_t dataLength) {

--- a/foxglove_bridge_base/src/perf_test_client.cpp
+++ b/foxglove_bridge_base/src/perf_test_client.cpp
@@ -1,0 +1,131 @@
+#include <chrono>
+#include <iostream>
+#include <memory>
+#include <regex>
+#include <unordered_map>
+
+#include <websocketpp/config/asio_client.hpp>
+
+#include <foxglove_bridge/websocket_client.hpp>
+
+struct ChannelStats {
+  std::string topic;
+  size_t bytesReceived = 0;
+  size_t msgsReceived = 0;
+  std::chrono::time_point<std::chrono::steady_clock> firstMsgTime;
+  std::chrono::time_point<std::chrono::steady_clock> lastMsgTime;
+};
+
+constexpr char DEFAULT_URI[] = "ws://localhost:8765";
+constexpr auto DEFAULT_TIMEOUT = std::chrono::seconds(5);
+
+bool doAbort = false;
+
+void signal_handler(int) {
+  doAbort = true;
+}
+
+int main(int argc, char** argv) {
+  const auto url = argc > 1 ? argv[1] : DEFAULT_URI;
+  const auto topicRegex = argc > 2 ? std::regex(argv[2]) : std::regex(".*");
+  std::unordered_map<foxglove::SubscriptionId, ChannelStats> channelStatsBySubId;
+  std::unordered_map<foxglove::ChannelId, foxglove::SubscriptionId> subIdByChannelId;
+  foxglove::SubscriptionId nextSubId = 0;
+  foxglove::Client<websocketpp::config::asio_client> client;
+  size_t maxTopicCharLength = 0;
+
+  client.setBinaryMessageHandler([&](const uint8_t* data, size_t dataLength) {
+    if (static_cast<foxglove::BinaryOpcode>(data[0]) != foxglove::BinaryOpcode::MESSAGE_DATA) {
+      return;
+    }
+
+    const auto subId = foxglove::ReadUint32LE(data + 1);
+    ChannelStats& channelStats = channelStatsBySubId[subId];
+    channelStats.msgsReceived++;
+    channelStats.bytesReceived += dataLength;
+    channelStats.lastMsgTime = std::chrono::steady_clock::now();
+    if (channelStats.msgsReceived == 1) {
+      channelStats.firstMsgTime = channelStats.lastMsgTime;
+    }
+  });
+
+  client.setTextMessageHandler([&](const std::string& payload) {
+    const auto msg = nlohmann::json::parse(payload);
+    const auto& op = msg["op"].get<std::string>();
+    if (op != "advertise") {
+      return;
+    }
+
+    const auto channels = msg["channels"].get<std::vector<foxglove::Channel>>();
+    std::vector<std::pair<foxglove::SubscriptionId, foxglove::ChannelId>> subscribePayload;
+
+    for (const auto& channel : channels) {
+      if (subIdByChannelId.find(channel.id) == subIdByChannelId.end() &&
+          std::regex_match(channel.topic, topicRegex)) {
+        const auto subId = nextSubId++;
+        subscribePayload.push_back({subId, channel.id});
+        subIdByChannelId.insert({channel.id, subId});
+        ChannelStats channelStats;
+        channelStats.topic = channel.topic;
+        channelStatsBySubId.insert({subId, channelStats});
+        maxTopicCharLength = std::max(maxTopicCharLength, channel.topic.size());
+      }
+    }
+
+    if (!subscribePayload.empty()) {
+      client.subscribe(subscribePayload);
+    }
+  });
+
+  const auto openHandler = [&](websocketpp::connection_hdl) {
+    std::cout << "Connected to " << std::string(url) << std::endl;
+  };
+  const auto closeHandler = [&](websocketpp::connection_hdl) {
+    std::cout << "Connection closed" << std::endl;
+    doAbort = true;
+  };
+
+  client.connect(url, openHandler, closeHandler);
+  std::signal(SIGINT, signal_handler);
+
+  while (!doAbort) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+  client.close();
+
+  size_t totalBytesRcvd = 0;
+  size_t totalMsgsRcvd = 0;
+  double totalBandwidth = 0;
+  std::cout << std::endl;
+  std::cout << "| " << std::setw(maxTopicCharLength) << "topic"
+            << " | Msgs rcvd |   bytes rcvd | bandwidth (b/s) |" << std::endl;
+  std::cout << "|-" << std::string(maxTopicCharLength, '-')
+            << "-|-----------|--------------|-----------------|" << std::endl;
+
+  for (const auto& [subId, stats] : channelStatsBySubId) {
+    (void)subId;
+    const auto duration =
+      std::chrono::duration_cast<std::chrono::milliseconds>(stats.lastMsgTime - stats.firstMsgTime)
+        .count();
+    const double bandwidth = static_cast<double>(stats.bytesReceived) / (duration / 1000.0);
+
+    std::cout << "| " << std::setw(maxTopicCharLength) << stats.topic << " | " << std::setw(9)
+              << stats.msgsReceived << " | " << std::setw(12) << stats.bytesReceived << " | "
+              << std::setw(15) << std::setprecision(2) << std::scientific << bandwidth << " |"
+              << std::endl;
+    totalBytesRcvd += stats.bytesReceived;
+    totalMsgsRcvd += stats.msgsReceived;
+    if (std::isnormal(bandwidth)) {
+      totalBandwidth += bandwidth;
+    }
+  }
+
+  std::cout << "|-" << std::string(maxTopicCharLength, '-')
+            << "-|-----------|--------------|-----------------|" << std::endl;
+  std::cout << "| " << std::setw(maxTopicCharLength) << "TOTAL"
+            << " | " << std::setw(9) << totalMsgsRcvd << " | " << std::setw(12) << totalBytesRcvd
+            << " | " << std::setw(15) << std::setprecision(2) << std::scientific << totalBandwidth
+            << " |" << std::endl;
+
+  return EXIT_SUCCESS;
+}

--- a/foxglove_bridge_base/src/perf_test_server.cpp
+++ b/foxglove_bridge_base/src/perf_test_server.cpp
@@ -1,0 +1,203 @@
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <fstream>
+#include <iostream>
+#include <mutex>
+#include <shared_mutex>
+#include <thread>
+#include <unordered_map>
+
+#include <boost/program_options.hpp>
+#include <nlohmann/json.hpp>
+
+#include <foxglove_bridge/server_factory.hpp>
+
+namespace po = boost::program_options;
+using ConnectionHandle = websocketpp::connection_hdl;
+
+struct ChannelConfig {
+  std::string topic;
+  int sizeInBytes;
+  double frequency;
+};
+
+std::atomic<bool> doAbort = false;
+std::unordered_map<foxglove::ChannelId, std::vector<ConnectionHandle>> subscriptions;
+std::shared_mutex subscriptionMutex;
+const std::vector<ChannelConfig> DEFAULT_CHANNELS = {
+  {"10 bytes @ 100 Hz", 10, 100.0},  {"10 bytes @ 500 Hz", 10, 500.0},
+  {"10 KB @ 100 Hz", 10000, 100.0},  {"10 KB @ 500 Hz", 10000, 500.0},
+  {"100 KB @ 10 Hz", 100000, 10.0},  {"100 KB @ 50 Hz", 100000, 50.0},
+  {"1 MB @ 10 Hz", 1000000, 10.0},   {"1 MB @ 50 Hz", 1000000, 50.0},
+  {"5 MB @ 10 Hz", 5000000, 10.0},   {"5 MB @ 20 Hz", 5000000, 20.0},
+  {"10 MB @ 10 Hz", 10000000, 10.0}, {"10 MB @ 20 Hz", 10000000, 20.0}};
+
+void from_json(const nlohmann::json& j, ChannelConfig& p) {
+  p.topic = j["topic"].get<std::string>();
+  p.frequency = j["frequency"].get<double>();
+  p.sizeInBytes = j["sizeInBytes"].get<int>();
+}
+
+void signal_handler(int) {
+  std::cout << "Received SIGINT, exiting..." << std::endl;
+  doAbort = true;
+}
+
+void logCallback(foxglove::WebSocketLogLevel level, char const* msg) {
+  switch (level) {
+    case foxglove::WebSocketLogLevel::Debug:
+      std::cout << "[DEBUG]" << msg << std::endl;
+      break;
+    case foxglove::WebSocketLogLevel::Info:
+      std::cout << "[INFO]" << msg << std::endl;
+      break;
+    case foxglove::WebSocketLogLevel::Warn:
+      std::cout << "[WARN]" << msg << std::endl;
+      break;
+    case foxglove::WebSocketLogLevel::Error:
+      std::cerr << "[ERROR]" << msg << std::endl;
+      break;
+    case foxglove::WebSocketLogLevel::Critical:
+      std::cerr << "[FATAL]" << msg << std::endl;
+      break;
+  }
+}
+
+void runFakeChannel(foxglove::ServerInterface<ConnectionHandle>* server,
+                    foxglove::ChannelId channelId, int sizeInBytes, double frequency) {
+  const std::vector<uint8_t> data(sizeInBytes);
+  if (frequency <= 0.0) return;
+  const uint64_t periodMs = static_cast<uint64_t>(1000.0 / frequency);
+
+  std::chrono::steady_clock::time_point lastTime = std::chrono::steady_clock::now();
+  while (!doAbort && server) {
+    // Calculate the time to sleep to maintain the desired frequency
+    const std::chrono::steady_clock::time_point currentTime = std::chrono::steady_clock::now();
+    const uint64_t elapsedMs =
+      std::chrono::duration_cast<std::chrono::milliseconds>(currentTime - lastTime).count();
+    const uint64_t sleepTimeMs = periodMs - elapsedMs;
+
+    if (sleepTimeMs > 0) {
+      std::this_thread::sleep_for(std::chrono::milliseconds(sleepTimeMs));
+    }
+
+    // Update the lastTime for the next iteration
+    lastTime = std::chrono::steady_clock::now();
+
+    std::shared_lock<std::shared_mutex> lock(subscriptionMutex);
+    const auto& subscriberHandles = subscriptions[channelId];
+    for (const auto hdl : subscriberHandles) {
+      server->sendMessage(hdl, channelId, 0, data.data(), data.size());
+    }
+  }
+}
+
+int main(int argc, char** argv) {
+  std::string address;
+  int port;
+  std::string channelConfigFile;
+  int sendBufferLimit;
+  std::string certfile;
+  std::string keyfile;
+
+  po::options_description desc("Options");
+  desc.add_options()("address", po::value<std::string>(&address)->default_value("0.0.0.0"),
+                     "Address to bind to")("port", po::value<int>(&port)->default_value(8765),
+                                           "Port to listen to")(
+    "send-buffer-limit", po::value<int>(&sendBufferLimit)->default_value(2e7),
+    "Send buffer limit in bytes")("channel-config", po::value<std::string>(&channelConfigFile),
+                                  "Path to JSON file with custom channels in the format "
+                                  "{topic: string, frequency: number, sizeInBytes:number}[].")(
+    "compression", "Enable per-message deflate compression")(
+    "certfile", po::value<std::string>(&certfile), "Path to the certificate to use for TLS")(
+    "keyfile", po::value<std::string>(&keyfile), "Path to the private key to use for TLS")(
+    "help", "Produce help message");
+
+  po::variables_map vm;
+  try {
+    po::store(po::parse_command_line(argc, argv, desc), vm);
+    po::notify(vm);
+  } catch (const po::error& e) {
+    std::cerr << "Error: " << e.what() << std::endl;
+    std::cerr << "Usage: " << argv[0] << " [options]" << std::endl << desc << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  if (vm.count("help")) {
+    std::cout << "Usage: " << argv[0] << " [options]" << std::endl << desc << std::endl;
+    return EXIT_SUCCESS;
+  }
+
+  const std::vector<ChannelConfig> channelConfig =
+    channelConfigFile.empty()
+      ? DEFAULT_CHANNELS
+      : nlohmann::json::parse(std::ifstream(channelConfigFile)).get<std::vector<ChannelConfig>>();
+
+  foxglove::ServerOptions serverOptions;
+  serverOptions.capabilities = {};
+  serverOptions.sendBufferLimitBytes = sendBufferLimit;
+  serverOptions.sessionId = std::to_string(std::time(nullptr));
+  serverOptions.useCompression = vm.count("compression");
+  serverOptions.useTls = !certfile.empty() && !keyfile.empty();
+  serverOptions.certfile = certfile;
+  serverOptions.keyfile = keyfile;
+  serverOptions.clientTopicWhitelistPatterns = {std::regex(".*")};
+
+  const auto logHandler = std::bind(&logCallback, std::placeholders::_1, std::placeholders::_2);
+  auto server = foxglove::ServerFactory::createServer<ConnectionHandle>("perf-test-server",
+                                                                        logHandler, serverOptions);
+
+  std::vector<foxglove::ChannelWithoutId> channelsWithoutId;
+  for (const auto& channelConfig : channelConfig) {
+    if (channelConfig.sizeInBytes > sendBufferLimit) {
+      std::cerr << "Message size of channel '" << channelConfig.topic
+                << "' is larger than the send buffer limit. No messages will be sent "
+                   "to clients."
+                << std::endl;
+    }
+    channelsWithoutId.emplace_back(foxglove::ChannelWithoutId{channelConfig.topic, "", "", "", ""});
+  }
+  const auto channelIds = server->addChannels(channelsWithoutId);
+  if (channelIds.size() != channelConfig.size()) {
+    std::cerr << "Failed to add channels" << std::endl;
+    return EXIT_FAILURE;
+  }
+
+  std::vector<std::thread> channelThreads;
+  for (size_t i = 0; i < channelConfig.size(); i++) {
+    const auto& cfg = channelConfig[i];
+    const auto channelId = channelIds[i];
+    channelThreads.emplace_back(runFakeChannel, server.get(), channelId, cfg.sizeInBytes,
+                                cfg.frequency);
+  }
+
+  foxglove::ServerHandlers<ConnectionHandle> hdlrs;
+  hdlrs.subscribeHandler = [&](foxglove::ChannelId channelId, ConnectionHandle hdl) {
+    std::unique_lock<std::shared_mutex> lock(subscriptionMutex);
+    auto& subscriberHandles = subscriptions[channelId];
+    subscriberHandles.push_back(hdl);
+  };
+  hdlrs.unsubscribeHandler = [&](foxglove::ChannelId channelId, ConnectionHandle hdl) {
+    std::unique_lock<std::shared_mutex> lock(subscriptionMutex);
+    auto& subscriberHandles = subscriptions[channelId];
+    const auto it = std::remove_if(subscriberHandles.begin(), subscriberHandles.end(),
+                                   [hdl](ConnectionHandle other) {
+                                     return !hdl.owner_before(other) && !other.owner_before(hdl);
+                                   });
+    subscriberHandles.erase(it, subscriberHandles.end());
+  };
+  server->setHandlers(std::move(hdlrs));
+  server->start(address, port);
+  std::signal(SIGINT, signal_handler);
+
+  while (!doAbort) {
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+  }
+
+  for (auto& thread : channelThreads) {
+    thread.join();
+  }
+  server->stop();
+  return EXIT_SUCCESS;
+}


### PR DESCRIPTION
### Public-Facing Changes

Add websocket throughput test server / client

### Description

Adds a server & client for testing websocket throughput. The server advertises various channels (low-bandwidth to high-bandwidth) which can be subscribed by the test client or https://foxglove.github.io/ws-protocol/ for measuring websocket throughput.

```
$ rosrun foxglove_bridge perf_test_server --help
Usage: /ros_ws/install_ros1/lib/foxglove_bridge/perf_test_server [options]
Options:
  --address arg (=0.0.0.0)            Address to bind to
  --port arg (=8765)                  Port to listen to
  --send-buffer-limit arg (=20000000) Send buffer limit in bytes
  --channel-config arg                Path to JSON file with custom channels in
                                      the format {topic: string, frequency: 
                                      number, sizeInBytes:number}[].
  --compression                       Enable per-message deflate compression
  --certfile arg                      Path to the certificate to use for TLS
  --keyfile arg                       Path to the private key to use for TLS
  --help                              Produce help message
```

```
$ rosrun foxglove_bridge perf_test_client 
Connected to ws://localhost:8765
^C
|             topic | Msgs rcvd |   bytes rcvd | bandwidth (b/s) |
|-------------------|-----------|--------------|-----------------|
| 10 bytes @ 100 Hz |      1043 |        23989 |        2.27e+03 |
| 10 bytes @ 500 Hz |      4858 |       111734 |        1.05e+04 |
|    10 KB @ 100 Hz |      1041 |     10423533 |        9.84e+05 |
|    10 KB @ 500 Hz |      4838 |     48442894 |        4.57e+06 |
|    100 KB @ 10 Hz |       106 |     10601378 |        1.01e+06 |
|    100 KB @ 50 Hz |       524 |     52406812 |        4.95e+06 |
|      1 MB @ 10 Hz |       106 |    106001378 |        1.00e+07 |
|      1 MB @ 50 Hz |       516 |    516006708 |        4.88e+07 |
|      5 MB @ 10 Hz |       105 |    525001365 |        5.02e+07 |
|      5 MB @ 20 Hz |       209 |   1045002717 |        9.93e+07 |
|     10 MB @ 10 Hz |       105 |   1050001365 |        1.01e+08 |
|     10 MB @ 20 Hz |       210 |   2100002730 |        2.00e+08 |
|-------------------|-----------|--------------|-----------------|
|             TOTAL |     13661 |   5464026603 |        5.20e+08 |
Connection closed
```