### PR TITLE
Fix usage of deprecated AsyncParametersClient constructor

### DIFF
--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -1,6 +1,7 @@
 #include "foxglove_bridge/parameter_interface.hpp"
 
 #include <nlohmann/json.hpp>
+#include <rclcpp/qos.hpp>
 
 #include <foxglove_bridge/regex_utils.hpp>
 #include <foxglove_bridge/utils.hpp>
@@ -196,7 +197,7 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string>& para
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
         nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 
@@ -239,7 +240,7 @@ void ParameterInterface::setParams(const ParameterList& parameters,
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
         nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 
@@ -282,7 +283,7 @@ void ParameterInterface::subscribeParams(const std::vector<std::string>& paramNa
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
         nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rmw_qos_profile_parameters, _callbackGroup));
+                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -2,6 +2,7 @@
 
 #include <nlohmann/json.hpp>
 #include <rclcpp/qos.hpp>
+#include <rclcpp/version.h>
 
 #include <foxglove_bridge/regex_utils.hpp>
 #include <foxglove_bridge/utils.hpp>
@@ -9,6 +10,12 @@
 namespace {
 
 constexpr char PARAM_SEP = '.';
+
+#if RCLCPP_VERSION_MAJOR > 16
+const rclcpp::ParametersQoS parameterQoS;
+#else
+const rmw_qos_profile_t& parameterQoS = rmw_qos_profile_parameters;
+#endif
 
 static std::pair<std::string, std::string> getNodeAndParamName(
   const std::string& nodeNameAndParamName) {
@@ -196,8 +203,8 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string>& para
     auto paramClientIt = _paramClientsByNode.find(nodeName);
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
-        nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
+        nodeName,
+        rclcpp::AsyncParametersClient::make_shared(_node, nodeName, parameterQoS, _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 
@@ -239,8 +246,8 @@ void ParameterInterface::setParams(const ParameterList& parameters,
     auto paramClientIt = _paramClientsByNode.find(nodeName);
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
-        nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
+        nodeName,
+        rclcpp::AsyncParametersClient::make_shared(_node, nodeName, parameterQoS, _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 
@@ -282,8 +289,8 @@ void ParameterInterface::subscribeParams(const std::vector<std::string>& paramNa
     auto paramClientIt = _paramClientsByNode.find(nodeName);
     if (paramClientIt == _paramClientsByNode.end()) {
       const auto insertedPair = _paramClientsByNode.emplace(
-        nodeName, rclcpp::AsyncParametersClient::make_shared(
-                    _node, nodeName, rclcpp::ParametersQoS(), _callbackGroup));
+        nodeName,
+        rclcpp::AsyncParametersClient::make_shared(_node, nodeName, parameterQoS, _callbackGroup));
       paramClientIt = insertedPair.first;
     }
 


### PR DESCRIPTION
### Changelog
Fix usage of deprecated AsyncParametersClient constructor (rolling)

### Docs
None

### Description
Fixes rolling [build farm builds](https://build.ros2.org/job/Rdev__foxglove_bridge__ubuntu_noble_amd64/16/console). The deprecated constructor has been removed in https://github.com/ros2/rclcpp/pull/2575/files#diff-e12b42b281d50847c271fe5c11443f00d55f363aae9c4bbf097fa19da0c36e5a