### PR TITLE
Fix rolling builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,11 +155,12 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
       ros2_foxglove_bridge/src/generic_client.cpp
     )
 
-    # Check if the ROS_DISTRO is greater than iron and set a compile definition if that's the case.
-    string(COMPARE GREATER $ENV{ROS_DISTRO} "iron" ROS_DISTRO_GT_IRON)
-    if(ROS_DISTRO_GT_IRON)
-      target_compile_definitions(foxglove_bridge_component PRIVATE ROS_DISTRO_GT_IRON)
-    endif()
+    target_compile_definitions(foxglove_bridge_component
+      PRIVATE
+        RCLCPP_VERSION_MAJOR=${rclcpp_VERSION_MAJOR}
+        RCLCPP_VERSION_MINOR=${rclcpp_VERSION_MINOR}
+        RCLCPP_VERSION_PATCH=${rclcpp_VERSION_PATCH}
+    )
 
     target_include_directories(foxglove_bridge_component
       PUBLIC

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,13 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
       ros2_foxglove_bridge/src/parameter_interface.cpp
       ros2_foxglove_bridge/src/generic_client.cpp
     )
+
+    # Check if the ROS_DISTRO is greater than iron and set a compile definition if that's the case.
+    string(COMPARE GREATER $ENV{ROS_DISTRO} "iron" ROS_DISTRO_GT_IRON)
+    if(ROS_DISTRO_GT_IRON)
+      target_compile_definitions(foxglove_bridge_component PRIVATE ROS_DISTRO_GT_IRON)
+    endif()
+
     target_include_directories(foxglove_bridge_component
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>

--- a/ros2_foxglove_bridge/src/generic_client.cpp
+++ b/ros2_foxglove_bridge/src/generic_client.cpp
@@ -9,6 +9,19 @@
 
 #include <foxglove_bridge/generic_client.hpp>
 
+/* True if the version of RCLCPP is at least major.minor.patch */
+#define RCLCPP_VERSION_GTE(major, minor, patch)        \
+  (major < RCLCPP_VERSION_MAJOR                        \
+     ? true                                            \
+     : major > RCLCPP_VERSION_MAJOR                    \
+         ? false                                       \
+         : minor < RCLCPP_VERSION_MINOR                \
+             ? true                                    \
+             : minor > RCLCPP_VERSION_MINOR            \
+                 ? false                               \
+                 : patch < RCLCPP_VERSION_PATCH ? true \
+                                                : patch > RCLCPP_VERSION_PATCH ? false : true)
+
 namespace {
 
 // Copy of github.com/ros2/rclcpp/blob/33dae5d67/rclcpp/src/rclcpp/typesupport_helpers.cpp#L69-L92
@@ -123,7 +136,9 @@ GenericClient::GenericClient(rclcpp::node_interfaces::NodeBaseInterface* nodeBas
   _typeIntrospectionHdl = (reinterpret_cast<decltype(get_ts)>(
     _typeIntrospectionLib->get_symbol(typeinstrospection_symbol_name)))();
 
-#ifdef ROS_DISTRO_GT_IRON
+  // get_typesupport_handle is deprecated since rclcpp 25.0.0
+  // (https://github.com/ros2/rclcpp/pull/2209)
+#if RCLCPP_VERSION_GTE(25, 0, 0)
   _requestTypeSupportHdl =
     rclcpp::get_message_typesupport_handle(requestTypeName, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
   _responseTypeSupportHdl = rclcpp::get_message_typesupport_handle(

--- a/ros2_foxglove_bridge/src/generic_client.cpp
+++ b/ros2_foxglove_bridge/src/generic_client.cpp
@@ -123,10 +123,17 @@ GenericClient::GenericClient(rclcpp::node_interfaces::NodeBaseInterface* nodeBas
   _typeIntrospectionHdl = (reinterpret_cast<decltype(get_ts)>(
     _typeIntrospectionLib->get_symbol(typeinstrospection_symbol_name)))();
 
+#ifdef ROS_DISTRO_GT_IRON
+  _requestTypeSupportHdl =
+    rclcpp::get_message_typesupport_handle(requestTypeName, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
+  _responseTypeSupportHdl = rclcpp::get_message_typesupport_handle(
+    responseTypeName, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
+#else
   _requestTypeSupportHdl =
     rclcpp::get_typesupport_handle(requestTypeName, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
   _responseTypeSupportHdl =
     rclcpp::get_typesupport_handle(responseTypeName, TYPESUPPORT_LIB_NAME, *_typeSupportLib);
+#endif
 
   rcl_ret_t ret = rcl_client_init(this->get_client_handle().get(), this->get_rcl_node_handle(),
                                   _serviceTypeSupportHdl, serviceName.c_str(), &client_options);

--- a/ros2_foxglove_bridge/src/generic_client.cpp
+++ b/ros2_foxglove_bridge/src/generic_client.cpp
@@ -9,6 +9,7 @@
 
 #include <foxglove_bridge/generic_client.hpp>
 
+// clang-format off
 /* True if the version of RCLCPP is at least major.minor.patch */
 #define RCLCPP_VERSION_GTE(major, minor, patch)        \
   (major < RCLCPP_VERSION_MAJOR                        \
@@ -21,6 +22,7 @@
                  ? false                               \
                  : patch < RCLCPP_VERSION_PATCH ? true \
                                                 : patch > RCLCPP_VERSION_PATCH ? false : true)
+// clang-format on
 
 namespace {
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -534,7 +534,9 @@ void FoxgloveBridge::subscribe(foxglove::ChannelId channelId, ConnectionHandle c
   try {
     auto subscriber = this->create_generic_subscription(
       topic, datatype, qos,
-      std::bind(&FoxgloveBridge::rosMessageHandler, this, channelId, clientHandle, _1),
+      [this, channelId, clientHandle](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+        this->rosMessageHandler(channelId, clientHandle, msg);
+      },
       subscriptionOptions);
     subscriptionsByClient.emplace(clientHandle, std::move(subscriber));
   } catch (const std::exception& ex) {


### PR DESCRIPTION
### Public-Facing Changes
None

### Description
Fixes ROS rolling compile errors, namely:
- Replace std::bind wtih lambda to make it compatible with latest rolling changes
- Fix deprecation warning (`get_typesupport_handle` is deprecated on rolling)

Fixes #284 (hopefully)
Resolves FG-6444