### PR TITLE
Potential for documentation copy-paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ $ ros2 launch foxglove_bridge foxglove_bridge_launch.xml port:=8765
 ```xml
 <launch>
   <!-- Including in another launch file -->
-  <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml"/>
+  <include file="$(find-pkg-share foxglove_bridge)/launch/foxglove_bridge_launch.xml">
     <arg name="port" value="8765"/>
     <!-- ... other arguments ... -->
   </include>


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

Documentation typo error.

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->

The example given for including the foxglove bridge launch file in another XML launch file in ROS2 had an extra forward slash that was removed.

Prevent copy-paste issue.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

```shell
[INFO] [launch]: Default logging verbosity is set to INFO
[ERROR] [launch]: Caught exception in launch (see debug for traceback): Caught multiple exceptions when trying to load file of format [xml]:
 - InvalidFrontendLaunchFileError: Caught multiple exceptions when trying to load file of format [xml]:
 - ParseError: mismatched tag: line 6, column 4
 - RuntimeError: Expected only one root
 - SyntaxError: invalid syntax (foxglove_bridge_launch.xml, line 1)

``` 

</td><td>



</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

