### PR TITLE
update `asset_uri_allowlist` parameter to allow multiple periods in file name

### DIFF
--- a/ros1_foxglove_bridge/launch/foxglove_bridge.launch
+++ b/ros1_foxglove_bridge/launch/foxglove_bridge.launch
@@ -13,7 +13,7 @@
   <arg name="nodelet_manager"                   default="foxglove_nodelet_manager" />
   <arg name="num_threads"                       default="0" />
   <arg name="capabilities"                      default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph,assets]" />
-  <arg name="asset_uri_allowlist"               default="['^package://(?:[-\w%]+/)*[-\w%]+\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />
+  <arg name="asset_uri_allowlist"               default="['^package://(?:[-\w%]+/)*[-\w%.]+\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />
   <arg name="service_type_retrieval_timeout_ms" default="250" />
 
   <node pkg="nodelet" type="nodelet" name="foxglove_nodelet_manager" args="manager"

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -107,7 +107,7 @@ public:
     const auto assetUriAllowlist = nhp.param<std::vector<std::string>>(
       "asset_uri_allowlist",
       {"^package://(?:[-\\w%]+/"
-       ")*[-\\w%]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$"});
+       ")*[-\\w%.]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$"});
     _assetUriAllowlistPatterns = parseRegexPatterns(assetUriAllowlist);
     if (assetUriAllowlist.size() != _assetUriAllowlistPatterns.size()) {
       ROS_ERROR("Failed to parse one or more asset URI whitelist patterns");

--- a/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
+++ b/ros2_foxglove_bridge/launch/foxglove_bridge_launch.xml
@@ -15,7 +15,7 @@
   <arg name="use_sim_time"                    default="false" />
   <arg name="capabilities"                    default="[clientPublish,parameters,parametersSubscribe,services,connectionGraph,assets]" />
   <arg name="include_hidden"                  default="false" />
-  <arg name="asset_uri_allowlist"             default="['^package://(?:[-\\w%]+/)*[-\\w%]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />  <!-- Needs double-escape -->
+  <arg name="asset_uri_allowlist"             default="['^package://(?:[-\\w%]+/)*[-\\w%.]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$']" />  <!-- Needs double-escape -->
   <arg name="ignore_unresponsive_param_nodes" default="true" />
 
   <node pkg="foxglove_bridge" exec="foxglove_bridge">

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -176,8 +176,8 @@ void declareParameters(rclcpp::Node* node) {
   node->declare_parameter(
     PARAM_ASSET_URI_ALLOWLIST,
     std::vector<std::string>(
-      {"^package://(?:[-\\w$]+/"
-       ")*[-\\w$]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$"}),
+      {"^package://(?:[-\\w%]+/"
+       ")*[-\\w%.]+\\.(?:dae|fbx|glb|gltf|jpeg|jpg|mtl|obj|png|stl|tif|tiff|urdf|webp|xacro)$"}),
     paramWhiteListDescription);
 
   auto ignUnresponsiveParamNodes = rcl_interfaces::msg::ParameterDescriptor{};


### PR DESCRIPTION
### Changelog
update `asset_uri_allowlist` parameter to allow multiple periods in file name

### Docs
None

### Description
Prior to this change, the default `asset_uri_allowlist` parameter would not allow URIs that have multiple periods in their file name part, such as e.g.  `package://foo/bar/robot.urdf.xacro`. This PR adapts the parameter to allow multiple periods.