### PR TITLE
avoid requesting parameters from unresponsive nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 2) __best_effort_qos_topic_whitelist__: List of regular expressions (ECMAScript) for topics that should be forced to use 'best_effort' QoS. Unmatched topics will use 'reliable' QoS if ALL publishers are 'reliable', 'best_effort' if any publishers are 'best_effort'. Defaults to `["(?!)"]` (match nothing).
  * (ROS 2) __include_hidden__: Include hidden topics and services. Defaults to `false`.
  * (ROS 2) __disable_load_message__: Do not publish as loaned message when publishing a client message. Defaults to `true`.
+ * (ROS 2) __ignore_unresponsive_param_nodes__: Avoid requesting parameters from previously unresponsive nodes. Defaults to `true`.
 
 ## Building from source
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -26,6 +26,7 @@ constexpr char PARAM_CLIENT_TOPIC_WHITELIST[] = "client_topic_whitelist";
 constexpr char PARAM_INCLUDE_HIDDEN[] = "include_hidden";
 constexpr char PARAM_DISABLE_LOAN_MESSAGE[] = "disable_load_message";
 constexpr char PARAM_ASSET_URI_ALLOWLIST[] = "asset_uri_allowlist";
+constexpr char PARAM_IGN_UNRESPONSIVE_PARAM_NODES[] = "ignore_unresponsive_param_nodes";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -19,7 +19,8 @@ using ParamUpdateFunc = std::function<void(const ParameterList&)>;
 
 class ParameterInterface {
 public:
-  ParameterInterface(rclcpp::Node* node, std::vector<std::regex> paramWhitelistPatterns);
+  ParameterInterface(rclcpp::Node* node, std::vector<std::regex> paramWhitelistPatterns,
+                     bool retry_unresponsive_nodes);
 
   ParameterList getParams(const std::vector<std::string>& paramNames,
                           const std::chrono::duration<double>& timeout);
@@ -36,6 +37,8 @@ private:
   std::unordered_map<std::string, rclcpp::AsyncParametersClient::SharedPtr> _paramClientsByNode;
   std::unordered_map<std::string, std::unordered_set<std::string>> _subscribedParamsByNode;
   std::unordered_map<std::string, rclcpp::SubscriptionBase::SharedPtr> _paramSubscriptionsByNode;
+  std::unordered_set<std::string> _ignoredNodeNames;
+  bool _ignoreUnresponsiveNodes;
   ParamUpdateFunc _paramUpdateFunc;
 
   ParameterList getNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,

--- a/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -17,10 +17,15 @@ namespace foxglove_bridge {
 using ParameterList = std::vector<foxglove::Parameter>;
 using ParamUpdateFunc = std::function<void(const ParameterList&)>;
 
+enum class UnresponsiveNodePolicy {
+  Ignore,
+  Retry,
+};
+
 class ParameterInterface {
 public:
   ParameterInterface(rclcpp::Node* node, std::vector<std::regex> paramWhitelistPatterns,
-                     bool retry_unresponsive_nodes);
+                     UnresponsiveNodePolicy unresponsiveNodePolicy);
 
   ParameterList getParams(const std::vector<std::string>& paramNames,
                           const std::chrono::duration<double>& timeout);
@@ -38,7 +43,7 @@ private:
   std::unordered_map<std::string, std::unordered_set<std::string>> _subscribedParamsByNode;
   std::unordered_map<std::string, rclcpp::SubscriptionBase::SharedPtr> _paramSubscriptionsByNode;
   std::unordered_set<std::string> _ignoredNodeNames;
-  bool _ignoreUnresponsiveNodes;
+  UnresponsiveNodePolicy _unresponsiveNodePolicy;
   ParamUpdateFunc _paramUpdateFunc;
 
   ParameterList getNodeParameters(rclcpp::AsyncParametersClient::SharedPtr paramClient,

--- a/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
+++ b/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
@@ -1,39 +1,41 @@
 <launch>
-  <arg name="port"                      default="8765" />
-  <arg name="address"                   default="0.0.0.0" />
-  <arg name="tls"                       default="false" />
-  <arg name="certfile"                  default="" />
-  <arg name="keyfile"                   default="" />
-  <arg name="topic_whitelist"           default="['.*']" />
-  <arg name="param_whitelist"           default="['.*']" />
-  <arg name="service_whitelist"         default="['.*']" />
-  <arg name="client_topic_whitelist"    default="['.*']" />
-  <arg name="min_qos_depth"             default="1" />
-  <arg name="max_qos_depth"             default="10" />
-  <arg name="num_threads"               default="0" />
-  <arg name="send_buffer_limit"         default="10000000" />
-  <arg name="use_sim_time"              default="false" />
-  <arg name="capabilities"              default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph,assets]" />
-  <arg name="include_hidden"            default="false" />
-  <arg name="asset_uri_allowlist"       default="['^package://(?:[-\\w]+/)*[-\\w]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />  <!-- Needs double-escape -->
+  <arg name="port"                            default="8765" />
+  <arg name="address"                         default="0.0.0.0" />
+  <arg name="tls"                             default="false" />
+  <arg name="certfile"                        default="" />
+  <arg name="keyfile"                         default="" />
+  <arg name="topic_whitelist"                 default="['.*']" />
+  <arg name="param_whitelist"                 default="['.*']" />
+  <arg name="service_whitelist"               default="['.*']" />
+  <arg name="client_topic_whitelist"          default="['.*']" />
+  <arg name="min_qos_depth"                   default="1" />
+  <arg name="max_qos_depth"                   default="10" />
+  <arg name="num_threads"                     default="0" />
+  <arg name="send_buffer_limit"               default="10000000" />
+  <arg name="use_sim_time"                    default="false" />
+  <arg name="capabilities"                    default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph,assets]" />
+  <arg name="include_hidden"                  default="false" />
+  <arg name="asset_uri_allowlist"             default="['^package://(?:[-\\w]+/)*[-\\w]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />  <!-- Needs double-escape -->
+  <arg name="ignore_unresponsive_param_nodes" default="true" />
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge">
-    <param name="port"                    value="$(var port)" />
-    <param name="address"                 value="$(var address)" />
-    <param name="tls"                     value="$(var tls)" />
-    <param name="certfile"                value="$(var certfile)" />
-    <param name="keyfile"                 value="$(var keyfile)" />
-    <param name="topic_whitelist"         value="$(var topic_whitelist)" />
-    <param name="service_whitelist"       value="$(var service_whitelist)" />
-    <param name="param_whitelist"         value="$(var param_whitelist)" />
-    <param name="client_topic_whitelist"  value="$(var client_topic_whitelist)" />
-    <param name="min_qos_depth"           value="$(var min_qos_depth)" />
-    <param name="max_qos_depth"           value="$(var max_qos_depth)" />
-    <param name="num_threads"             value="$(var num_threads)" />
-    <param name="send_buffer_limit"       value="$(var send_buffer_limit)" />
-    <param name="use_sim_time"            value="$(var use_sim_time)" />
-    <param name="capabilities"            value="$(var capabilities)" />
-    <param name="include_hidden"          value="$(var include_hidden)" />
-    <param name="asset_uri_allowlist"     value="$(var asset_uri_allowlist)" />
+    <param name="port"                            value="$(var port)" />
+    <param name="address"                         value="$(var address)" />
+    <param name="tls"                             value="$(var tls)" />
+    <param name="certfile"                        value="$(var certfile)" />
+    <param name="keyfile"                         value="$(var keyfile)" />
+    <param name="topic_whitelist"                 value="$(var topic_whitelist)" />
+    <param name="service_whitelist"               value="$(var service_whitelist)" />
+    <param name="param_whitelist"                 value="$(var param_whitelist)" />
+    <param name="client_topic_whitelist"          value="$(var client_topic_whitelist)" />
+    <param name="min_qos_depth"                   value="$(var min_qos_depth)" />
+    <param name="max_qos_depth"                   value="$(var max_qos_depth)" />
+    <param name="num_threads"                     value="$(var num_threads)" />
+    <param name="send_buffer_limit"               value="$(var send_buffer_limit)" />
+    <param name="use_sim_time"                    value="$(var use_sim_time)" />
+    <param name="capabilities"                    value="$(var capabilities)" />
+    <param name="include_hidden"                  value="$(var include_hidden)" />
+    <param name="asset_uri_allowlist"             value="$(var asset_uri_allowlist)" />
+    <param name="ignore_unresponsive_param_nodes" value="$(var ignore_unresponsive_param_nodes)" />
   </node>
 </launch>

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -179,6 +179,14 @@ void declareParameters(rclcpp::Node* node) {
       {"^package://(?:[-\\w]+/"
        ")*[-\\w]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$"}),
     paramWhiteListDescription);
+
+  auto ignUnresponsiveParamNodes = rcl_interfaces::msg::ParameterDescriptor{};
+  ignUnresponsiveParamNodes.name = PARAM_IGN_UNRESPONSIVE_PARAM_NODES;
+  ignUnresponsiveParamNodes.type = rcl_interfaces::msg::ParameterType::PARAMETER_BOOL;
+  ignUnresponsiveParamNodes.description =
+    "Avoid requesting parameters from previously unresponsive nodes";
+  ignUnresponsiveParamNodes.read_only = true;
+  node->declare_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES, true, ignUnresponsiveParamNodes);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -136,12 +136,12 @@ using foxglove::isWhitelisted;
 
 ParameterInterface::ParameterInterface(rclcpp::Node* node,
                                        std::vector<std::regex> paramWhitelistPatterns,
-                                       bool ignoreUnresponsiveNodes)
+                                       UnresponsiveNodePolicy unresponsiveNodePolicy)
     : _node(node)
     , _paramWhitelistPatterns(paramWhitelistPatterns)
     , _callbackGroup(node->create_callback_group(rclcpp::CallbackGroupType::Reentrant))
     , _ignoredNodeNames({node->get_fully_qualified_name()})
-    , _ignoreUnresponsiveNodes(ignoreUnresponsiveNodes) {}
+    , _unresponsiveNodePolicy(unresponsiveNodePolicy) {}
 
 ParameterList ParameterInterface::getParams(const std::vector<std::string>& paramNames,
                                             const std::chrono::duration<double>& timeout) {
@@ -225,7 +225,7 @@ ParameterList ParameterInterface::getParams(const std::vector<std::string>& para
       RCLCPP_ERROR(_node->get_logger(), "Failed to retrieve parameters from node '%s': %s",
                    nodeName.c_str(), e.what());
 
-      if (_ignoreUnresponsiveNodes) {
+      if (_unresponsiveNodePolicy == UnresponsiveNodePolicy::Ignore) {
         // Certain nodes may fail to handle incoming service requests — for example, if they're
         // stuck in a busy loop or otherwise unresponsive. In such cases, attempting to retrieve
         // parameter names or values can result in timeouts. To avoid repeated failures, these nodes

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -55,6 +55,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   const auto assetUriAllowlist = this->get_parameter(PARAM_ASSET_URI_ALLOWLIST).as_string_array();
   _assetUriAllowlistPatterns = parseRegexStrings(this, assetUriAllowlist);
   _disableLoanMessage = this->get_parameter(PARAM_DISABLE_LOAN_MESSAGE).as_bool();
+  const auto ignoreUnresponsiveParamNodes =
+    this->get_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES).as_bool();
 
   const auto logHandler = std::bind(&FoxgloveBridge::logHandler, this, _1, _2);
   // Fetching of assets may be blocking, hence we fetch them in a separate thread.
@@ -95,7 +97,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
     hdlrs.parameterSubscriptionHandler =
       std::bind(&FoxgloveBridge::subscribeParameters, this, _1, _2, _3);
 
-    _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns);
+    _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns,
+                                                           ignoreUnresponsiveParamNodes);
     _paramInterface->setParamUpdateCallback(std::bind(&FoxgloveBridge::parameterUpdates, this, _1));
   }
 

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -98,7 +98,9 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
       std::bind(&FoxgloveBridge::subscribeParameters, this, _1, _2, _3);
 
     _paramInterface = std::make_shared<ParameterInterface>(this, paramWhitelistPatterns,
-                                                           ignoreUnresponsiveParamNodes);
+                                                           ignoreUnresponsiveParamNodes
+                                                             ? UnresponsiveNodePolicy::Ignore
+                                                             : UnresponsiveNodePolicy::Retry);
     _paramInterface->setParamUpdateCallback(std::bind(&FoxgloveBridge::parameterUpdates, this, _1));
   }
 


### PR DESCRIPTION
### Changelog
avoid requesting parameters from unresponsive parameter nodes

### Docs
None

### Description
Proper fix for #337 

Adds unresponsive nodes to a ignore list to fetching parameters from them in the future. Behavior can be turned off with a parameter (default is on). 

The python ROS2 node below can be used for testing. It declares a parameter but does not set up a dedicated spinner/executor which can handle parameter service requests, resulting in incoming service requests timing out.

```py
def main(args=None):
    rclpy.init(args=args)
    node = rclpy.create_node('example_node')
    node.declare_parameter('my_param_name', 42)
    publisher = node.create_publisher(String, 'my_topic_name', 10)

    i = 0
    while rclpy.ok():
        msg = String(data=f'Hello World: {i}')
        i += 1
        publisher.publish(msg)
        time.sleep(1)
```
