### PR TITLE
added explicit call to ParameterValue() to avoid clang error

### DIFF
--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -94,7 +94,7 @@ static foxglove::Parameter fromRosParam(const rclcpp::Parameter& p) {
   } else if (type == rclcpp::ParameterType::PARAMETER_BOOL_ARRAY) {
     std::vector<foxglove::ParameterValue> paramVec;
     for (const auto value : p.as_bool_array()) {
-      paramVec.push_back(value);
+      paramVec.push_back(foxglove::ParameterValue(value));
     }
     return foxglove::Parameter(p.get_name(), paramVec);
   } else if (type == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY) {


### PR DESCRIPTION
# Public-Facing Changes

None

# Description

## Fixed bug
<!-- describe what has changed, and motivation behind those changes -->

on macOS, when using clang++ as compiler, we get the following error message:
```ba
~/Developer/foxtest via 🅒 foxtest took 19s ➜
colcon build
Starting >>> foxglove_bridge
[Processing: foxglove_bridge]
--- stderr: foxglove_bridge
ld: warning: -pie being ignored. It is only used when linking a main executable
/Users/tudoroancea/Developer/foxtest/src/ros-foxglove-bridge/ros2_foxglove_bridge/src/parameter_interface.cpp:97:16: error: no matching member function for call to 'push_back'
      paramVec.push_back(value);
      ~~~~~~~~~^~~~~~~~~
/Users/tudoroancea/miniforge3/envs/ihm2/bin/../include/c++/v1/vector:591:62: note: candidate function not viable: no known conversion from 'const std::__bit_iterator<std::vector<bool>, true, 0>::reference' (aka 'const std::__bit_const_reference<std::vector<bool>>') to 'const std::vector<foxglove::ParameterValue>::value_type' (aka 'const foxglove::ParameterValue') for 1st argument
    _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(const_reference __x);
                                                             ^
/Users/tudoroancea/miniforge3/envs/ihm2/bin/../include/c++/v1/vector:593:62: note: candidate function not viable: no known conversion from 'const std::__bit_iterator<std::vector<bool>, true, 0>::reference' (aka 'const std::__bit_const_reference<std::vector<bool>>') to 'std::vector<foxglove::ParameterValue>::value_type' (aka 'foxglove::ParameterValue') for 1st argument
    _LIBCPP_CONSTEXPR_SINCE_CXX20 _LIBCPP_HIDE_FROM_ABI void push_back(value_type&& __x);
                                                             ^
1 error generated.
make[2]: *** [CMakeFiles/foxglove_bridge_component.dir/build.make:118: CMakeFiles/foxglove_bridge_component.dir/ros2_foxglove_bridge/src/parameter_interface.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:193: CMakeFiles/foxglove_bridge_component.dir/all] Error 2
make: *** [Makefile:146: all] Error 2
---
Failed   <<< foxglove_bridge [38.4s, exited with code 2]

Summary: 0 packages finished [38.8s]
  1 package failed: foxglove_bridge
  1 package had stderr output: foxglove_bridge
```

<!-- Link relevant Github issues. Use `Fixes #1234` to auto-close the issue after merging. -->

## How I fixed it

just explicitly called the constructor `foxglove::ParameterValue()`
