### PR TITLE
add "rosx_introspection" to support JSON encoding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,6 +24,7 @@ macro(enable_strict_compiler_warnings target)
   endif()
 endmacro()
 
+find_package(nlohmann_json QUIET)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -86,7 +87,11 @@ target_link_libraries(foxglove_bridge_base
   ZLIB::ZLIB
   ${CMAKE_THREAD_LIBS_INIT}
 )
-
+if(nlohmann_json_FOUND)
+  target_link_libraries(foxglove_bridge_base nlohmann_json::nlohmann_json)
+else()
+  message(STATUS "nlohmann_json not found, will search at compile time")
+endif()
 enable_strict_compiler_warnings(foxglove_bridge_base)
 
 message(STATUS "ROS_VERSION: " $ENV{ROS_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,7 +24,6 @@ macro(enable_strict_compiler_warnings target)
   endif()
 endmacro()
 
-find_package(nlohmann_json QUIET)
 find_package(OpenSSL REQUIRED)
 find_package(Threads REQUIRED)
 find_package(websocketpp REQUIRED)
@@ -87,11 +86,7 @@ target_link_libraries(foxglove_bridge_base
   ZLIB::ZLIB
   ${CMAKE_THREAD_LIBS_INIT}
 )
-if(nlohmann_json_FOUND)
-  target_link_libraries(foxglove_bridge_base nlohmann_json::nlohmann_json)
-else()
-  message(STATUS "nlohmann_json not found, will search at compile time")
-endif()
+
 enable_strict_compiler_warnings(foxglove_bridge_base)
 
 message(STATUS "ROS_VERSION: " $ENV{ROS_VERSION})
@@ -146,6 +141,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     find_package(rclcpp REQUIRED)
     find_package(rclcpp_components REQUIRED)
     find_package(resource_retriever REQUIRED)
+    find_package(rosx_introspection REQUIRED)
 
     add_library(foxglove_bridge_component SHARED
       ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -168,7 +164,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros2_foxglove_bridge/include>
         $<INSTALL_INTERFACE:include>
     )
-    ament_target_dependencies(foxglove_bridge_component ament_index_cpp rclcpp rclcpp_components resource_retriever rosgraph_msgs)
+    ament_target_dependencies(foxglove_bridge_component ament_index_cpp rclcpp rclcpp_components resource_retriever rosgraph_msgs rosx_introspection)
     target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
     rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")
     enable_strict_compiler_warnings(foxglove_bridge_component)

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -761,10 +761,10 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
                                           length,
                                           data};
         _handlers.clientMessageHandler(clientMessage, hdl);
-      } catch (const ServiceError& e) {
+      } catch (const ClientChannelError& e) {
         sendStatusAndLogMsg(hdl, StatusLevel::Error, e.what());
       } catch (...) {
-        sendStatusAndLogMsg(hdl, StatusLevel::Error, "callService: Failed to execute handler");
+        sendStatusAndLogMsg(hdl, StatusLevel::Error, "clientMessage: Failed to execute handler");
       }
     } break;
     case ClientBinaryOpcode::SERVICE_CALL_REQUEST: {

--- a/package.xml
+++ b/package.xml
@@ -23,6 +23,9 @@
     <depend condition="$ROS_VERSION == 2">rclcpp</depend>
     <depend condition="$ROS_VERSION == 2">rclcpp_components</depend>
 
+    <depend condition="$ROS_VERSION == 2">rosx_introspection</depend>
+
+
     <!-- Test dependencies -->
     <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
@@ -36,7 +39,6 @@
     <build_depend>asio</build_depend>
     <build_depend>libssl-dev</build_depend>
     <build_depend>libwebsocketpp-dev</build_depend>
-    <build_depend>nlohmann-json-dev</build_depend>
     <build_depend>ros_environment</build_depend>
     <build_depend>zlib</build_depend>
 

--- a/package.xml
+++ b/package.xml
@@ -39,6 +39,7 @@
     <build_depend>asio</build_depend>
     <build_depend>libssl-dev</build_depend>
     <build_depend>libwebsocketpp-dev</build_depend>
+    <build_depend>nlohmann-json-dev</build_depend>
     <build_depend>ros_environment</build_depend>
     <build_depend>zlib</build_depend>
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -20,6 +20,8 @@
 #include <foxglove_bridge/server_factory.hpp>
 #include <foxglove_bridge/utils.hpp>
 
+#include <rosx_introspection/ros_parser.hpp>
+
 namespace foxglove_bridge {
 
 using ConnectionHandle = websocketpp::connection_hdl;
@@ -82,6 +84,7 @@ private:
   std::atomic<bool> _subscribeGraphUpdates = false;
   bool _includeHidden = false;
   std::unique_ptr<foxglove::CallbackQueue> _fetchAssetQueue;
+  std::unordered_map<std::string, std::shared_ptr<RosMsgParser::Parser>> _jsonParsers;
 
   void subscribeConnectionGraph(bool subscribe);
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -8,6 +8,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
+#include <rosx_introspection/ros_parser.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
 
 #include <foxglove_bridge/callback_queue.hpp>
@@ -19,8 +20,6 @@
 #include <foxglove_bridge/regex_utils.hpp>
 #include <foxglove_bridge/server_factory.hpp>
 #include <foxglove_bridge/utils.hpp>
-
-#include <rosx_introspection/ros_parser.hpp>
 
 namespace foxglove_bridge {
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -266,12 +266,17 @@ void FoxgloveBridge::updateAdvertisedTopics(
                   topicAndDatatype.first.c_str(), topicAndDatatype.second.c_str(), err.what());
       continue;
     }
-    // register the JSON parser for this scheName
-    auto parserIt = _jsonParsers.find(newChannel.topic);
-    if (parserIt == _jsonParsers.end()) {
-      auto parser = std::make_shared<RosMsgParser::Parser>(
-        newChannel.topic, RosMsgParser::ROSType(newChannel.schemaName), newChannel.schema);
-      _jsonParsers.insert({newChannel.topic, parser});
+    // register the JSON parser for this schemaName
+    if(newChannel.schema.empty() && newChannel.encoding == "json") {
+      RCLCPP_ERROR(this->get_logger(), "Schema is empty for topic \"%s\" (%s)", 
+                   newChannel.topic.c_str(), newChannel.schemaName.c_str());
+    } else {
+      auto parserIt = _jsonParsers.find(newChannel.schemaName);
+      if (parserIt == _jsonParsers.end()) {
+        auto parser = std::make_shared<RosMsgParser::Parser>(
+          newChannel.topic, RosMsgParser::ROSType(newChannel.schemaName), newChannel.schema);
+        _jsonParsers.insert({newChannel.schemaName, parser});
+      }
     }
     channelsToAdd.push_back(newChannel);
   }
@@ -732,33 +737,36 @@ void FoxgloveBridge::clientMessage(const foxglove::ClientMessage& message, Conne
     std::shared_ptr<RosMsgParser::Parser> parser;
     {
       std::lock_guard<std::mutex> lock(_subscriptionsMutex);
-      auto parserIt = _jsonParsers.find(message.advertisement.topic);
+      auto parserIt = _jsonParsers.find(message.advertisement.schemaName);
       if (parserIt != _jsonParsers.end()) {
         parser = parserIt->second;
       }
     }
     if (!parser) {
-      RCLCPP_WARN(get_logger(), "No parser found for %s", message.advertisement.topic.c_str());
+      throw foxglove::ClientChannelError(message.advertisement.channelId,
+                                         "Dropping client message from " +
+                                         _server->remoteEndpointString(hdl) +
+                                         " with encoding \"json\": no parser found");
     } else {
       thread_local RosMsgParser::ROS2_Serializer serializer;
       serializer.reset();
-      std::string_view jsonMessage(reinterpret_cast<const char*>(message.getData()),
-                                   message.getLength());
+      const std::string jsonMessage(reinterpret_cast<const char*>(message.getData()),
+                                    message.getLength());
       try {
         parser->serializeFromJson(jsonMessage, &serializer);
         PublishMessage(serializer.getBufferData(), serializer.getBufferSize());
       } catch (const std::exception& ex) {
         throw foxglove::ClientChannelError(message.advertisement.channelId,
-                                           std::string{"Dropping client message from "} +
-                                             _server->remoteEndpointString(hdl) +
-                                             " with encoding \"json\": " + ex.what());
+                                           "Dropping client message from " +
+                                           _server->remoteEndpointString(hdl) +
+                                           " with encoding \"json\": " + ex.what());
       }
     }
   } else {
     throw foxglove::ClientChannelError(
       message.advertisement.channelId,
       "Dropping client message from " + _server->remoteEndpointString(hdl) +
-        " with unknown encoding \"" + message.advertisement.encoding + "\"");
+      " with unknown encoding \"" + message.advertisement.encoding + "\"");
   }
 }
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -712,7 +712,7 @@ void FoxgloveBridge::clientMessage(const foxglove::ClientMessage& message, Conne
     publisher = it2->second;
   }
 
-  auto PublishMessage = [publisher](const void* data, size_t size) {
+  auto PublishMessage = [publisher, this](const void* data, size_t size) {
     // Copy the message payload into a SerializedMessage object
     rclcpp::SerializedMessage serializedMessage{size};
     auto& rclSerializedMsg = serializedMessage.get_rcl_serialized_message();

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -710,7 +710,7 @@ void FoxgloveBridge::clientMessage(const foxglove::ClientMessage& message, Conne
     publisher = it2->second;
   }
 
-  auto PublishMessage = [this, publisher](const void* data, size_t size) {
+  auto PublishMessage = [publisher](const void* data, size_t size) {
     // Copy the message payload into a SerializedMessage object
     rclcpp::SerializedMessage serializedMessage{size};
     auto& rclSerializedMsg = serializedMessage.get_rcl_serialized_message();

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -269,9 +269,8 @@ void FoxgloveBridge::updateAdvertisedTopics(
     // register the JSON parser for this scheName
     auto parserIt = _jsonParsers.find(newChannel.topic);
     if (parserIt == _jsonParsers.end()) {
-      auto parser = std::make_shared<RosMsgParser::Parser>(newChannel.topic,
-                                                           RosMsgParser::ROSType(newChannel.schemaName),
-                                                           newChannel.schema);
+      auto parser = std::make_shared<RosMsgParser::Parser>(
+        newChannel.topic, RosMsgParser::ROSType(newChannel.schemaName), newChannel.schema);
       _jsonParsers.insert({newChannel.topic, parser});
     }
     channelsToAdd.push_back(newChannel);
@@ -743,16 +742,16 @@ void FoxgloveBridge::clientMessage(const foxglove::ClientMessage& message, Conne
     } else {
       thread_local RosMsgParser::ROS2_Serializer serializer;
       serializer.reset();
-      std::string_view jsonMessage(reinterpret_cast<const char*>(message.getData()), message.getLength());
-      try{
+      std::string_view jsonMessage(reinterpret_cast<const char*>(message.getData()),
+                                   message.getLength());
+      try {
         parser->serializeFromJson(jsonMessage, &serializer);
         PublishMessage(serializer.getBufferData(), serializer.getBufferSize());
-      }
-      catch (const std::exception& ex) {
+      } catch (const std::exception& ex) {
         throw foxglove::ClientChannelError(message.advertisement.channelId,
                                            std::string{"Dropping client message from "} +
-                                           _server->remoteEndpointString(hdl) +
-                                           " with encoding \"json\": " + ex.what());
+                                             _server->remoteEndpointString(hdl) +
+                                             " with encoding \"json\": " + ex.what());
       }
     }
   } else {


### PR DESCRIPTION
## Description

This is an alternative to #288 using **rosx_introspection** instead.

Note that this requires the latest changes in the **main** branch, more specifically: https://github.com/facontidavide/rosx_introspection/commit/b4c5a0db17a494a7de5d2c9469d83e2787fe7768

**rosx_introspection** will be release soon on all the ROS2 distros and, potentially, Noetic too. This will allow us to add this functionality to the ROS1 bridge too, in a follow-up PR.

IMPORTANT: the JSON parser support missing fields (in that case, default values will be used).
