### PR TITLE
send service call failure operation

### DIFF
--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -99,6 +99,8 @@ public:
   virtual void broadcastTime(uint64_t timestamp) = 0;
   virtual void sendServiceResponse(ConnectionHandle clientHandle,
                                    const ServiceResponse& response) = 0;
+  virtual void sendServiceFailure(ConnectionHandle clientHandle, ServiceId serviceId,
+                                  uint32_t callId, const std::string& message) = 0;
   virtual void updateConnectionGraph(const MapOfSets& publishedTopics,
                                      const MapOfSets& subscribedTopics,
                                      const MapOfSets& advertisedServices) = 0;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -773,7 +773,7 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
         const std::string errMessage =
           "Invalid service call request length " + std::to_string(length);
         sendServiceFailure(hdl, request.serviceId, request.callId, errMessage);
-        sendStatusAndLogMsg(hdl, StatusLevel::Error, errMessage);
+        _server.get_elog().write(RECOVERABLE, errMessage);
         return;
       }
 
@@ -785,7 +785,7 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
           const std::string errMessage =
             "Service " + std::to_string(request.serviceId) + " is not advertised";
           sendServiceFailure(hdl, request.serviceId, request.callId, errMessage);
-          sendStatusAndLogMsg(hdl, StatusLevel::Error, errMessage);
+          _server.get_elog().write(RECOVERABLE, errMessage);
           return;
         }
       }
@@ -798,7 +798,7 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
         _handlers.serviceRequestHandler(request, hdl);
       } catch (const std::exception& e) {
         sendServiceFailure(hdl, request.serviceId, request.callId, e.what());
-        sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
+        _server.get_elog().write(RECOVERABLE, e.what());
       }
     } break;
     default: {

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -604,7 +604,7 @@ TEST_F(ServiceTest, testCallServiceParallel) {
   }
 }
 
-TEST_F(ServiceTest, testCallNonexistantService) {
+TEST_F(ServiceTest, testCallNonexistentService) {
   auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
   ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(std::chrono::seconds(5)));
 
@@ -626,7 +626,7 @@ TEST_F(ServiceTest, testCallNonexistantService) {
 
   ASSERT_EQ(std::future_status::ready, serviceFailureFuture.wait_for(std::chrono::seconds(5)));
   const auto failureMsg = serviceFailureFuture.get();
-  EXPECT_EQ(failureMsg["serviceId"].get<uint32_t>(), request.serviceId);
+  EXPECT_EQ(failureMsg["serviceId"].get<foxglove::ServiceId>(), request.serviceId);
   EXPECT_EQ(failureMsg["callId"].get<uint32_t>(), request.callId);
 }
 


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->

### Description
Similar to https://github.com/foxglove/ws-protocol/pull/743, this PR implements the recently added `serviceCallFailure` operation that was added inhttps://github.com/foxglove/ws-protocol/pull/733. This operation is sent to a client when the service call failed or if the service could not be found to avoid that the client potentially waits forever for a service response message.