### PR TITLE
Move components from legacy ws-protocol to new namespace

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,41 +51,6 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
-# Download Foxglove SDK shared lib
-# TODO: Add conditionals and URL/SHA lookup table for other OS/architecture combos
-# using CMAKE_SYSTEM_PROCESSOR and CMAKE_SYSTEM_NAME
-include(FetchContent)
-FetchContent_Declare(
-  foxglove_sdk
-  URL https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.9.0/foxglove-v0.9.0-cpp-aarch64-unknown-linux-gnu.zip
-  URL_HASH SHA256=a554f82b3d1c3096457887bccee7088646b729494ec18909846ac7fcdd06ee1d
-)
-FetchContent_MakeAvailable(foxglove_sdk)
-
-file(GLOB_RECURSE _foxglove_sdk_sources ${foxglove_sdk_SOURCE_DIR}/src/*.cpp)
-add_library(foxglove_sdk SHARED
-  ${_foxglove_sdk_sources}
-)
-file(GLOB_RECURSE _foxglove_sdk_headers ${foxglove_sdk_SOURCE_DIR}/include/*.hpp)
-target_include_directories(foxglove_sdk
-  PUBLIC
-    $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
-    $<INSTALL_INTERFACE:include>
-)
-target_link_libraries(foxglove_sdk
-  PUBLIC
-    ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.so
-)
-install(FILES ${_foxglove_sdk_headers}
-  DESTINATION include/${PROJECT_NAME}
-)
-install(TARGETS foxglove_sdk
-  EXPORT foxglove_sdk
-  ARCHIVE DESTINATION lib
-  LIBRARY DESTINATION lib
-  RUNTIME DESTINATION bin
-)
-
 # Get git commit hash and replace variables in version.cpp.in
 find_program(GIT_SCM git DOC "Git version control")
 if (GIT_SCM)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,41 @@ if (ENDIAN)
   add_compile_definitions(ARCH_IS_BIG_ENDIAN=1)
 endif()
 
+# Download Foxglove SDK shared lib
+# TODO: Add conditionals and URL/SHA lookup table for other OS/architecture combos
+# using CMAKE_SYSTEM_PROCESSOR and CMAKE_SYSTEM_NAME
+include(FetchContent)
+FetchContent_Declare(
+  foxglove_sdk
+  URL https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.9.0/foxglove-v0.9.0-cpp-aarch64-unknown-linux-gnu.zip
+  URL_HASH SHA256=a554f82b3d1c3096457887bccee7088646b729494ec18909846ac7fcdd06ee1d
+)
+FetchContent_MakeAvailable(foxglove_sdk)
+
+file(GLOB_RECURSE _foxglove_sdk_sources ${foxglove_sdk_SOURCE_DIR}/src/*.cpp)
+add_library(foxglove_sdk SHARED
+  ${_foxglove_sdk_sources}
+)
+file(GLOB_RECURSE _foxglove_sdk_headers ${foxglove_sdk_SOURCE_DIR}/include/*.hpp)
+target_include_directories(foxglove_sdk
+  PUBLIC
+    $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+)
+target_link_libraries(foxglove_sdk
+  PUBLIC
+    ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.so
+)
+install(FILES ${_foxglove_sdk_headers}
+  DESTINATION include/${PROJECT_NAME}
+)
+install(TARGETS foxglove_sdk
+  EXPORT foxglove_sdk
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+  RUNTIME DESTINATION bin
+)
+
 # Get git commit hash and replace variables in version.cpp.in
 find_program(GIT_SCM git DOC "Git version control")
 if (GIT_SCM)

--- a/foxglove_bridge_base/include/foxglove_bridge/base64.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/base64.hpp
@@ -5,10 +5,10 @@
 #include <string_view>
 #include <vector>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 std::string base64Encode(const std::string_view& input);
 
 std::vector<unsigned char> base64Decode(const std::string& input);
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/callback_queue.hpp
@@ -10,7 +10,7 @@
 
 #include "websocket_logging.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 class CallbackQueue {
 public:
@@ -78,4 +78,4 @@ private:
   std::vector<std::thread> _workerThreads;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/common.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/common.hpp
@@ -7,7 +7,7 @@
 #include <string>
 #include <vector>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 constexpr char SUPPORTED_SUBPROTOCOL[] = "foxglove.websocket.v1";
 constexpr char CAPABILITY_CLIENT_PUBLISH[] = "clientPublish";
@@ -159,4 +159,4 @@ struct FetchAssetResponse {
   std::vector<uint8_t> data;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/parameter.hpp
@@ -6,7 +6,7 @@
 #include <unordered_map>
 #include <vector>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 enum class ParameterSubscriptionOperation {
   SUBSCRIBE,
@@ -74,4 +74,4 @@ private:
   ParameterValue _value;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/regex_utils.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/regex_utils.hpp
@@ -5,7 +5,7 @@
 #include <string>
 #include <vector>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 inline bool isWhitelisted(const std::string& name, const std::vector<std::regex>& regexPatterns) {
   return std::find_if(regexPatterns.begin(), regexPatterns.end(), [name](const auto& regex) {
@@ -13,4 +13,4 @@ inline bool isWhitelisted(const std::string& name, const std::vector<std::regex>
          }) != regexPatterns.end();
 }
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/serialization.hpp
@@ -7,7 +7,7 @@
 #include "common.hpp"
 #include "parameter.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 inline void WriteUint64LE(uint8_t* buf, uint64_t val) {
 #ifdef ARCH_IS_BIG_ENDIAN
@@ -53,4 +53,4 @@ void from_json(const nlohmann::json& j, Parameter& p);
 void to_json(nlohmann::json& j, const Service& p);
 void from_json(const nlohmann::json& j, Service& p);
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/server_factory.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_factory.hpp
@@ -8,7 +8,7 @@
 #include "common.hpp"
 #include "server_interface.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 class ServerFactory {
 public:
@@ -18,4 +18,4 @@ public:
     const ServerOptions& options);
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -11,7 +11,7 @@
 #include "common.hpp"
 #include "parameter.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 constexpr size_t DEFAULT_SEND_BUFFER_LIMIT_BYTES = 10000000UL;  // 10 MB
 
@@ -111,4 +111,4 @@ public:
   virtual std::string remoteEndpointString(ConnectionHandle clientHandle) = 0;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/test/test_client.hpp
@@ -9,7 +9,7 @@
 #include "../parameter.hpp"
 #include "../websocket_client.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 std::future<std::vector<uint8_t>> waitForChannelMsg(ClientInterface* client,
                                                     SubscriptionId subscriptionId);
@@ -29,4 +29,4 @@ std::future<FetchAssetResponse> waitForFetchAssetResponse(std::shared_ptr<Client
 
 extern template class Client<websocketpp::config::asio_client>;
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_client.hpp
@@ -16,7 +16,7 @@
 #include "parameter.hpp"
 #include "serialization.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 inline void to_json(nlohmann::json& j, const ClientAdvertisement& p) {
   j = nlohmann::json{{"id", p.channelId},
@@ -180,7 +180,7 @@ public:
   void publish(ClientChannelId channelId, const uint8_t* buffer, size_t size) override {
     std::vector<uint8_t> payload(1 + 4 + size);
     payload[0] = uint8_t(ClientBinaryOpcode::MESSAGE_DATA);
-    foxglove::WriteUint32LE(payload.data() + 1, channelId);
+    foxglove_ws::WriteUint32LE(payload.data() + 1, channelId);
     std::memcpy(payload.data() + 1 + 4, buffer, size);
     sendBinary(payload.data(), payload.size());
   }
@@ -256,4 +256,4 @@ protected:
   BinaryMessageHandler _binaryMessageHandler;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_logging.hpp
@@ -7,7 +7,7 @@
 
 #include "common.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 using LogCallback = std::function<void(WebSocketLogLevel, char const*)>;
 
@@ -97,4 +97,4 @@ private:
   LogCallback _callback;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_notls.hpp
@@ -6,7 +6,7 @@
 
 #include "./websocket_logging.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 struct WebSocketNoTls : public websocketpp::config::core {
   typedef WebSocketNoTls type;
@@ -43,4 +43,4 @@ struct WebSocketNoTls : public websocketpp::config::core {
     permessage_deflate_type;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_tls.hpp
@@ -5,7 +5,7 @@
 
 #include "./websocket_logging.hpp"
 
-namespace foxglove {
+namespace foxglove_ws {
 
 struct WebSocketTls : public websocketpp::config::core {
   typedef WebSocketTls type;
@@ -42,4 +42,4 @@ struct WebSocketTls : public websocketpp::config::core {
     permessage_deflate_type;
 };
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/src/base64.cpp
+++ b/foxglove_bridge_base/src/base64.cpp
@@ -2,7 +2,7 @@
 
 #include <foxglove_bridge/base64.hpp>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 // Adapted from:
 // https://gist.github.com/tomykaira/f0fd86b6c73063283afe550bc5d77594
@@ -103,4 +103,4 @@ std::vector<unsigned char> base64Decode(const std::string& input) {
   return decoded;
 }
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/src/parameter.cpp
+++ b/foxglove_bridge_base/src/parameter.cpp
@@ -1,6 +1,6 @@
 #include <foxglove_bridge/parameter.hpp>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 ParameterValue::ParameterValue()
     : _type(ParameterType::PARAMETER_NOT_SET) {}
@@ -40,4 +40,4 @@ Parameter::Parameter(const std::string& name, const ParameterValue& value)
     : _name(name)
     , _value(value) {}
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/src/serialization.cpp
+++ b/foxglove_bridge_base/src/serialization.cpp
@@ -1,7 +1,7 @@
 #include <foxglove_bridge/base64.hpp>
 #include <foxglove_bridge/serialization.hpp>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 void to_json(nlohmann::json& j, const Channel& c) {
   j = {
@@ -157,15 +157,15 @@ void ServiceResponse::read(const uint8_t* data, size_t dataLength) {
 
 void ServiceResponse::write(uint8_t* data) const {
   size_t offset = 0;
-  foxglove::WriteUint32LE(data + offset, this->serviceId);
+  foxglove_ws::WriteUint32LE(data + offset, this->serviceId);
   offset += 4;
-  foxglove::WriteUint32LE(data + offset, this->callId);
+  foxglove_ws::WriteUint32LE(data + offset, this->callId);
   offset += 4;
-  foxglove::WriteUint32LE(data + offset, static_cast<uint32_t>(this->encoding.size()));
+  foxglove_ws::WriteUint32LE(data + offset, static_cast<uint32_t>(this->encoding.size()));
   offset += 4;
   std::memcpy(data + offset, this->encoding.data(), this->encoding.size());
   offset += this->encoding.size();
   std::memcpy(data + offset, this->data.data(), this->data.size());
 }
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/src/server_factory.cpp
+++ b/foxglove_bridge_base/src/server_factory.cpp
@@ -5,16 +5,18 @@
 #include <foxglove_bridge/websocket_server.hpp>
 #include <foxglove_bridge/websocket_tls.hpp>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 template <>
 std::unique_ptr<ServerInterface<websocketpp::connection_hdl>> ServerFactory::createServer(
   const std::string& name, const std::function<void(WebSocketLogLevel, char const*)>& logHandler,
   const ServerOptions& options) {
   if (options.useTls) {
-    return std::make_unique<foxglove::Server<foxglove::WebSocketTls>>(name, logHandler, options);
+    return std::make_unique<foxglove_ws::Server<foxglove_ws::WebSocketTls>>(name, logHandler,
+                                                                            options);
   } else {
-    return std::make_unique<foxglove::Server<foxglove::WebSocketNoTls>>(name, logHandler, options);
+    return std::make_unique<foxglove_ws::Server<foxglove_ws::WebSocketNoTls>>(name, logHandler,
+                                                                              options);
   }
 }
 
@@ -59,4 +61,4 @@ inline void Server<WebSocketTls>::setupTlsHandler() {
   });
 }
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/src/test/test_client.cpp
+++ b/foxglove_bridge_base/src/test/test_client.cpp
@@ -6,7 +6,7 @@
 #include <foxglove_bridge/test/test_client.hpp>
 #include <foxglove_bridge/websocket_client.hpp>
 
-namespace foxglove {
+namespace foxglove_ws {
 
 std::future<std::vector<uint8_t>> waitForChannelMsg(ClientInterface* client,
                                                     SubscriptionId subscriptionId) {
@@ -58,7 +58,7 @@ std::future<ServiceResponse> waitForServiceResponse(std::shared_ptr<ClientInterf
         return;
       }
 
-      foxglove::ServiceResponse response;
+      foxglove_ws::ServiceResponse response;
       response.read(data + 1, dataLength - 1);
       promise->set_value(response);
     });
@@ -122,11 +122,11 @@ std::future<FetchAssetResponse> waitForFetchAssetResponse(std::shared_ptr<Client
         return;
       }
 
-      foxglove::FetchAssetResponse response;
+      foxglove_ws::FetchAssetResponse response;
       size_t offset = 1;
       response.requestId = ReadUint32LE(data + offset);
       offset += 4;
-      response.status = static_cast<foxglove::FetchAssetStatus>(data[offset]);
+      response.status = static_cast<foxglove_ws::FetchAssetStatus>(data[offset]);
       offset += 1;
       const size_t errorMsgLength = static_cast<size_t>(ReadUint32LE(data + offset));
       offset += 4;
@@ -144,4 +144,4 @@ std::future<FetchAssetResponse> waitForFetchAssetResponse(std::shared_ptr<Client
 // Explicit template instantiation
 template class Client<websocketpp::config::asio_client>;
 
-}  // namespace foxglove
+}  // namespace foxglove_ws

--- a/foxglove_bridge_base/tests/base64_test.cpp
+++ b/foxglove_bridge_base/tests/base64_test.cpp
@@ -5,20 +5,20 @@
 TEST(Base64Test, EncodingTest) {
   constexpr char arr[] = {'A', 'B', 'C', 'D'};
   const std::string_view sv(arr, sizeof(arr));
-  const std::string b64encoded = foxglove::base64Encode(sv);
+  const std::string b64encoded = foxglove_ws::base64Encode(sv);
   EXPECT_EQ(b64encoded, "QUJDRA==");
 }
 
 TEST(Base64Test, DecodeTest) {
   const std::vector<unsigned char> expectedVal = {0x00, 0xFF, 0x01, 0xFE};
-  EXPECT_EQ(foxglove::base64Decode("AP8B/g=="), expectedVal);
+  EXPECT_EQ(foxglove_ws::base64Decode("AP8B/g=="), expectedVal);
 }
 
 TEST(Base64Test, DecodeInvalidStringTest) {
   // String length not multiple of 4
-  EXPECT_THROW(foxglove::base64Decode("faefa"), std::runtime_error);
+  EXPECT_THROW(foxglove_ws::base64Decode("faefa"), std::runtime_error);
   // Invalid characters
-  EXPECT_THROW(foxglove::base64Decode("fa^ef a"), std::runtime_error);
+  EXPECT_THROW(foxglove_ws::base64Decode("fa^ef a"), std::runtime_error);
 }
 
 int main(int argc, char** argv) {

--- a/foxglove_bridge_base/tests/serialization_test.cpp
+++ b/foxglove_bridge_base/tests/serialization_test.cpp
@@ -3,7 +3,7 @@
 #include <foxglove_bridge/serialization.hpp>
 
 TEST(SerializationTest, ServiceRequestSerialization) {
-  foxglove::ServiceRequest req;
+  foxglove_ws::ServiceRequest req;
   req.serviceId = 2;
   req.callId = 1;
   req.encoding = "json";
@@ -12,7 +12,7 @@ TEST(SerializationTest, ServiceRequestSerialization) {
   std::vector<uint8_t> data(req.size());
   req.write(data.data());
 
-  foxglove::ServiceRequest req2;
+  foxglove_ws::ServiceRequest req2;
   req2.read(data.data(), data.size());
   EXPECT_EQ(req.serviceId, req2.serviceId);
   EXPECT_EQ(req.callId, req2.callId);

--- a/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros1_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -10,8 +10,8 @@
 
 namespace foxglove_bridge {
 
-foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value);
-XmlRpc::XmlRpcValue toRosParam(const foxglove::ParameterValue& param);
+foxglove_ws::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value);
+XmlRpc::XmlRpcValue toRosParam(const foxglove_ws::ParameterValue& param);
 
 std::vector<std::regex> parseRegexPatterns(const std::vector<std::string>& strings);
 

--- a/ros1_foxglove_bridge/src/param_utils.cpp
+++ b/ros1_foxglove_bridge/src/param_utils.cpp
@@ -6,29 +6,29 @@
 
 namespace foxglove_bridge {
 
-foxglove::ParameterValue fromRosParam(const XmlRpc::XmlRpcValue& value) {
+foxglove_ws::ParameterValue fromRosParam(const XmlRpc::XmlRpcValue& value) {
   const auto type = value.getType();
 
   if (type == XmlRpc::XmlRpcValue::Type::TypeBoolean) {
-    return foxglove::ParameterValue(static_cast<bool>(value));
+    return foxglove_ws::ParameterValue(static_cast<bool>(value));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeInt) {
-    return foxglove::ParameterValue(static_cast<int64_t>(static_cast<int>(value)));
+    return foxglove_ws::ParameterValue(static_cast<int64_t>(static_cast<int>(value)));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeDouble) {
-    return foxglove::ParameterValue(static_cast<double>(value));
+    return foxglove_ws::ParameterValue(static_cast<double>(value));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeString) {
-    return foxglove::ParameterValue(static_cast<std::string>(value));
+    return foxglove_ws::ParameterValue(static_cast<std::string>(value));
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeStruct) {
-    std::unordered_map<std::string, foxglove::ParameterValue> paramMap;
+    std::unordered_map<std::string, foxglove_ws::ParameterValue> paramMap;
     for (const auto& [elementName, elementVal] : value) {
       paramMap.insert({elementName, fromRosParam(elementVal)});
     }
-    return foxglove::ParameterValue(paramMap);
+    return foxglove_ws::ParameterValue(paramMap);
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeArray) {
-    std::vector<foxglove::ParameterValue> paramVec;
+    std::vector<foxglove_ws::ParameterValue> paramVec;
     for (int i = 0; i < value.size(); ++i) {
       paramVec.push_back(fromRosParam(value[i]));
     }
-    return foxglove::ParameterValue(paramVec);
+    return foxglove_ws::ParameterValue(paramVec);
   } else if (type == XmlRpc::XmlRpcValue::Type::TypeInvalid) {
     throw std::runtime_error("Parameter not set");
   } else {
@@ -36,31 +36,31 @@ foxglove::ParameterValue fromRosParam(const XmlRpc::XmlRpcValue& value) {
   }
 }
 
-foxglove::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value) {
-  return foxglove::Parameter(name, fromRosParam(value));
+foxglove_ws::Parameter fromRosParam(const std::string& name, const XmlRpc::XmlRpcValue& value) {
+  return foxglove_ws::Parameter(name, fromRosParam(value));
 }
 
-XmlRpc::XmlRpcValue toRosParam(const foxglove::ParameterValue& param) {
+XmlRpc::XmlRpcValue toRosParam(const foxglove_ws::ParameterValue& param) {
   const auto paramType = param.getType();
-  if (paramType == foxglove::ParameterType::PARAMETER_BOOL) {
+  if (paramType == foxglove_ws::ParameterType::PARAMETER_BOOL) {
     return param.getValue<bool>();
-  } else if (paramType == foxglove::ParameterType::PARAMETER_INTEGER) {
+  } else if (paramType == foxglove_ws::ParameterType::PARAMETER_INTEGER) {
     return static_cast<int>(param.getValue<int64_t>());
-  } else if (paramType == foxglove::ParameterType::PARAMETER_DOUBLE) {
+  } else if (paramType == foxglove_ws::ParameterType::PARAMETER_DOUBLE) {
     return param.getValue<double>();
-  } else if (paramType == foxglove::ParameterType::PARAMETER_STRING) {
+  } else if (paramType == foxglove_ws::ParameterType::PARAMETER_STRING) {
     return param.getValue<std::string>();
-  } else if (paramType == foxglove::ParameterType::PARAMETER_STRUCT) {
+  } else if (paramType == foxglove_ws::ParameterType::PARAMETER_STRUCT) {
     XmlRpc::XmlRpcValue valueStruct;
     const auto& paramMap =
-      param.getValue<std::unordered_map<std::string, foxglove::ParameterValue>>();
+      param.getValue<std::unordered_map<std::string, foxglove_ws::ParameterValue>>();
     for (const auto& [paramName, paramElement] : paramMap) {
       valueStruct[paramName] = toRosParam(paramElement);
     }
     return valueStruct;
-  } else if (paramType == foxglove::ParameterType::PARAMETER_ARRAY) {
+  } else if (paramType == foxglove_ws::ParameterType::PARAMETER_ARRAY) {
     XmlRpc::XmlRpcValue arr;
-    const auto vec = param.getValue<std::vector<foxglove::ParameterValue>>();
+    const auto vec = param.getValue<std::vector<foxglove_ws::ParameterValue>>();
     for (int i = 0; i < static_cast<int>(vec.size()); ++i) {
       arr[i] = toRosParam(vec[i]);
     }

--- a/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/parameter_interface.hpp
@@ -14,7 +14,7 @@
 
 namespace foxglove_bridge {
 
-using ParameterList = std::vector<foxglove::Parameter>;
+using ParameterList = std::vector<foxglove_ws::Parameter>;
 using ParamUpdateFunc = std::function<void(const ParameterList&)>;
 
 enum class UnresponsiveNodePolicy {

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -24,11 +24,11 @@
 namespace foxglove_bridge {
 
 using ConnectionHandle = websocketpp::connection_hdl;
-using LogLevel = foxglove::WebSocketLogLevel;
+using LogLevel = foxglove_ws::WebSocketLogLevel;
 using Subscription = rclcpp::GenericSubscription::SharedPtr;
 using SubscriptionsByClient = std::map<ConnectionHandle, Subscription, std::owner_less<>>;
 using Publication = rclcpp::GenericPublisher::SharedPtr;
-using ClientPublications = std::unordered_map<foxglove::ClientChannelId, Publication>;
+using ClientPublications = std::unordered_map<foxglove_ws::ClientChannelId, Publication>;
 using PublicationsByClient = std::map<ConnectionHandle, ClientPublications, std::owner_less<>>;
 
 class FoxgloveBridge : public rclcpp::Node {
@@ -57,18 +57,18 @@ private:
     }
   };
 
-  std::unique_ptr<foxglove::ServerInterface<ConnectionHandle>> _server;
+  std::unique_ptr<foxglove_ws::ServerInterface<ConnectionHandle>> _server;
   foxglove::MessageDefinitionCache _messageDefinitionCache;
   std::vector<std::regex> _topicWhitelistPatterns;
   std::vector<std::regex> _serviceWhitelistPatterns;
   std::vector<std::regex> _assetUriAllowlistPatterns;
   std::vector<std::regex> _bestEffortQosTopicWhiteListPatterns;
   std::shared_ptr<ParameterInterface> _paramInterface;
-  std::unordered_map<foxglove::ChannelId, foxglove::ChannelWithoutId> _advertisedTopics;
-  std::unordered_map<foxglove::ServiceId, foxglove::ServiceWithoutId> _advertisedServices;
-  std::unordered_map<foxglove::ChannelId, SubscriptionsByClient> _subscriptions;
+  std::unordered_map<foxglove_ws::ChannelId, foxglove_ws::ChannelWithoutId> _advertisedTopics;
+  std::unordered_map<foxglove_ws::ServiceId, foxglove_ws::ServiceWithoutId> _advertisedServices;
+  std::unordered_map<foxglove_ws::ChannelId, SubscriptionsByClient> _subscriptions;
   PublicationsByClient _clientAdvertisedTopics;
-  std::unordered_map<foxglove::ServiceId, GenericClient::SharedPtr> _serviceClients;
+  std::unordered_map<foxglove_ws::ServiceId, GenericClient::SharedPtr> _serviceClients;
   rclcpp::CallbackGroup::SharedPtr _subscriptionCallbackGroup;
   rclcpp::CallbackGroup::SharedPtr _clientPublishCallbackGroup;
   rclcpp::CallbackGroup::SharedPtr _servicesCallbackGroup;
@@ -84,39 +84,39 @@ private:
   std::atomic<bool> _subscribeGraphUpdates = false;
   bool _includeHidden = false;
   bool _disableLoanMessage = true;
-  std::unique_ptr<foxglove::CallbackQueue> _fetchAssetQueue;
+  std::unique_ptr<foxglove_ws::CallbackQueue> _fetchAssetQueue;
   std::unordered_map<std::string, std::shared_ptr<RosMsgParser::Parser>> _jsonParsers;
   std::atomic<bool> _shuttingDown = false;
 
   void subscribeConnectionGraph(bool subscribe);
 
-  void subscribe(foxglove::ChannelId channelId, ConnectionHandle clientHandle);
+  void subscribe(foxglove_ws::ChannelId channelId, ConnectionHandle clientHandle);
 
-  void unsubscribe(foxglove::ChannelId channelId, ConnectionHandle clientHandle);
+  void unsubscribe(foxglove_ws::ChannelId channelId, ConnectionHandle clientHandle);
 
-  void clientAdvertise(const foxglove::ClientAdvertisement& advertisement, ConnectionHandle hdl);
+  void clientAdvertise(const foxglove_ws::ClientAdvertisement& advertisement, ConnectionHandle hdl);
 
-  void clientUnadvertise(foxglove::ChannelId channelId, ConnectionHandle hdl);
+  void clientUnadvertise(foxglove_ws::ChannelId channelId, ConnectionHandle hdl);
 
-  void clientMessage(const foxglove::ClientMessage& message, ConnectionHandle hdl);
+  void clientMessage(const foxglove_ws::ClientMessage& message, ConnectionHandle hdl);
 
-  void setParameters(const std::vector<foxglove::Parameter>& parameters,
+  void setParameters(const std::vector<foxglove_ws::Parameter>& parameters,
                      const std::optional<std::string>& requestId, ConnectionHandle hdl);
 
   void getParameters(const std::vector<std::string>& parameters,
                      const std::optional<std::string>& requestId, ConnectionHandle hdl);
 
   void subscribeParameters(const std::vector<std::string>& parameters,
-                           foxglove::ParameterSubscriptionOperation op, ConnectionHandle);
+                           foxglove_ws::ParameterSubscriptionOperation op, ConnectionHandle);
 
-  void parameterUpdates(const std::vector<foxglove::Parameter>& parameters);
+  void parameterUpdates(const std::vector<foxglove_ws::Parameter>& parameters);
 
   void logHandler(LogLevel level, char const* msg);
 
-  void rosMessageHandler(const foxglove::ChannelId& channelId, ConnectionHandle clientHandle,
+  void rosMessageHandler(const foxglove_ws::ChannelId& channelId, ConnectionHandle clientHandle,
                          std::shared_ptr<const rclcpp::SerializedMessage> msg);
 
-  void serviceRequest(const foxglove::ServiceRequest& request, ConnectionHandle clientHandle);
+  void serviceRequest(const foxglove_ws::ServiceRequest& request, ConnectionHandle clientHandle);
 
   void fetchAsset(const std::string& assetId, uint32_t requestId, ConnectionHandle clientHandle);
 

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -139,8 +139,8 @@ void declareParameters(rclcpp::Node* node) {
   paramCapabilities.read_only = true;
   node->declare_parameter(
     PARAM_CAPABILITIES,
-    std::vector<std::string>(std::vector<std::string>(foxglove::DEFAULT_CAPABILITIES.begin(),
-                                                      foxglove::DEFAULT_CAPABILITIES.end())),
+    std::vector<std::string>(std::vector<std::string>(foxglove_ws::DEFAULT_CAPABILITIES.begin(),
+                                                      foxglove_ws::DEFAULT_CAPABILITIES.end())),
     paramCapabilities);
 
   auto clientTopicWhiteListDescription = rcl_interfaces::msg::ParameterDescriptor{};

--- a/ros2_foxglove_bridge/src/parameter_interface.cpp
+++ b/ros2_foxglove_bridge/src/parameter_interface.cpp
@@ -28,9 +28,9 @@ static std::string prependNodeNameToParamName(const std::string& paramName,
   return nodeName + PARAM_SEP + paramName;
 }
 
-static rclcpp::Parameter toRosParam(const foxglove::Parameter& p) {
-  using foxglove::Parameter;
-  using foxglove::ParameterType;
+static rclcpp::Parameter toRosParam(const foxglove_ws::Parameter& p) {
+  using foxglove_ws::Parameter;
+  using foxglove_ws::ParameterType;
 
   const auto paramType = p.getType();
   const auto value = p.getValue();
@@ -46,7 +46,7 @@ static rclcpp::Parameter toRosParam(const foxglove::Parameter& p) {
   } else if (paramType == ParameterType::PARAMETER_BYTE_ARRAY) {
     return rclcpp::Parameter(p.getName(), value.getValue<std::vector<unsigned char>>());
   } else if (paramType == ParameterType::PARAMETER_ARRAY) {
-    const auto paramVec = value.getValue<std::vector<foxglove::ParameterValue>>();
+    const auto paramVec = value.getValue<std::vector<foxglove_ws::ParameterValue>>();
 
     const auto elementType = paramVec.front().getType();
     if (elementType == ParameterType::PARAMETER_BOOL) {
@@ -84,45 +84,45 @@ static rclcpp::Parameter toRosParam(const foxglove::Parameter& p) {
   return rclcpp::Parameter();
 }
 
-static foxglove::Parameter fromRosParam(const rclcpp::Parameter& p) {
+static foxglove_ws::Parameter fromRosParam(const rclcpp::Parameter& p) {
   const auto type = p.get_type();
 
   if (type == rclcpp::ParameterType::PARAMETER_NOT_SET) {
-    return foxglove::Parameter(p.get_name(), foxglove::ParameterValue());
+    return foxglove_ws::Parameter(p.get_name(), foxglove_ws::ParameterValue());
   } else if (type == rclcpp::ParameterType::PARAMETER_BOOL) {
-    return foxglove::Parameter(p.get_name(), p.as_bool());
+    return foxglove_ws::Parameter(p.get_name(), p.as_bool());
   } else if (type == rclcpp::ParameterType::PARAMETER_INTEGER) {
-    return foxglove::Parameter(p.get_name(), p.as_int());
+    return foxglove_ws::Parameter(p.get_name(), p.as_int());
   } else if (type == rclcpp::ParameterType::PARAMETER_DOUBLE) {
-    return foxglove::Parameter(p.get_name(), p.as_double());
+    return foxglove_ws::Parameter(p.get_name(), p.as_double());
   } else if (type == rclcpp::ParameterType::PARAMETER_STRING) {
-    return foxglove::Parameter(p.get_name(), p.as_string());
+    return foxglove_ws::Parameter(p.get_name(), p.as_string());
   } else if (type == rclcpp::ParameterType::PARAMETER_BYTE_ARRAY) {
-    return foxglove::Parameter(p.get_name(), p.as_byte_array());
+    return foxglove_ws::Parameter(p.get_name(), p.as_byte_array());
   } else if (type == rclcpp::ParameterType::PARAMETER_BOOL_ARRAY) {
-    std::vector<foxglove::ParameterValue> paramVec;
+    std::vector<foxglove_ws::ParameterValue> paramVec;
     for (const auto value : p.as_bool_array()) {
-      paramVec.push_back(foxglove::ParameterValue(value));
+      paramVec.push_back(foxglove_ws::ParameterValue(value));
     }
-    return foxglove::Parameter(p.get_name(), paramVec);
+    return foxglove_ws::Parameter(p.get_name(), paramVec);
   } else if (type == rclcpp::ParameterType::PARAMETER_INTEGER_ARRAY) {
-    std::vector<foxglove::ParameterValue> paramVec;
+    std::vector<foxglove_ws::ParameterValue> paramVec;
     for (const auto value : p.as_integer_array()) {
       paramVec.push_back(value);
     }
-    return foxglove::Parameter(p.get_name(), paramVec);
+    return foxglove_ws::Parameter(p.get_name(), paramVec);
   } else if (type == rclcpp::ParameterType::PARAMETER_DOUBLE_ARRAY) {
-    std::vector<foxglove::ParameterValue> paramVec;
+    std::vector<foxglove_ws::ParameterValue> paramVec;
     for (const auto value : p.as_double_array()) {
       paramVec.push_back(value);
     }
-    return foxglove::Parameter(p.get_name(), paramVec);
+    return foxglove_ws::Parameter(p.get_name(), paramVec);
   } else if (type == rclcpp::ParameterType::PARAMETER_STRING_ARRAY) {
-    std::vector<foxglove::ParameterValue> paramVec;
+    std::vector<foxglove_ws::ParameterValue> paramVec;
     for (const auto& value : p.as_string_array()) {
       paramVec.push_back(value);
     }
-    return foxglove::Parameter(p.get_name(), paramVec);
+    return foxglove_ws::Parameter(p.get_name(), paramVec);
   } else {
     throw std::runtime_error("Unsupported parameter type");
   }
@@ -132,7 +132,7 @@ static foxglove::Parameter fromRosParam(const rclcpp::Parameter& p) {
 
 namespace foxglove_bridge {
 
-using foxglove::isWhitelisted;
+using foxglove_ws::isWhitelisted;
 
 ParameterInterface::ParameterInterface(rclcpp::Node* node,
                                        std::vector<std::regex> paramWhitelistPatterns,


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
This mechanical refactoring PR is in preparation for migrating away from the legacy foxglove/ws-protocol implementation within the ROS bridge in favor of the SDK. Including headers from the SDK results in build errors due to conflicting symbols in the `foxglove` namespace. This PR introduces a new namespace, `foxglove_ws`, to provide separation, and migrates the files in `foxglove_bridge_base` that were copied from foxglvoe/ws-protocol to use this namespace.

Tested that ros1 and ros2 implementations compile successfully.

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

Code from foxglove/ws-protocol in `foxglove_bridge_base` is in the `foxglove` namespace.

</td><td>

Code from foxglove/ws-protocol in `foxglove_bridge_base` is in the `foxglove_ws` namespace.

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

