### PR TITLE
Set up clangd for vscode dev container

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -7,6 +7,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
   build-essential \
   clang \
   clang-format \
+  clangd-14 \
   curl \
   gdb \
   git \
@@ -24,6 +25,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Set clang as default compiler
 ENV CC=clang
 ENV CXX=clang++
+
+# Configure clangd
+RUN update-alternatives --install /usr/local/bin/clangd clangd $(which clangd-14) 1000
 
 # Create a non-root user
 # Taken from https://code.visualstudio.com/remote/advancedcontainers/add-nonroot-user#_creating-a-nonroot-user
@@ -61,7 +65,7 @@ SHELL ["/bin/bash", "-c"]
 
 # Add aliases to .bashrc
 RUN echo $'\
-alias ros2_build_debug="source /opt/ros/humble/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug"\n\
+alias ros2_build_debug="source /opt/ros/humble/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON"\n\
 alias ros2_build_release="source /opt/ros/humble/setup.bash && colcon build --cmake-args -DCMAKE_BUILD_TYPE=RelWithDebInfo"\n\
 alias ros2_foxglove_bridge="source /ros_ws/install_ros2/setup.bash && ros2 run foxglove_bridge foxglove_bridge --ros-args --log-level debug --log-level rcl:=INFO"\n\
 ' >> ~/.bashrc

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,6 +11,7 @@
   "customizations": {
     "vscode": {
       "extensions": [
+        "llvm-vs-code-extensions.vscode-clangd",
         "ms-vscode.cpptools",
         "xaver.clang-format",
         "twxs.cmake"
@@ -25,7 +26,13 @@
             ],
             "icon": "terminal-bash"
           }
-        }
+        },
+        "clangd.arguments": [
+          "-log=verbose",
+          "-pretty",
+          "--background-index",
+          "--compile-commands-dir=/ros_ws/build_ros2"
+        ]
       }
     }
   },


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Developer quality-of-life change to install `clangd-14` in the VSCode dev container, configure it to provide `clangd`, and configure CMake to output `compile_commands.json` when a debug build configuration is selected.

Enables IntelliSense-like code navigation, in-editor checking, and semantic completion capabilities in VSCode.

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

