### PR TITLE
Fix flaky publishing test

### DIFF
--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -260,10 +260,13 @@ TEST(SmokeTest, testSubscriptionParallel) {
 
 TEST_P(PublisherTest, testPublishing) {
   const auto& [encoding, message] = GetParam();
+  // use a unique topic for each test to prevent tests from interfering with each other
+  static size_t testPublishingCount = 0;
+  ++testPublishingCount;
 
   foxglove::ClientAdvertisement advertisement;
   advertisement.channelId = 1;
-  advertisement.topic = "/foo";
+  advertisement.topic = "/testPublishing_" + std::to_string(testPublishingCount);
   advertisement.encoding = encoding;
   advertisement.schemaName = "std_msgs/msg/String";
   advertisement.schema =
@@ -282,10 +285,10 @@ TEST_P(PublisherTest, testPublishing) {
   // Set up the client, advertise and publish the binary message
   auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
   ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
+  auto channelFuture = foxglove::waitForChannel(client, advertisement.topic);
   client->advertise({advertisement});
 
   // Wait until the advertisement got advertised as channel by the server
-  auto channelFuture = foxglove::waitForChannel(client, advertisement.topic);
   ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(ONE_SECOND));
 
   // Publish the message and unadvertise again

--- a/ros2_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge/tests/smoke_test.cpp
@@ -284,8 +284,8 @@ TEST_P(PublisherTest, testPublishing) {
 
   // Set up the client, advertise and publish the binary message
   auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
-  ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
   auto channelFuture = foxglove::waitForChannel(client, advertisement.topic);
+  ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
   client->advertise({advertisement});
 
   // Wait until the advertisement got advertised as channel by the server
@@ -334,11 +334,11 @@ TEST_P(ExistingPublisherTest, testPublishingWithExistingPublisher) {
 
   // Set up the client, advertise and publish the binary message
   auto client = std::make_shared<foxglove::Client<websocketpp::config::asio_client>>();
+  auto channelFuture = foxglove::waitForChannel(client, advertisement.topic);
   ASSERT_EQ(std::future_status::ready, client->connect(URI).wait_for(ONE_SECOND));
   client->advertise({advertisement});
 
   // Wait until the advertisement got advertised as channel by the server
-  auto channelFuture = foxglove::waitForChannel(client, advertisement.topic);
   ASSERT_EQ(std::future_status::ready, channelFuture.wait_for(ONE_SECOND));
 
   // Publish the message and unadvertise again


### PR DESCRIPTION
### Changelog
None

### Docs

None

### Description

More follow-up from #354 

I believe the fact that a single FoxgloveBridge node is used for all tests was causing the PublisherTest to be flaky. I worked around the issue by using a unique topic name for each iteration of the test.

Some other tests seemed to be failing because the initial channels are sent before the test sets up its text message handler. I fixed that by moving the waitForChannel earlier.

Fixes FG-11910 / https://github.com/orgs/foxglove/discussions/1127 (again, hopefully)