### PR TITLE
Run ros2 executable without component manager

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -186,6 +186,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     )
     target_include_directories(foxglove_bridge SYSTEM PRIVATE ${rclcpp_INCLUDE_DIRS})
     target_link_libraries(foxglove_bridge
+      foxglove_bridge_component
       rclcpp::rclcpp
       rclcpp_components::component
       rclcpp_components::component_manager

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge_node.cpp
@@ -1,5 +1,7 @@
 #include <rclcpp_components/component_manager.hpp>
 
+#include <foxglove_bridge/ros2_foxglove_bridge.hpp>
+
 int main(int argc, char* argv[]) {
   rclcpp::init(argc, argv);
 
@@ -27,18 +29,7 @@ int main(int argc, char* argv[]) {
   auto executor =
     rclcpp::executors::MultiThreadedExecutor::make_shared(rclcpp::ExecutorOptions{}, numThreads);
 
-  rclcpp_components::ComponentManager componentManager(executor,
-                                                       "foxglove_bridge_component_manager");
-  const auto componentResources = componentManager.get_component_resources("foxglove_bridge");
-
-  if (componentResources.empty()) {
-    RCLCPP_INFO(componentManager.get_logger(), "No loadable resources found");
-    return EXIT_FAILURE;
-  }
-
-  auto componentFactory = componentManager.create_component_factory(componentResources.front());
-  auto node = componentFactory->create_node_instance(rclcpp::NodeOptions());
-
+  foxglove_bridge::FoxgloveBridge node;
   executor->add_node(node.get_node_base_interface());
   executor->spin();
   rclcpp::shutdown();


### PR DESCRIPTION
### Changelog
Fix warning when running ROS2 executable with custom node name

### Docs
None

### Description
Changes the ROS2 executable to use the standalone foxglove_bridge node rather than using a component manager and loading the foxglove_bridge component in it. 

