### PR TITLE
Fix srv definition parsing failing due to carriage return

### DIFF
--- a/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/utils.hpp
@@ -31,6 +31,7 @@ inline std::vector<std::string> splitMessageDefinitions(std::istream& stream) {
   std::string definition = "";
 
   while (std::getline(stream, line)) {
+    line = trimString(line);
     if (line == "---") {
       definitions.push_back(trimString(definition));
       definition = "";

--- a/ros2_foxglove_bridge/tests/utils_test.cpp
+++ b/ros2_foxglove_bridge/tests/utils_test.cpp
@@ -73,6 +73,17 @@ TEST(SplitDefinitionsTest, ActionDefinitionNoGoal) {
   EXPECT_EQ(definitions[2], "bool feedback");
 }
 
+TEST(SplitDefinitionsTest, HandleCarriageReturn) {
+  const std::string messageDef =
+    "---\r\n"
+    "string device_name\n";
+  std::istringstream stream(messageDef);
+  const auto definitions = foxglove_bridge::splitMessageDefinitions(stream);
+  ASSERT_EQ(definitions.size(), 2u);
+  EXPECT_EQ(definitions[0], "");
+  EXPECT_EQ(definitions[1], "string device_name");
+}
+
 int main(int argc, char** argv) {
   testing::InitGoogleTest(&argc, argv);
   return RUN_ALL_TESTS();


### PR DESCRIPTION
### Changelog
Fix srv definition parsing failing due to carriage return

### Docs
None

### Description
Fixes srv (or action) definition parsing failing when the definition seperator `---` is terminated with `\r\n` instead of just `\n`. More details in #301.

Fixes: #301

