### PR TITLE
Add ROS 2 dependency for ament_index_cpp

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,7 +160,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros2_foxglove_bridge/include>
         $<INSTALL_INTERFACE:include>
     )
-    ament_target_dependencies(foxglove_bridge_component rclcpp rclcpp_components resource_retriever rosgraph_msgs)
+    ament_target_dependencies(foxglove_bridge_component ament_index_cpp rclcpp rclcpp_components resource_retriever rosgraph_msgs)
     target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
     rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")
     enable_strict_compiler_warnings(foxglove_bridge_component)


### PR DESCRIPTION
### Public-Facing Changes

None

### Description

There is a direct dependency in this package to ament_index_cpp, so make sure to add it.

This should fix the failing build on Rolling: https://build.ros2.org/view/Rbin_uJ64/job/Rbin_uJ64__foxglove_bridge__ubuntu_jammy_amd64__binary/89/
