### PR TITLE
Fix delayed notification of clients about client published topic [ROS 1]

### DIFF
--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -345,6 +345,8 @@ private:
       ROS_INFO("Client %s is advertising \"%s\" (%s) on channel %d",
                _server->remoteEndpointString(clientHandle).c_str(), channel.topic.c_str(),
                channel.schemaName.c_str(), channel.channelId);
+      // Trigger topic discovery so other clients are immediately informed about this new topic.
+      updateAdvertisedTopics();
     } else {
       const auto errMsg =
         "Failed to create publisher for topic " + channel.topic + "(" + channel.schemaName + ")";


### PR DESCRIPTION
### Public-Facing Changes

Fix delayed notification of clients about client published topic [ROS 1]

### Description
We manually trigger topic discovery to avoid the delay that would incur when waiting for the next timer-triggered topic discovery. Only necessary for the ROS 1 implementation as the ROS 2 node listens for graph changes.

Fixes #273
Resolves FG-5729
