### PR TITLE
Implement asset fetch functionality in SDK version

### DIFF
--- a/ros2_foxglove_bridge_sdk/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge_sdk/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -13,6 +13,7 @@
 
 #include <foxglove/foxglove.hpp>
 #include <foxglove/server.hpp>
+#include <foxglove/server/fetch_asset.hpp>
 #include <foxglove_bridge/callback_queue.hpp>
 #include <foxglove_bridge/foxglove_bridge.hpp>
 #include <foxglove_bridge/generic_client.hpp>
@@ -141,7 +142,7 @@ private:
 
   void serviceRequest(const foxglove_ws::ServiceRequest& request, ConnectionHandle clientHandle);
 
-  void fetchAsset(const std::string& assetId, uint32_t requestId, ConnectionHandle clientHandle);
+  void fetchAsset(const std::string_view uri, foxglove::FetchAssetResponder&& responder);
 
   bool hasCapability(const std::string& capability);
 

--- a/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
@@ -915,7 +915,7 @@ void FoxgloveBridge::fetchAsset(const std::string_view uriView,
     // `package://<pkg_name>/../../../secret.txt`. This is an extra security measure and should
     // not be necessary if the allowlist is strict enough.
     if (uri.find("..") != std::string::npos || !isWhitelisted(uri, _assetUriAllowlistPatterns)) {
-      throw std::runtime_error("Asset URI not allowed: " + std::string(uri));
+      throw std::runtime_error("Asset URI not allowed: " + uri);
     }
 
     resource_retriever::Retriever resource_retriever;

--- a/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
@@ -126,6 +126,10 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
       std::bind(&FoxgloveBridge::clientMessage, this, _1, _2, _3, _4);
   }
 
+  if (hasCapability(foxglove_ws::CAPABILITY_ASSETS)) {
+    sdkServerOptions.fetch_asset = std::bind(&FoxgloveBridge::fetchAsset, this, _1, _2);
+  }
+
   // TODO: The SDK server currently doesn't implement any of the TLS functionality. Once that
   // exists, add it here.
 
@@ -901,11 +905,9 @@ void FoxgloveBridge::serviceRequest(const foxglove_ws::ServiceRequest& request,
   client->async_send_request(reqMessage, responseReceivedCallback);
 }
 
-void FoxgloveBridge::fetchAsset(const std::string& uri, uint32_t requestId,
-                                ConnectionHandle clientHandle) {
-  foxglove_ws::FetchAssetResponse response;
-  response.requestId = requestId;
-
+void FoxgloveBridge::fetchAsset(const std::string_view uriView,
+                                foxglove::FetchAssetResponder&& responder) {
+  std::string uri(uriView);
   try {
     // We reject URIs that are not on the allowlist or that contain two consecutive dots. The
     // latter can be utilized to construct URIs for retrieving confidential files that should
@@ -913,7 +915,7 @@ void FoxgloveBridge::fetchAsset(const std::string& uri, uint32_t requestId,
     // `package://<pkg_name>/../../../secret.txt`. This is an extra security measure and should
     // not be necessary if the allowlist is strict enough.
     if (uri.find("..") != std::string::npos || !isWhitelisted(uri, _assetUriAllowlistPatterns)) {
-      throw std::runtime_error("Asset URI not allowed: " + uri);
+      throw std::runtime_error("Asset URI not allowed: " + std::string(uri));
     }
 
     resource_retriever::Retriever resource_retriever;
@@ -922,25 +924,18 @@ void FoxgloveBridge::fetchAsset(const std::string& uri, uint32_t requestId,
 #if RESOURCE_RETRIEVER_VERSION_MAJOR > 3 || \
   (RESOURCE_RETRIEVER_VERSION_MAJOR == 3 && RESOURCE_RETRIEVER_VERSION_MINOR > 6)
     const auto memoryResource = resource_retriever.get_shared(uri);
-    response.status = foxglove_ws::FetchAssetStatus::Success;
-    response.errorMessage = "";
-    response.data.resize(memoryResource->data.size());
-    std::memcpy(response.data.data(), memoryResource->data.data(), memoryResource->data.size());
+    std::vector<std::byte> data(memoryResource->data.size());
+    std::memcpy(data.data(), memoryResource->data.data(), memoryResource->data.size());
+    std::move(responder).respondOk(data);
 #else
     const resource_retriever::MemoryResource memoryResource = resource_retriever.get(uri);
-    response.status = foxglove_ws::FetchAssetStatus::Success;
-    response.errorMessage = "";
-    response.data.resize(memoryResource.size);
-    std::memcpy(response.data.data(), memoryResource.data.get(), memoryResource.size);
+    std::vector<std::byte> data(memoryResource.size);
+    std::memcpy(data.data(), memoryResource.data.get(), memoryResource.size);
+    std::move(responder).respondOk(data);
 #endif
   } catch (const std::exception& ex) {
     RCLCPP_WARN(this->get_logger(), "Failed to retrieve asset '%s': %s", uri.c_str(), ex.what());
-    response.status = foxglove_ws::FetchAssetStatus::Error;
-    response.errorMessage = "Failed to retrieve asset " + uri;
-  }
-
-  if (_server) {
-    _server->sendFetchAssetResponse(clientHandle, response);
+    std::move(responder).respondError("Failed to retrieve asset " + uri);
   }
 }
 

--- a/ros2_foxglove_bridge_sdk/tests/smoke_test.cpp
+++ b/ros2_foxglove_bridge_sdk/tests/smoke_test.cpp
@@ -719,8 +719,7 @@ TEST(SmokeTest, receiveMessagesOfMultipleTransientLocalPublishers) {
   spinnerThread.join();
 }
 
-// TODO: FG-12235: Enable when Asset capability is implemented
-TEST(FetchAssetTest, DISABLED_fetchExistingAsset) {
+TEST(FetchAssetTest, fetchExistingAsset) {
   auto wsClient = std::make_shared<foxglove_ws::Client<websocketpp::config::asio_client>>();
   EXPECT_EQ(std::future_status::ready, wsClient->connect(URI).wait_for(DEFAULT_TIMEOUT));
 
@@ -749,8 +748,7 @@ TEST(FetchAssetTest, DISABLED_fetchExistingAsset) {
   std::remove(tmpFilePath.c_str());
 }
 
-// TODO: FG-12235: Enable when Asset capability is implemented
-TEST(FetchAssetTest, DISABLED_fetchNonExistingAsset) {
+TEST(FetchAssetTest, fetchNonExistingAsset) {
   auto wsClient = std::make_shared<foxglove_ws::Client<websocketpp::config::asio_client>>();
   EXPECT_EQ(std::future_status::ready, wsClient->connect(URI).wait_for(DEFAULT_TIMEOUT));
 


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Use the SDK server facilities for handling asset requests and [fetching assets](https://foxglove.github.io/foxglove-sdk/cpp/generated/api/classfoxglove_1_1FetchAssetResponder.html#_CPPv4N8foxglove19FetchAssetResponderE).

<table><tr><th>Before</th><th>After</th></tr><tr><td>

No asset functionality exists in SDK version; unit tests fail.

</td><td>

SDK version supports fetching assets; unit tests pass.

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

Fixes: FG-12235