### PR TITLE
Fix race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution: [melodic, noetic, humble, iron, rolling]
+        ros_distribution: [melodic, noetic, humble, iron, jazzy, kilted, rolling]
 
     name: Test (ROS ${{ matrix.ros_distribution }})
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make lint
 
   test:
@@ -26,7 +26,7 @@ jobs:
     name: Test (ROS ${{ matrix.ros_distribution }})
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make ${{ matrix.ros_distribution }}-test
 
   test-boost-asio:
@@ -38,5 +38,5 @@ jobs:
     name: Test (ROS ${{ matrix.ros_distribution }}, Boost Asio)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: make ${{ matrix.ros_distribution }}-test-boost-asio

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     enable_strict_compiler_warnings(base64_test)
 
     # Repeat tests 10 times to catch nondeterministic issues
-    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=10)
+    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=100)
     target_link_libraries(smoke_test
       foxglove_bridge_component
       ${std_msgs_TARGETS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -169,15 +169,27 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/ros2_foxglove_bridge/include>
         $<INSTALL_INTERFACE:include>
     )
-    ament_target_dependencies(foxglove_bridge_component ament_index_cpp rclcpp rclcpp_components resource_retriever rosgraph_msgs rosx_introspection)
-    target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
+    target_link_libraries(foxglove_bridge_component
+      foxglove_bridge_base
+      ${rosgraph_msgs_TARGETS}
+      ament_index_cpp::ament_index_cpp
+      rclcpp::rclcpp
+      rclcpp_components::component
+      rclcpp_components::component_manager
+      resource_retriever::resource_retriever
+      rosx_introspection::rosx_introspection
+    )
     rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")
     enable_strict_compiler_warnings(foxglove_bridge_component)
     add_executable(foxglove_bridge
       ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
     )
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${rclcpp_INCLUDE_DIRS})
-    ament_target_dependencies(foxglove_bridge rclcpp rclcpp_components)
+    target_link_libraries(foxglove_bridge
+      rclcpp::rclcpp
+      rclcpp_components::component
+      rclcpp_components::component_manager
+    )
     enable_strict_compiler_warnings(foxglove_bridge)
   else()
     message(FATAL_ERROR "Could not find ament_cmake")
@@ -241,8 +253,14 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     enable_strict_compiler_warnings(base64_test)
 
     ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp)
-    ament_target_dependencies(smoke_test rclcpp rclcpp_components std_msgs std_srvs)
-    target_link_libraries(smoke_test foxglove_bridge_component)
+    target_link_libraries(smoke_test
+      foxglove_bridge_component
+      ${std_msgs_TARGETS}
+      ${std_srvs_TARGETS}
+      rclcpp::rclcpp
+      rclcpp_components::component
+      rclcpp_components::component_manager
+    )
     enable_strict_compiler_warnings(smoke_test)
 
     ament_add_gtest(utils_test ros2_foxglove_bridge/tests/utils_test.cpp)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     target_link_libraries(base64_test foxglove_bridge_base)
     enable_strict_compiler_warnings(base64_test)
 
-    # Repeat tests 10 times to catch nondeterministic issues
+    # Repeat tests several times to catch nondeterministic issues
     ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=100)
     target_link_libraries(smoke_test
       foxglove_bridge_component

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     enable_strict_compiler_warnings(base64_test)
 
     # Repeat tests several times to catch nondeterministic issues
-    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=100)
+    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=50 TIMEOUT 600)
     target_link_libraries(smoke_test
       foxglove_bridge_component
       ${std_msgs_TARGETS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -252,7 +252,8 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     target_link_libraries(base64_test foxglove_bridge_base)
     enable_strict_compiler_warnings(base64_test)
 
-    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp)
+    # Repeat tests 10 times to catch nondeterministic issues
+    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp APPEND_ENV GTEST_REPEAT=10)
     target_link_libraries(smoke_test
       foxglove_bridge_component
       ${std_msgs_TARGETS}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -253,7 +253,7 @@ elseif(ROS_BUILD_TYPE STREQUAL "ament_cmake")
     enable_strict_compiler_warnings(base64_test)
 
     # Repeat tests 10 times to catch nondeterministic issues
-    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp APPEND_ENV GTEST_REPEAT=10)
+    ament_add_gtest(smoke_test ros2_foxglove_bridge/tests/smoke_test.cpp ENV GTEST_REPEAT=10)
     target_link_libraries(smoke_test
       foxglove_bridge_component
       ${std_msgs_TARGETS}

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -1,7 +1,15 @@
 ARG ROS_DISTRIBUTION=noetic
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
-# Install clang and set as default compiler.
+# Update apt keys for EOL distros. For current distros this is already in the base docker image.
+# https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
+# https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
+ADD --checksum=sha256:c0cc26f70da91a4fa5a613278a53885184e91df45214ab34e1bae0f3a44f83ea https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros-apt-source_1.1.0.focal_all.deb /tmp/ros-apt-source.deb
+RUN apt-get install /tmp/ros-apt-source.deb \
+  && rm -f /tmp/ros-apt-source.deb \
+  && rm -rf /var/lib/apt/lists/*
+
+  # Install clang and set as default compiler.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   clang \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -5,7 +5,7 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
 # https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 ADD --checksum=sha256:c0cc26f70da91a4fa5a613278a53885184e91df45214ab34e1bae0f3a44f83ea https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros-apt-source_1.1.0.focal_all.deb /tmp/ros-apt-source.deb
-RUN rm /etc/apt/sources.list.d/ros1-latest.list && \
+RUN rm /etc/apt/sources.list.d/ros1-latest.list \
   && apt-get install /tmp/ros-apt-source.deb \
   && rm -f /tmp/ros-apt-source.deb \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -5,7 +5,7 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
 # https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 ADD --checksum=sha256:c0cc26f70da91a4fa5a613278a53885184e91df45214ab34e1bae0f3a44f83ea https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros-apt-source_1.1.0.focal_all.deb /tmp/ros-apt-source.deb
-RUN rm /etc/apt/sources.list.d/ros1-latest.list \
+RUN rm -f /etc/apt/sources.list.d/ros1-latest.list \
   && apt-get install /tmp/ros-apt-source.deb \
   && rm -f /tmp/ros-apt-source.deb \
   && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile.ros1
+++ b/Dockerfile.ros1
@@ -5,7 +5,8 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
 # https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 ADD --checksum=sha256:c0cc26f70da91a4fa5a613278a53885184e91df45214ab34e1bae0f3a44f83ea https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros-apt-source_1.1.0.focal_all.deb /tmp/ros-apt-source.deb
-RUN apt-get install /tmp/ros-apt-source.deb \
+RUN rm /etc/apt/sources.list.d/ros1-latest.list && \
+  && apt-get install /tmp/ros-apt-source.deb \
   && rm -f /tmp/ros-apt-source.deb \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -3,11 +3,8 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Update apt keys for EOL distros. For current distros this is already in the base docker image.
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
-RUN apt-get install curl && \
-  curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
-  && echo "1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
-  && apt-get update \
-  && apt-get install /tmp/ros2-apt-source.deb \
+ADD --checksum=sha256:1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb /tmp/ros2-apt-source.deb
+RUN apt-get install /tmp/ros2-apt-source.deb \
   && rm -f /tmp/ros2-apt-source.deb \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -1,6 +1,15 @@
 ARG ROS_DISTRIBUTION=humble
 FROM ros:$ROS_DISTRIBUTION-ros-base
 
+# Update apt keys for EOL distros. For current distros this is already in the base docker image.
+# https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
+RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
+  && echo "1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
+  && apt-get update \
+  && apt-get install /tmp/ros2-apt-source.deb \
+  && rm -f /tmp/ros2-apt-source.deb \
+  && rm -rf /var/lib/apt/lists/*
+
 # Install clang and set as default compiler.
 RUN apt-get update && apt-get install -y --no-install-recommends \
   clang \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -3,6 +3,7 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Update apt keys for EOL distros. For current distros this is already in the base docker image.
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
+# https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 ADD --checksum=sha256:1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb /tmp/ros2-apt-source.deb
 RUN apt-get install /tmp/ros2-apt-source.deb \
   && rm -f /tmp/ros2-apt-source.deb \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -3,7 +3,8 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Update apt keys for EOL distros. For current distros this is already in the base docker image.
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
-RUN wget -O /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
+RUN apt-get install curl && \
+  curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
   && echo "1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
   && apt-get update \
   && apt-get install /tmp/ros2-apt-source.deb \

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -5,7 +5,7 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
 # https://discourse.ros.org/t/ros-signing-key-migration-guide/43937
 ADD --checksum=sha256:1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb /tmp/ros2-apt-source.deb
-RUN apt-get install /tmp/ros2-apt-source.deb \
+RUN (dpkg-query -s ros2-apt-source || apt-get install /tmp/ros2-apt-source.deb) \
   && rm -f /tmp/ros2-apt-source.deb \
   && rm -rf /var/lib/apt/lists/*
 

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -3,7 +3,7 @@ FROM ros:$ROS_DISTRIBUTION-ros-base
 
 # Update apt keys for EOL distros. For current distros this is already in the base docker image.
 # https://github.com/osrf/docker_images/commit/eb5634cf92ba079897e44fb7541d3b78aa6cf717
-RUN curl -L -s -o /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
+RUN wget -O /tmp/ros2-apt-source.deb https://github.com/ros-infrastructure/ros-apt-source/releases/download/1.1.0/ros2-apt-source_1.1.0.jammy_all.deb \
   && echo "1600cb8cc28258a39bffc1736a75bcbf52d1f2db371a4d020c1b187d2a5a083b /tmp/ros2-apt-source.deb" | sha256sum --strict --check \
   && apt-get update \
   && apt-get install /tmp/ros2-apt-source.deb \

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ROS1_DISTRIBUTIONS := melodic noetic
-ROS2_DISTRIBUTIONS := humble iron rolling
+ROS2_DISTRIBUTIONS := humble iron jazzy kilted rolling
 
 define generate_ros1_targets
 .PHONY: $(1)

--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ foxglove_bridge
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#humble)
 [![ROS Iron version](https://img.shields.io/ros/v/iron/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#iron)
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#jazzy)
+[![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#kilted)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#rolling)
 
 High performance ROS 1 and ROS 2 WebSocket bridge using the Foxglove WebSocket protocol, written in C++.

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1240,8 +1240,8 @@ void Server<ServerConfiguration>::handleSubscribe(const nlohmann::json& payload,
     }
 
     {
-    std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
-    _clients.at(hdl).subscriptionsByChannel.emplace(channelId, subId);
+      std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
+      _clients.at(hdl).subscriptionsByChannel.emplace(channelId, subId);
     }
 
     // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1239,14 +1239,14 @@ void Server<ServerConfiguration>::handleSubscribe(const nlohmann::json& payload,
       continue;
     }
 
-    // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*
-    // adding to subscriptionsByChannel, to prevent the message from being dropped
-    _handlers.subscribeHandler(channelId, hdl);
-
     {
       std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
       _clients.at(hdl).subscriptionsByChannel.emplace(channelId, subId);
     }
+
+    // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*
+    // adding to subscriptionsByChannel, to prevent the message from being dropped
+    _handlers.subscribeHandler(channelId, hdl);
   }
 }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1239,9 +1239,14 @@ void Server<ServerConfiguration>::handleSubscribe(const nlohmann::json& payload,
       continue;
     }
 
-    _handlers.subscribeHandler(channelId, hdl);
+    {
     std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
     _clients.at(hdl).subscriptionsByChannel.emplace(channelId, subId);
+    }
+
+    // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*
+    // adding to subscriptionsByChannel, to prevent the message from being dropped
+    _handlers.subscribeHandler(channelId, hdl);
   }
 }
 

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -1239,14 +1239,14 @@ void Server<ServerConfiguration>::handleSubscribe(const nlohmann::json& payload,
       continue;
     }
 
+    // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*
+    // adding to subscriptionsByChannel, to prevent the message from being dropped
+    _handlers.subscribeHandler(channelId, hdl);
+
     {
       std::unique_lock<std::shared_mutex> clientsLock(_clientsMutex);
       _clients.at(hdl).subscriptionsByChannel.emplace(channelId, subId);
     }
-
-    // In case the subscribeHandler triggers an immediate sendMessage, this must be done *after*
-    // adding to subscriptionsByChannel, to prevent the message from being dropped
-    _handlers.subscribeHandler(channelId, hdl);
   }
 }
 


### PR DESCRIPTION
### Changelog
Fixed a race condition that could cause messages received during or shortly after subscribing to be dropped

### Docs

None

### Description

Fixes FG-11910

- Fix CMake warnings from deprecated `ament_target_dependencies`  (the changes were mostly just suggested by the warning message itself)
- Some apt nonsense to make the docker images work again
- Fix race condition caused by "latched" messages being dropped during subscribe (reported by @asymingt in https://github.com/orgs/foxglove/discussions/1127). We already had a test that would catch this, but it didn't happen all the time.
- Repeat tests 50x to make catching failures more likely