### PR TITLE
Point build to SDK v0.10.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,0 @@
-tmp/*.zip filter=lfs diff=lfs merge=lfs -text

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,33 +55,23 @@ if (ENDIAN)
 endif()
 
 if(USE_FOXGLOVE_SDK)
-  # if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-  #   set(FOXGLOVE_SDK_RELEASES "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.9.0/foxglove-v0.9.0-cpp-aarch64-unknown-linux-gnu.zip" "a554f82b3d1c3096457887bccee7088646b729494ec18909846ac7fcdd06ee1d")
-  # elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-  #   set(FOXGLOVE_SDK_RELEASES "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.9.0/foxglove-v0.9.0-cpp-x86_64-unknown-linux-gnu.zip" "48ea17c348583154d7c1934c9f7e82f57067e2afa76b586e1f7ac14cc6b6c1d0")
-  # else()
-  #   message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
-  # endif()
-
-  # list(GET FOXGLOVE_SDK_RELEASES 0 url)
-  # list(GET FOXGLOVE_SDK_RELEASES 1 hash)
-
   if (CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "aarch64")
-    set(FOXGLOVE_SDK_ZIP_PATH ${CMAKE_CURRENT_SOURCE_DIR}/tmp/foxglove-aarch64.zip)
+    set(FOXGLOVE_SDK_RELEASES "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.10.0/foxglove-v0.10.0-cpp-aarch64-unknown-linux-gnu.zip" "81e2379e3a08160c023779eab0fe5c5764ace3b30c8727b0030ac7dc8b415016")
   elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
-    set(FOXGLOVE_SDK_ZIP_PATH ${CMAKE_CURRENT_SOURCE_DIR}/tmp/foxglove-x86_64.zip)
+    set(FOXGLOVE_SDK_RELEASES "https://github.com/foxglove/foxglove-sdk/releases/download/sdk%2Fv0.10.0/foxglove-v0.10.0-cpp-x86_64-unknown-linux-gnu.zip" "209d34a8703d44a129c559493e1a3fb215888b4d5973622750ac28b1c345946c")
   else()
     message(FATAL_ERROR "Unsupported platform: ${CMAKE_SYSTEM_PROCESSOR}-${CMAKE_SYSTEM_NAME}")
   endif()
 
+  list(GET FOXGLOVE_SDK_RELEASES 0 url)
+  list(GET FOXGLOVE_SDK_RELEASES 1 hash)
 
   # Download Foxglove SDK shared lib
   include(FetchContent)
   FetchContent_Declare(
     foxglove_sdk
-    # URL ${url}
-    # URL_HASH SHA256=${hash}
-    URL ${FOXGLOVE_SDK_ZIP_PATH}
+    URL ${url}
+    URL_HASH SHA256=${hash}
   )
   FetchContent_MakeAvailable(foxglove_sdk)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ if(USE_FOXGLOVE_SDK)
   )
   FetchContent_MakeAvailable(foxglove_sdk)
 
-  add_library(foxglove_sdk SHARED)
+  add_library(foxglove_sdk STATIC)
   target_include_directories(foxglove_sdk SYSTEM
     PUBLIC
       $<BUILD_INTERFACE:${foxglove_sdk_SOURCE_DIR}/include>
@@ -83,6 +83,7 @@ if(USE_FOXGLOVE_SDK)
   )
   file(GLOB_RECURSE FOXGLOVE_SDK_SOURCES CONFIGURE_DEPENDS "${foxglove_sdk_SOURCE_DIR}/src/*.cpp")
   target_sources(foxglove_sdk PRIVATE ${FOXGLOVE_SDK_SOURCES})
+  set_target_properties(foxglove_sdk PROPERTIES POSITION_INDEPENDENT_CODE ON)
   target_link_libraries(foxglove_sdk PRIVATE ${foxglove_sdk_SOURCE_DIR}/lib/libfoxglove.a)
 endif()
 

--- a/Dockerfile.ros2
+++ b/Dockerfile.ros2
@@ -46,7 +46,6 @@ COPY CMakeLists.txt src/ros-foxglove-bridge/CMakeLists.txt
 COPY foxglove_bridge_base src/ros-foxglove-bridge/foxglove_bridge_base
 COPY ros2_foxglove_bridge src/ros-foxglove-bridge/ros2_foxglove_bridge
 COPY ros2_foxglove_bridge_sdk src/ros-foxglove-bridge/ros2_foxglove_bridge_sdk
-COPY tmp src/ros-foxglove-bridge/tmp
 
 ARG USE_ASIO_STANDALONE=ON
 ARG USE_FOXGLOVE_SDK=OFF

--- a/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
@@ -850,8 +850,8 @@ void FoxgloveBridge::rosMessageHandler(ChannelId channelId, SinkId sinkId,
   }
 
   auto& channel = _sdkChannels.at(channelId);
-  channel.log(reinterpret_cast<const std::byte*>(rclSerializedMsg.buffer),
-              rclSerializedMsg.buffer_length, timestamp, sinkId);
+  channel.log_(reinterpret_cast<const std::byte*>(rclSerializedMsg.buffer),
+               rclSerializedMsg.buffer_length, timestamp, sinkId);
 }
 
 void FoxgloveBridge::serviceRequest(const foxglove_ws::ServiceRequest& request,

--- a/tmp/foxglove-aarch64.zip
+++ b/tmp/foxglove-aarch64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:9eb637a7a5fa2f12123081e4652de4a145795104262ea1699cdeacabfd7d5d4f
-size 13427545

--- a/tmp/foxglove-x86_64.zip
+++ b/tmp/foxglove-x86_64.zip
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:02fdccf4cbbb1063f3c9578b38d94603cf793ca6443a0282a927284cb47c439c
-size 13453115


### PR DESCRIPTION
### Changelog
None

### Docs
None

### Description
Update build file to point to the [v0.10.0 SDK release](https://github.com/foxglove/foxglove-sdk/releases/tag/sdk%2Fv0.10.0) and remove temporarily-checked-in build artifacts from LFS.

Also fix issue where foxglove_sdk is being built as a shared library but not installed, by changing the build file to link it statically.

Fixes: FG-12452
