### PR TITLE
Update README.md to remove '$ ' so that you can copy and run command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The `foxglove_bridge` uses the [Foxglove WebSocket protocol](https://github.com/
 The `foxglove_bridge` package is available for ROS 1 Melodic and Noetic, and ROS 2 Humble and Rolling. Earlier releases of ROS will not be supported due to API design and/or performance limitations. The package can be installed with the following command:
 
 ```bash
-$ sudo apt install ros-$ROS_DISTRO-foxglove-bridge
+sudo apt install ros-$ROS_DISTRO-foxglove-bridge
 ```
 
 ## Running the bridge
@@ -32,7 +32,7 @@ To run the bridge node, it is recommended to use the provided launch file:
 **ROS 1**
 
 ```bash
-$ roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
+roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
 ```
 
 ```xml
@@ -48,7 +48,7 @@ $ roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
 **ROS 2**
 
 ```bash
-$ ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
+ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
 ```
 
 ```xml


### PR DESCRIPTION
because of the extra '$ ' this happens:

```
(spot_mini_env) vscode@gdogv10:~/catkin_ws/src$ $ roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
bash: $: command not found
```

### Changelog
fixed typo in readme so you can paste commands to the terminal

### Description

I forget the command to start foxglove bridge, so I google 'foxglove bridge github', end up at the README, copy and paste the command to my terminal and then this happens:
```
(spot_mini_env) vscode@gdogv10:~/catkin_ws/src$ $ roslaunch --screen foxglove_bridge foxglove_bridge.launch port:=8765
bash: $: command not found
```

the extra '$ '  needs to be removed...
