### PR TITLE
Fix error on Windows

### DIFF
--- a/ros2_foxglove_bridge/src/message_definition_cache.cpp
+++ b/ros2_foxglove_bridge/src/message_definition_cache.cpp
@@ -234,7 +234,7 @@ const MessageSpec& MessageDefinitionCache::load_message_spec(
   }
 
   // Read the file
-  const std::string full_path = share_dir + std::filesystem::path::preferred_separator + *it;
+  const std::string full_path = (std::filesystem::path(share_dir) / *it).string();
   std::ifstream file{full_path};
   if (!file.good()) {
     throw DefinitionNotFoundError(definition_identifier.package_resource_name);


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
Build error on Windows with RoboStack:
```
%SRC_DIR%\ros-humble-foxglove-bridge\src\work\ros2_foxglove_bridge\src\message_definition_cache.cpp(237,33): error C2678: binary '+': no operator found which takes a left-hand operand of type 'const std::string' (or there is no acceptable conversion)
```

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->
See error above
</td><td>

<!--after content goes here-->
Builds fine
</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

