### PR TITLE
Add missing functional include in message_definition_cache.cpp

### DIFF
--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -2,6 +2,7 @@
 
 #include <filesystem>
 #include <fstream>
+#include <functional>
 #include <optional>
 #include <regex>
 #include <set>


### PR DESCRIPTION
### Changelog

message_definition_cache.cpp uses std::function, so it should include the functional STL header

### Docs

None

### Description

message_definition_cache.cpp uses std::function, so it should include the functional STL header