### PR TITLE
fix rolling/kilted builds due to resource_retriever API changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -156,6 +156,13 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
       ros2_foxglove_bridge/src/generic_client.cpp
     )
 
+    target_compile_definitions(foxglove_bridge_component
+      PRIVATE
+        RESOURCE_RETRIEVER_VERSION_MAJOR=${resource_retriever_VERSION_MAJOR}
+        RESOURCE_RETRIEVER_VERSION_MINOR=${resource_retriever_VERSION_MINOR}
+        RESOURCE_RETRIEVER_VERSION_PATCH=${resource_retriever_VERSION_PATCH}
+    )
+
     target_include_directories(foxglove_bridge_component
       PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/foxglove_bridge_base/include>


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
In https://github.com/ros/resource_retriever/commit/cc80ce3b7814f3f4199f0d0553fcda8f95f5fdcd, the `resource_retriever` API has changed causing rolling and kilted (new ROS2 distro) to fail. This PR fixes this by compiling different code paths based on the `resource_retriever` version.

Resolves FG-11399