### PR TITLE
Fix service definition parsing on ROS rolling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -243,6 +243,10 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     ament_target_dependencies(smoke_test rclcpp rclcpp_components std_msgs std_srvs)
     target_link_libraries(smoke_test foxglove_bridge_base)
     enable_strict_compiler_warnings(smoke_test)
+
+    ament_add_gtest(utils_test ros2_foxglove_bridge/tests/utils_test.cpp)
+    target_link_libraries(utils_test foxglove_bridge_component)
+    enable_strict_compiler_warnings(utils_test)
   endif()
 endif()
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -109,7 +109,7 @@ private:
   void logHandler(LogLevel level, char const* msg);
 
   void rosMessageHandler(const foxglove::ChannelId& channelId, ConnectionHandle clientHandle,
-                         std::shared_ptr<rclcpp::SerializedMessage> msg);
+                         std::shared_ptr<const rclcpp::SerializedMessage> msg);
 
   void serviceRequest(const foxglove::ServiceRequest& request, ConnectionHandle clientHandle);
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
@@ -30,7 +30,7 @@ inline std::vector<std::string> splitMessageDefinitions(std::istream& stream) {
   std::string line = "";
   std::string definition = "";
 
-  while (getline(stream, line)) {
+  while (std::getline(stream, line)) {
     if (line == "---") {
       definitions.push_back(trimString(definition));
       definition = "";

--- a/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
@@ -17,4 +17,30 @@ inline std::pair<std::string, std::string> getNodeAndNodeNamespace(const std::st
   return std::make_pair(fqnNodeName.substr(0, found), fqnNodeName.substr(found + 1));
 }
 
+inline std::string trimString(std::string& str) {
+  constexpr char whitespaces[] = "\t\n\r ";
+  str.erase(0, str.find_first_not_of(whitespaces));  // trim left
+  str.erase(str.find_last_not_of(whitespaces) + 1);  // trim right
+  return str;
+}
+
+inline std::vector<std::string> splitMessageDefinitions(std::istream& stream) {
+  std::vector<std::string> definitions;
+
+  std::string line = "";
+  std::string definition = "";
+
+  while (getline(stream, line)) {
+    if (line == "---") {
+      definitions.push_back(trimString(definition));
+      definition = "";
+    } else {
+      definition += line + "\n";
+    }
+  }
+
+  definitions.push_back(trimString(definition));
+  return definitions;
+}
+
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -31,6 +31,8 @@ static const std::unordered_set<std::string> PRIMITIVE_TYPES{
   "bool",  "byte",   "char",  "float32", "float64", "int8",   "uint8",
   "int16", "uint16", "int32", "uint32",  "int64",   "uint64", "string"};
 
+constexpr char SEP[] = "---\n";
+
 static std::set<std::string> parse_msg_dependencies(const std::string& text,
                                                     const std::string& package_context) {
   std::set<std::string> dependencies;
@@ -130,8 +132,6 @@ static std::string trim_string(std::string& str) {
 /// @return A tuple holding goal, result and feedback definitions
 static std::tuple<std::string, std::string, std::string> split_action_msg_definition(
   const std::string& action_definition) {
-  constexpr char SEP[] = "---";
-
   auto definitions = split_string(action_definition, SEP);
   if (definitions.size() != 3) {
     throw std::invalid_argument("Invalid action definition:\n" + action_definition);
@@ -145,8 +145,6 @@ static std::tuple<std::string, std::string, std::string> split_action_msg_defini
 /// @return A tuple holding request and response definitions
 static std::tuple<std::string, std::string> split_service_msg_definition(
   const std::string& service_definition) {
-  constexpr char SEP[] = "---";
-
   auto definitions = split_string(service_definition, SEP);
   if (definitions.size() != 2) {
     throw std::invalid_argument("Invalid service definition:\n" + service_definition);

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -226,14 +226,16 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   }
 
   if (subfolder == "action") {
-    const auto splitDefinitions = foxglove_bridge::splitMessageDefinitions(file);
-    if (splitDefinitions.size() != 3) {
-      throw std::invalid_argument("Invalid action definition: " + filename);
+    const auto split_definitions = foxglove_bridge::splitMessageDefinitions(file);
+    if (split_definitions.size() != 3) {
+      throw std::invalid_argument("Invalid action definition in " + filename +
+                                  ": Expected 3 definitions, got " +
+                                  std::to_string(split_definitions.size()));
     }
 
-    const auto& goalDef = splitDefinitions[0];
-    const auto& resultDef = splitDefinitions[1];
-    const auto& feedbackDef = splitDefinitions[2];
+    const auto& goalDef = split_definitions[0];
+    const auto& resultDef = split_definitions[1];
+    const auto& feedbackDef = split_definitions[2];
 
     // Define type definitions for each action subtype.
     // These type definitions may include additional fields such as the goal_id.
@@ -266,13 +268,15 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
     }
     return it->second;
   } else if (subfolder == "srv") {
-    const auto splitDefinitions = foxglove_bridge::splitMessageDefinitions(file);
-    if (splitDefinitions.size() != 2) {
-      throw std::invalid_argument("Invalid service definition: " + filename);
+    const auto split_definitions = foxglove_bridge::splitMessageDefinitions(file);
+    if (split_definitions.size() != 2) {
+      throw std::invalid_argument("Invalid service definition in " + filename +
+                                  ": Expected 2 definitions, got " +
+                                  std::to_string(split_definitions.size()));
     }
 
-    const auto& requestDef = splitDefinitions[0];
-    const auto& responseDef = splitDefinitions[1];
+    const auto& requestDef = split_definitions[0];
+    const auto& responseDef = split_definitions[1];
     const std::map<std::string, std::string> service_type_definitions = {
       {SERVICE_REQUEST_MESSAGE_SUFFIX, requestDef}, {SERVICE_RESPONSE_MESSAGE_SUFFIX, responseDef}};
 

--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -118,19 +118,26 @@ static std::vector<std::string> split_string(const std::string& str,
   return strings;
 }
 
+static std::string trim_string(std::string& str) {
+  constexpr char whitespaces[] = "\t\n\r ";
+  str.erase(0, str.find_first_not_of(whitespaces));  // trim left
+  str.erase(str.find_last_not_of(whitespaces) + 1);  // trim right
+  return str;
+}
+
 /// @brief Split an action definition into individual goal, result and feedback definitions.
 /// @param action_definition The full action definition as read from a .action file
 /// @return A tuple holding goal, result and feedback definitions
 static std::tuple<std::string, std::string, std::string> split_action_msg_definition(
   const std::string& action_definition) {
-  constexpr char SEP[] = "\n---\n";
+  constexpr char SEP[] = "---";
 
-  const auto definitions = split_string(action_definition, SEP);
+  auto definitions = split_string(action_definition, SEP);
   if (definitions.size() != 3) {
     throw std::invalid_argument("Invalid action definition:\n" + action_definition);
   }
 
-  return {definitions[0], definitions[1], definitions[2]};
+  return {trim_string(definitions[0]), trim_string(definitions[1]), trim_string(definitions[2])};
 }
 
 /// @brief Split an service definition into individual request and response definitions.
@@ -138,14 +145,14 @@ static std::tuple<std::string, std::string, std::string> split_action_msg_defini
 /// @return A tuple holding request and response definitions
 static std::tuple<std::string, std::string> split_service_msg_definition(
   const std::string& service_definition) {
-  constexpr char SEP[] = "---\n";
+  constexpr char SEP[] = "---";
 
-  const auto definitions = split_string(service_definition, SEP);
+  auto definitions = split_string(service_definition, SEP);
   if (definitions.size() != 2) {
     throw std::invalid_argument("Invalid service definition:\n" + service_definition);
   }
 
-  return {definitions[0], definitions[1]};
+  return {trim_string(definitions[0]), trim_string(definitions[1])};
 }
 
 inline bool ends_with(const std::string& str, const std::string& suffix) {

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -126,7 +126,7 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   if (_useSimTime) {
     _clockSubscription = this->create_subscription<rosgraph_msgs::msg::Clock>(
       "/clock", rclcpp::QoS{rclcpp::KeepLast(1)}.best_effort(),
-      [&](std::shared_ptr<rosgraph_msgs::msg::Clock> msg) {
+      [&](std::shared_ptr<const rosgraph_msgs::msg::Clock> msg) {
         const auto timestamp = rclcpp::Time{msg->clock}.nanoseconds();
         assert(timestamp >= 0 && "Timestamp is negative");
         _server->broadcastTime(static_cast<uint64_t>(timestamp));
@@ -534,7 +534,7 @@ void FoxgloveBridge::subscribe(foxglove::ChannelId channelId, ConnectionHandle c
   try {
     auto subscriber = this->create_generic_subscription(
       topic, datatype, qos,
-      [this, channelId, clientHandle](std::shared_ptr<rclcpp::SerializedMessage> msg) {
+      [this, channelId, clientHandle](std::shared_ptr<const rclcpp::SerializedMessage> msg) {
         this->rosMessageHandler(channelId, clientHandle, msg);
       },
       subscriptionOptions);
@@ -770,7 +770,7 @@ void FoxgloveBridge::logHandler(LogLevel level, char const* msg) {
 
 void FoxgloveBridge::rosMessageHandler(const foxglove::ChannelId& channelId,
                                        ConnectionHandle clientHandle,
-                                       std::shared_ptr<rclcpp::SerializedMessage> msg) {
+                                       std::shared_ptr<const rclcpp::SerializedMessage> msg) {
   // NOTE: Do not call any RCLCPP_* logging functions from this function. Otherwise, subscribing
   // to `/rosout` will cause a feedback loop
   const auto timestamp = this->now().nanoseconds();

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -537,6 +537,24 @@ TEST_F(ParameterTest, testGetParametersParallel) {
   }
 }
 
+TEST_F(ServiceTest, testAdvertiseService) {
+  auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
+  auto serviceFuture = foxglove::waitForService(client, SERVICE_NAME);
+  ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
+  ASSERT_EQ(std::future_status::ready, serviceFuture.wait_for(DEFAULT_TIMEOUT));
+  const foxglove::Service service = serviceFuture.get();
+
+  EXPECT_EQ(service.name, SERVICE_NAME);
+  EXPECT_EQ(service.type, "std_srvs/srv/SetBool");
+  EXPECT_EQ(service.requestSchema, "bool data # e.g. for hardware enabling / disabling\n");
+  EXPECT_EQ(service.responseSchema,
+            "bool success   # indicate successful run of triggered service\nstring message # "
+            "informational, e.g. for error messages\n");
+
+  std_srvs::srv::SetBool::Request requestMsg;
+  requestMsg.data = true;
+}
+
 TEST_F(ServiceTest, testCallServiceParallel) {
   // Connect a few clients (in parallel) and make sure that they can all call the service
   auto clients = {

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -546,10 +546,10 @@ TEST_F(ServiceTest, testAdvertiseService) {
 
   EXPECT_EQ(service.name, SERVICE_NAME);
   EXPECT_EQ(service.type, "std_srvs/srv/SetBool");
-  EXPECT_EQ(service.requestSchema, "bool data # e.g. for hardware enabling / disabling\n");
+  EXPECT_EQ(service.requestSchema, "bool data # e.g. for hardware enabling / disabling");
   EXPECT_EQ(service.responseSchema,
             "bool success   # indicate successful run of triggered service\nstring message # "
-            "informational, e.g. for error messages\n");
+            "informational, e.g. for error messages");
 
   std_srvs::srv::SetBool::Request requestMsg;
   requestMsg.data = true;

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -263,7 +263,7 @@ TEST(SmokeTest, testPublishing) {
   auto msgFuture = msgPromise.get_future();
   auto node = rclcpp::Node::make_shared("tester");
   auto sub = node->create_subscription<std_msgs::msg::String>(
-    advertisement.topic, 10, [&msgPromise](const std_msgs::msg::String::SharedPtr msg) {
+    advertisement.topic, 10, [&msgPromise](std::shared_ptr<const std_msgs::msg::String> msg) {
       msgPromise.set_value(msg->data);
     });
   rclcpp::executors::SingleThreadedExecutor executor;
@@ -300,7 +300,7 @@ TEST_F(ExistingPublisherTest, testPublishingWithExistingPublisher) {
   auto msgFuture = msgPromise.get_future();
   auto node = rclcpp::Node::make_shared("tester");
   auto sub = node->create_subscription<std_msgs::msg::String>(
-    advertisement.topic, 10, [&msgPromise](const std_msgs::msg::String::SharedPtr msg) {
+    advertisement.topic, 10, [&msgPromise](std::shared_ptr<const std_msgs::msg::String> msg) {
       msgPromise.set_value(msg->data);
     });
   rclcpp::executors::SingleThreadedExecutor executor;

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -550,9 +550,6 @@ TEST_F(ServiceTest, testAdvertiseService) {
   EXPECT_EQ(service.responseSchema,
             "bool success   # indicate successful run of triggered service\nstring message # "
             "informational, e.g. for error messages");
-
-  std_srvs::srv::SetBool::Request requestMsg;
-  requestMsg.data = true;
 }
 
 TEST_F(ServiceTest, testCallServiceParallel) {

--- a/ros2_foxglove_bridge/tests/utils_test.cpp
+++ b/ros2_foxglove_bridge/tests/utils_test.cpp
@@ -1,0 +1,79 @@
+#include <gtest/gtest.h>
+
+#include <foxglove_bridge/utils.hpp>
+
+TEST(SplitDefinitionsTest, EmptyMessageDefinition) {
+  const std::string messageDef = "";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 1u);
+  EXPECT_EQ(definitions[0], "");
+}
+
+TEST(SplitDefinitionsTest, ServiceDefinition) {
+  const std::string messageDef =
+    "bool data\n"
+    "---\n"
+    "bool success ";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 2u);
+  EXPECT_EQ(definitions[0], "bool data");
+  EXPECT_EQ(definitions[1], "bool success");
+}
+
+TEST(SplitDefinitionsTest, ServiceDefinitionEmptyRequest) {
+  const std::string messageDef =
+    "---\n"
+    "bool success ";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 2u);
+  EXPECT_EQ(definitions[0], "");
+  EXPECT_EQ(definitions[1], "bool success");
+}
+
+TEST(SplitDefinitionsTest, ServiceDefinitionEmptyResponse) {
+  const std::string messageDef =
+    "bool data\n"
+    "---";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 2u);
+  EXPECT_EQ(definitions[0], "bool data");
+  EXPECT_EQ(definitions[1], "");
+}
+
+TEST(SplitDefinitionsTest, ActionDefinition) {
+  const std::string messageDef =
+    "bool data\n"
+    "---\n"
+    "bool success\n"
+    "---\n"
+    "bool feedback";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 3u);
+  EXPECT_EQ(definitions[0], "bool data");
+  EXPECT_EQ(definitions[1], "bool success");
+  EXPECT_EQ(definitions[2], "bool feedback");
+}
+
+TEST(SplitDefinitionsTest, ActionDefinitionNoGoal) {
+  const std::string messageDef =
+    "bool data\n"
+    "---\n"
+    "---\n"
+    "bool feedback";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 3u);
+  EXPECT_EQ(definitions[0], "bool data");
+  EXPECT_EQ(definitions[1], "");
+  EXPECT_EQ(definitions[2], "bool feedback");
+}
+
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
### Changelog
Fix service definition parsing on ROS rolling

### Description
Prior to this change, we used the auto-generated `_Request.msg` and `_Response.msg` message definitions for parsing a service's request and response definition. However, these message definitions have been removed in https://github.com/ros2/rosidl/pull/753 causing foxglove bridge to raise warnings that the service definition could not be found. This PR changes the service definition parsing to lookup the service definition using the `.srv` file and splitting the content using the `===` seperator to obtain the request and response definition.