### PR TITLE
Support publishing client message as loaned message

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 2) __min_qos_depth__: Minimum depth used for the QoS profile of subscriptions. Defaults to `1`. This is to set a lower limit for a subscriber's QoS depth which is computed by summing up depths of all publishers. See also [#208](https://github.com/foxglove/ros-foxglove-bridge/issues/208).
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `25`.
  * (ROS 2) __include_hidden__: Include hidden topics and services. Defaults to `false`.
+ * (ROS 2) __disable_load_message__: Do not publish as loaned message when publishing a client message. Defaults to `false`.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 2) __min_qos_depth__: Minimum depth used for the QoS profile of subscriptions. Defaults to `1`. This is to set a lower limit for a subscriber's QoS depth which is computed by summing up depths of all publishers. See also [#208](https://github.com/foxglove/ros-foxglove-bridge/issues/208).
  * (ROS 2) __max_qos_depth__: Maximum depth used for the QoS profile of subscriptions. Defaults to `25`.
  * (ROS 2) __include_hidden__: Include hidden topics and services. Defaults to `false`.
- * (ROS 2) __disable_load_message__: Do not publish as loaned message when publishing a client message. Defaults to `false`.
+ * (ROS 2) __disable_load_message__: Do not publish as loaned message when publishing a client message. Defaults to `true`.
 
 ## Building from source
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -23,6 +23,7 @@ constexpr char PARAM_USE_COMPRESSION[] = "use_compression";
 constexpr char PARAM_CAPABILITIES[] = "capabilities";
 constexpr char PARAM_CLIENT_TOPIC_WHITELIST[] = "client_topic_whitelist";
 constexpr char PARAM_INCLUDE_HIDDEN[] = "include_hidden";
+constexpr char PARAM_DISABLE_LOAN_MESSAGE[] = "disable_load_message";
 constexpr char PARAM_ASSET_URI_ALLOWLIST[] = "asset_uri_allowlist";
 
 constexpr int64_t DEFAULT_PORT = 8765;

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -81,7 +81,7 @@ private:
   std::vector<std::string> _capabilities;
   std::atomic<bool> _subscribeGraphUpdates = false;
   bool _includeHidden = false;
-  bool _disableLoanMessage = false;
+  bool _disableLoanMessage = true;
   std::unique_ptr<foxglove::CallbackQueue> _fetchAssetQueue;
   std::atomic<bool> _shuttingDown = false;
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -81,6 +81,7 @@ private:
   std::vector<std::string> _capabilities;
   std::atomic<bool> _subscribeGraphUpdates = false;
   bool _includeHidden = false;
+  bool _disableLoanMessage = false;
   std::unique_ptr<foxglove::CallbackQueue> _fetchAssetQueue;
   std::atomic<bool> _shuttingDown = false;
 

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -153,7 +153,7 @@ void declareParameters(rclcpp::Node* node) {
   disableLoanMessageDescription.description =
     "Do not publish as loaned message when publishing a client message";
   disableLoanMessageDescription.read_only = true;
-  node->declare_parameter(PARAM_DISABLE_LOAN_MESSAGE, false, disableLoanMessageDescription);
+  node->declare_parameter(PARAM_DISABLE_LOAN_MESSAGE, true, disableLoanMessageDescription);
 
   auto assetUriAllowlistDescription = rcl_interfaces::msg::ParameterDescriptor{};
   assetUriAllowlistDescription.name = PARAM_ASSET_URI_ALLOWLIST;

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -147,6 +147,14 @@ void declareParameters(rclcpp::Node* node) {
   includeHiddenDescription.read_only = true;
   node->declare_parameter(PARAM_INCLUDE_HIDDEN, false, includeHiddenDescription);
 
+  auto disableLoanMessageDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  disableLoanMessageDescription.name = PARAM_DISABLE_LOAN_MESSAGE;
+  disableLoanMessageDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  disableLoanMessageDescription.description =
+    "Do not publish as loaned message when publishing a client message";
+  disableLoanMessageDescription.read_only = true;
+  node->declare_parameter(PARAM_DISABLE_LOAN_MESSAGE, false, disableLoanMessageDescription);
+
   auto assetUriAllowlistDescription = rcl_interfaces::msg::ParameterDescriptor{};
   assetUriAllowlistDescription.name = PARAM_ASSET_URI_ALLOWLIST;
   assetUriAllowlistDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;


### PR DESCRIPTION
### Changelog
Support publishing client message as loaned message

### Docs
None

### Description
Support publishing client message as loaned message when the middleware supports it. 
[`publish_as_loaned_msg`](https://docs.ros.org/en/humble/p/rclcpp/generated/classrclcpp_1_1GenericPublisher.html#_CPPv4N6rclcpp16GenericPublisher21publish_as_loaned_msgERKN6rclcpp17SerializedMessageE) is available as of ROS humble.

Fixes #280