### PR TITLE
Add per topic message throttling

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -198,6 +198,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         ros2_foxglove_bridge_sdk/src/ros2_foxglove_bridge.cpp
         ros2_foxglove_bridge_sdk/src/parameter_interface.cpp
         ros2_foxglove_bridge_sdk/src/generic_client.cpp
+        ros2_foxglove_bridge/src/message_throttler.cpp
       )
       target_include_directories(foxglove_bridge_component
         PUBLIC
@@ -222,6 +223,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
         ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
         ros2_foxglove_bridge/src/parameter_interface.cpp
         ros2_foxglove_bridge/src/generic_client.cpp
+        ros2_foxglove_bridge/src/message_throttler.cpp
       )
       target_include_directories(foxglove_bridge_component
         PUBLIC
@@ -232,7 +234,6 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
 
       target_link_libraries(foxglove_bridge_component foxglove_bridge_base)
     endif()
-
 
     target_compile_definitions(foxglove_bridge_component
       PRIVATE

--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 2) __include_hidden__: Include hidden topics and services. Defaults to `false`.
  * (ROS 2) __disable_load_message__: Do not publish as loaned message when publishing a client message. Defaults to `true`.
  * (ROS 2) __ignore_unresponsive_param_nodes__: Avoid requesting parameters from previously unresponsive nodes. Defaults to `true`.
+ * (ROS 2) __topic_throttle_rates__: List of rates to throttle corresponding (matching index) patterns by. Represents messages per second. If not provided nothing will be throttled. Must have same length as __topic_throttle_patterns__.
+ * (ROS 2) __topic_throttle_patterns__: List of regex patterns to throttle by corresponding rate (matching index) If not provided nothing will be throttled. Must have the same length as __topic_throttle_rates__.
 
 ## Building from source
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * (ROS 2) __ignore_unresponsive_param_nodes__: Avoid requesting parameters from previously unresponsive nodes. Defaults to `true`.
  * (ROS 2) __topic_throttle_rates__: List of rates to throttle corresponding (matching index) patterns by. Represents messages per second. If not provided nothing will be throttled. Must have same length as __topic_throttle_patterns__.
  * (ROS 2) __topic_throttle_patterns__: List of regex patterns to throttle by corresponding rate (matching index) If not provided nothing will be throttled. Must have the same length as __topic_throttle_rates__.
+ * (ROS 2) __min_qos_topic_patterns__: List of regex patterns to use corresponding min qos depth for (matching index). If not provided all topics will use __min_qos_depth__. Must have the same length as __min_qos_topic_depths__.
+ * (ROS 2) __min_qos_topic_depths__: List of depths to use on corresponding min qos pattern (matching index). If not provided all topics will use __min_qos_depth__. Must have the same length as __min_qos_topic_patterns__.
 
 ## Building from source
 

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -83,6 +83,7 @@ public:
   virtual void start(const std::string& host, uint16_t port) = 0;
   virtual void stop() = 0;
 
+  virtual std::unordered_map<ChannelId, Channel> getChannels() = 0;
   virtual std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) = 0;
   virtual void removeChannels(const std::vector<ChannelId>& channelIds) = 0;
   virtual void publishParameterValues(ConnectionHandle clientHandle,

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <functional>
-#include <mutex>
 #include <optional>
 #include <regex>
 #include <shared_mutex>

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -1,8 +1,10 @@
 #pragma once
 
 #include <functional>
+#include <mutex>
 #include <optional>
 #include <regex>
+#include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -76,6 +78,16 @@ struct ServerHandlers {
   std::function<void(const std::string&, uint32_t, ConnectionHandle)> fetchAssetHandler;
 };
 
+struct ChannelsWithLock {
+  const std::unordered_map<ChannelId, Channel>& channels;
+  std::shared_lock<std::shared_mutex> lock;
+
+  ChannelsWithLock(const std::unordered_map<ChannelId, Channel>& ch,
+                   std::shared_lock<std::shared_mutex>&& l)
+      : channels(ch)
+      , lock(std::move(l)) {}
+};
+
 template <typename ConnectionHandle>
 class ServerInterface {
 public:
@@ -83,7 +95,7 @@ public:
   virtual void start(const std::string& host, uint16_t port) = 0;
   virtual void stop() = 0;
 
-  virtual std::unordered_map<ChannelId, Channel> getChannels() = 0;
+  virtual ChannelsWithLock getChannels() = 0;
   virtual std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) = 0;
   virtual void removeChannels(const std::vector<ChannelId>& channelIds) = 0;
   virtual void publishParameterValues(ConnectionHandle clientHandle,

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -130,8 +130,8 @@ public:
 
   void start(const std::string& host, uint16_t port) override;
   void stop() override;
-
-  std::unordered_map<ChannelId, Channel> getChannels() override;
+  
+  ChannelsWithLock getChannels() override;
   std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) override;
   void removeChannels(const std::vector<ChannelId>& channelIds) override;
   void publishParameterValues(ConnHandle clientHandle, const std::vector<Parameter>& parameters,
@@ -173,6 +173,7 @@ private:
     ClientInfo(ClientInfo&&) = default;
     ClientInfo& operator=(ClientInfo&&) = default;
   };
+
 
   std::string _name;
   LogCallback _logger;
@@ -810,9 +811,9 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
 }
 
 template <typename ServerConfiguration>
-std::unordered_map<ChannelId, Channel> Server<ServerConfiguration>::getChannels() {
-  std::unique_lock<std::shared_mutex> lock(_channelsMutex);
-  return this->_channels;
+ChannelsWithLock Server<ServerConfiguration>::getChannels() {
+  std::shared_lock<std::shared_mutex> lock(_channelsMutex);
+  return ChannelsWithLock(this->_channels, std::move(lock));
 }
 
 template <typename ServerConfiguration>

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -131,6 +131,7 @@ public:
   void start(const std::string& host, uint16_t port) override;
   void stop() override;
 
+  std::unordered_map<ChannelId, Channel> getChannels() override;
   std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) override;
   void removeChannels(const std::vector<ChannelId>& channelIds) override;
   void publishParameterValues(ConnHandle clientHandle, const std::vector<Parameter>& parameters,
@@ -806,6 +807,12 @@ inline void Server<ServerConfiguration>::handleBinaryMessage(ConnHandle hdl, Mes
                           "Unrecognized client opcode " + std::to_string(uint8_t(op)));
     } break;
   }
+}
+
+template <typename ServerConfiguration>
+std::unordered_map<ChannelId, Channel> Server<ServerConfiguration>::getChannels() {
+  std::unique_lock<std::shared_mutex> lock(_channelsMutex);
+  return this->_channels;
 }
 
 template <typename ServerConfiguration>

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -130,7 +130,7 @@ public:
 
   void start(const std::string& host, uint16_t port) override;
   void stop() override;
-  
+
   ChannelsWithLock getChannels() override;
   std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) override;
   void removeChannels(const std::vector<ChannelId>& channelIds) override;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -174,7 +174,6 @@ private:
     ClientInfo& operator=(ClientInfo&&) = default;
   };
 
-
   std::string _name;
   LogCallback _logger;
   ServerOptions _options;

--- a/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
@@ -38,13 +38,9 @@ struct ThrottledTopicInfo {
 
 class ThrottledMessage {
 public:
-  ThrottledMessage(ThrottledTopicInfo* topicInfo, const rcl_serialized_message_t& serializedMsg)
-      : _topicInfo(topicInfo)
-      , _serializedMsg(serializedMsg) {
-    this->tryDecode();
-  }
+  ThrottledMessage(ThrottledTopicInfo* topicInfo, const rcl_serialized_message_t& serializedMsg);
 
-  bool allowedThrough(Nanoseconds currentTime);
+  bool isAllowedThrough(Nanoseconds currentTime);
 
   void updateLastSeen(Nanoseconds currentTime);
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
@@ -74,8 +74,7 @@ public:
   MessageThrottleManager(foxglove::ServerInterface<ConnectionHandle>* server,
                          std::vector<double>& topicThrottleRates,
                          std::vector<std::regex>& topicThrottlePatterns)
-      : _logger(rclcpp::get_logger("message_throttle_manager"))
-      , _server(server)
+      : _server(server)
       , _topicThrottleRates(topicThrottleRates)
       , _topicThrottlePatterns(topicThrottlePatterns) {}
 
@@ -83,7 +82,6 @@ public:
                       const Nanoseconds now);
 
 private:
-  rclcpp::Logger _logger;
   std::unordered_map<TypeName, std::shared_ptr<RosMsgParser::Parser>> _messageParsers;
   std::unordered_map<TopicName, std::unique_ptr<ThrottledTopicInfo>> _throttledTopics;
   std::shared_mutex _topicInfoLock;
@@ -95,7 +93,8 @@ private:
 
   /// @param lock Must be a unique_lock on _topicInfoLock
   template <typename Lock>
-  std::optional<std::shared_ptr<RosMsgParser::Parser>> createParser(const TopicName& topic, Lock& lock);
+  std::optional<std::shared_ptr<RosMsgParser::Parser>> createParser(const TopicName& topic,
+                                                                    Lock& lock);
 
   std::optional<TypeSchema> getTypeSchema(const TypeName& type);
 
@@ -109,9 +108,12 @@ private:
 
   /// Checks if a topic should be throttled based on existing throttle configuration.
   /// Two overloads are provided:
-  /// 1. Convenience version that acquires its own shared lock (use when you don't need to hold the lock afterward)
-  /// 2. Template version that accepts caller-provided lock (use when you already have a lock or need to hold it longer)
-  /// @return std::nullopt if topic is unknown, otherwise bool indicating if message should be throttled
+  /// 1. Convenience version that acquires its own shared lock (use when you don't need to hold the
+  /// lock afterward)
+  /// 2. Template version that accepts caller-provided lock (use when you already have a lock or
+  /// need to hold it longer)
+  /// @return std::nullopt if topic is unknown, otherwise bool indicating if message should be
+  /// throttled
   std::optional<bool> tryThrottleIfKnown(const TopicName& topic,
                                          const rcl_serialized_message_t& serializedMsg,
                                          const Nanoseconds now);

--- a/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
@@ -82,7 +82,6 @@ public:
                       const Nanoseconds now);
 
 private:
-  std::unordered_map<TypeName, std::shared_ptr<RosMsgParser::Parser>> _messageParsers;
   std::unordered_map<TopicName, std::unique_ptr<ThrottledTopicInfo>> _throttledTopics;
   std::shared_mutex _topicInfoLock;
   std::unordered_set<TopicName> _unthrottledTopics;
@@ -101,8 +100,6 @@ private:
   std::optional<TypeName> getTypeFromTopic(const TopicName& topic);
 
   std::optional<Nanoseconds> getTopicThrottleInterval(const TopicName& topic);
-
-  std::mutex& waitForParserLock(const TopicName& topic);
 
   bool shouldThrottleAndUpdate(ThrottledMessage& msg, const Nanoseconds time);
 

--- a/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/message_throttler.hpp
@@ -1,0 +1,133 @@
+#pragma once
+
+#include <mutex>
+#include <optional>
+
+#include <rclcpp/rclcpp.hpp>
+#include <rosx_introspection/ros_parser.hpp>
+#include <websocketpp/common/connection_hdl.hpp>
+
+#include <foxglove_bridge/server_interface.hpp>
+
+#define NANOSECONDS_IN_SECOND 1'000'000'000
+
+namespace foxglove_bridge {
+using ConnectionHandle = websocketpp::connection_hdl;
+using TypeName = std::string;
+using Frameid = std::string;
+using TopicName = std::string;
+using TypeSchema = std::string;
+using Nanoseconds = rcl_time_point_value_t;
+
+struct ThrottledTopicInfo {
+  TopicName topic;
+  Nanoseconds throttleInterval;
+  std::mutex parserLock;
+  // NOTE: should be assigned value only on object creation
+  std::optional<std::shared_ptr<RosMsgParser::Parser>> parser;
+  // NOTE: for topics with no frame id, we use "" as frame id, map should only have one element
+  std::unordered_map<Frameid, Nanoseconds> frameIdLastRecieved;
+  std::shared_mutex frameIdLastRecievedLock;
+
+  ThrottledTopicInfo(Nanoseconds interval, std::optional<std::shared_ptr<RosMsgParser::Parser>> p,
+                     std::unordered_map<Frameid, Nanoseconds> frameMap = {})
+      : throttleInterval(interval)
+      , parser(p)
+      , frameIdLastRecieved(std::move(frameMap)) {}
+};
+
+class ThrottledMessage {
+public:
+  ThrottledMessage(ThrottledTopicInfo* topicInfo, const rcl_serialized_message_t& serializedMsg)
+      : _topicInfo(topicInfo)
+      , _serializedMsg(serializedMsg) {
+    this->tryDecode();
+  }
+
+  bool allowedThrough(Nanoseconds currentTime);
+
+  void updateLastSeen(Nanoseconds currentTime);
+
+  template <typename T>
+  std::optional<T> getDecodedMessageField(const std::string& fieldName) {
+    if (!_topicInfo->parser) {
+      return std::nullopt;
+    }
+
+    for (auto& field : _decodedMsg.value) {
+      std::string fieldPath = field.first.toStdString();
+      if (fieldPath.find(fieldName) != std::string::npos) {
+        return std::make_optional<T>(field.second.extract<T>());
+      }
+    }
+
+    return std::nullopt;
+  }
+
+private:
+  ThrottledTopicInfo* _topicInfo;
+  Frameid _frameid;
+  RosMsgParser::FlatMessage _decodedMsg;
+  const rcl_serialized_message_t& _serializedMsg;
+
+  void tryDecode();
+};
+
+class MessageThrottleManager {
+public:
+  MessageThrottleManager(foxglove::ServerInterface<ConnectionHandle>* server,
+                         std::vector<double>& topicThrottleRates,
+                         std::vector<std::regex>& topicThrottlePatterns)
+      : _logger(rclcpp::get_logger("message_throttle_manager"))
+      , _server(server)
+      , _topicThrottleRates(topicThrottleRates)
+      , _topicThrottlePatterns(topicThrottlePatterns) {}
+
+  bool shouldThrottle(const TopicName& topic, const rcl_serialized_message_t& serializedMsg,
+                      const Nanoseconds now);
+
+private:
+  rclcpp::Logger _logger;
+  std::unordered_map<TypeName, std::shared_ptr<RosMsgParser::Parser>> _messageParsers;
+  std::unordered_map<TopicName, std::unique_ptr<ThrottledTopicInfo>> _throttledTopics;
+  std::shared_mutex _topicInfoLock;
+  std::unordered_set<TopicName> _unthrottledTopics;
+  std::shared_mutex _unthrottledTopicLock;
+  foxglove::ServerInterface<ConnectionHandle>* _server;
+  const std::vector<double>& _topicThrottleRates;
+  const std::vector<std::regex>& _topicThrottlePatterns;
+
+  /// @param lock Must be a unique_lock on _topicInfoLock
+  template <typename Lock>
+  std::optional<std::shared_ptr<RosMsgParser::Parser>> createParser(const TopicName& topic, Lock& lock);
+
+  std::optional<TypeSchema> getTypeSchema(const TypeName& type);
+
+  std::optional<TypeName> getTypeFromTopic(const TopicName& topic);
+
+  std::optional<Nanoseconds> getTopicThrottleInterval(const TopicName& topic);
+
+  std::mutex& waitForParserLock(const TopicName& topic);
+
+  bool shouldThrottleAndUpdate(ThrottledMessage& msg, const Nanoseconds time);
+
+  /// Checks if a topic should be throttled based on existing throttle configuration.
+  /// Two overloads are provided:
+  /// 1. Convenience version that acquires its own shared lock (use when you don't need to hold the lock afterward)
+  /// 2. Template version that accepts caller-provided lock (use when you already have a lock or need to hold it longer)
+  /// @return std::nullopt if topic is unknown, otherwise bool indicating if message should be throttled
+  std::optional<bool> tryThrottleIfKnown(const TopicName& topic,
+                                         const rcl_serialized_message_t& serializedMsg,
+                                         const Nanoseconds now);
+
+  /// @param lock Must be a shared_lock or unique_lock on _topicInfoLock
+  template <typename Lock>
+  std::optional<bool> tryThrottleIfKnown(const TopicName& topic,
+                                         const rcl_serialized_message_t& serializedMsg,
+                                         const Nanoseconds now, Lock& lock);
+
+  bool isUnthrottledTopic(const TopicName& topic);
+
+  void addUnthrottledTopic(const TopicName& topic);
+};
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -27,8 +27,10 @@ constexpr char PARAM_INCLUDE_HIDDEN[] = "include_hidden";
 constexpr char PARAM_DISABLE_LOAN_MESSAGE[] = "disable_load_message";
 constexpr char PARAM_ASSET_URI_ALLOWLIST[] = "asset_uri_allowlist";
 constexpr char PARAM_IGN_UNRESPONSIVE_PARAM_NODES[] = "ignore_unresponsive_param_nodes";
-constexpr char TOPIC_THROTTLE_RATES[] = "topic_throttle_rates";
-constexpr char TOPIC_THROTTLE_PATTERNS[] = "topic_throttle_patterns";
+constexpr char PARAM_TOPIC_THROTTLE_RATES[] = "topic_throttle_rates";
+constexpr char PARAM_TOPIC_THROTTLE_PATTERNS[] = "topic_throttle_patterns";
+constexpr char PARAM_MIN_QOS_TOPIC_PATTERNS[] = "min_qos_topic_patterns";
+constexpr char PARAM_MIN_QOS_TOPIC_DEPTHS[] = "min_qos_topic_depths";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/param_utils.hpp
@@ -27,6 +27,8 @@ constexpr char PARAM_INCLUDE_HIDDEN[] = "include_hidden";
 constexpr char PARAM_DISABLE_LOAN_MESSAGE[] = "disable_load_message";
 constexpr char PARAM_ASSET_URI_ALLOWLIST[] = "asset_uri_allowlist";
 constexpr char PARAM_IGN_UNRESPONSIVE_PARAM_NODES[] = "ignore_unresponsive_param_nodes";
+constexpr char TOPIC_THROTTLE_RATES[] = "topic_throttle_rates";
+constexpr char TOPIC_THROTTLE_PATTERNS[] = "topic_throttle_patterns";
 
 constexpr int64_t DEFAULT_PORT = 8765;
 constexpr char DEFAULT_ADDRESS[] = "0.0.0.0";

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -32,6 +32,7 @@ using SubscriptionsByClient = std::map<ConnectionHandle, Subscription, std::owne
 using Publication = rclcpp::GenericPublisher::SharedPtr;
 using ClientPublications = std::unordered_map<foxglove_ws::ClientChannelId, Publication>;
 using PublicationsByClient = std::map<ConnectionHandle, ClientPublications, std::owner_less<>>;
+using qosDepth = size_t;
 
 class FoxgloveBridge : public rclcpp::Node {
 public:
@@ -65,8 +66,10 @@ private:
   std::vector<std::regex> _serviceWhitelistPatterns;
   std::vector<std::regex> _assetUriAllowlistPatterns;
   std::vector<std::regex> _bestEffortQosTopicWhiteListPatterns;
-  std::vector<double> _topicThrottleRates;
   std::vector<std::regex> _topicThrottlePatterns;
+  std::vector<double> _topicThrottleRates;
+  std::vector<std::regex> _minQosTopicPatterns;
+  std::vector<int64_t> _minQosTopicDepths;
   std::shared_ptr<ParameterInterface> _paramInterface;
   std::unordered_map<foxglove_ws::ChannelId, foxglove_ws::ChannelWithoutId> _advertisedTopics;
   std::unordered_map<foxglove_ws::ServiceId, foxglove_ws::ServiceWithoutId> _advertisedServices;
@@ -152,6 +155,8 @@ private:
 
   bool shouldThrottle(const TopicName& topic, const rcl_serialized_message_t& serializedMsg,
                       const Nanoseconds now);
+
+  size_t getTopicMinQosDepth(const TopicName& topic);
 };
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/message_throttler.cpp
+++ b/ros2_foxglove_bridge/src/message_throttler.cpp
@@ -36,9 +36,8 @@ void ThrottledMessage::tryDecode() {
   {
     std::lock_guard<std::mutex> lock(_topicInfo->parserLock);
     if (!_topicInfo->parser->get()->deserialize(serializedMsgSpan, &_decodedMsg, &deserializer)) {
-      throw std::runtime_error(
-        "Failed to parse message, likely an array with too many elements, adjust parser max "
-        "array policy");
+      _frameid = "";
+      return;
     }
   }  // drop lock
 

--- a/ros2_foxglove_bridge/src/message_throttler.cpp
+++ b/ros2_foxglove_bridge/src/message_throttler.cpp
@@ -1,0 +1,189 @@
+#include <foxglove_bridge/message_throttler.hpp>
+
+namespace foxglove_bridge {
+
+template <>
+std::optional<std::string> ThrottledMessage::getDecodedMessageField(const std::string& fieldName) {
+  if (!_topicInfo->parser) {
+    return std::nullopt;
+  }
+
+  for (auto& field : _decodedMsg.name) {
+    std::string fieldPath = field.first.toStdString();
+    if (fieldPath.find(fieldName) != std::string::npos) {
+      return std::make_optional<std::string>(field.second);
+    }
+  }
+
+  return std::nullopt;
+}
+
+void ThrottledMessage::tryDecode() {
+  if (!_topicInfo->parser) {
+    _frameid = "";
+    return;
+  }
+
+  RosMsgParser::ROS2_Deserializer deserializer;
+  auto serializedMsgSpan = nonstd::span(_serializedMsg.buffer, _serializedMsg.buffer_length);
+  {
+    std::lock_guard<std::mutex> lock(_topicInfo->parserLock);
+    if (!_topicInfo->parser->get()->deserialize(serializedMsgSpan, &_decodedMsg, &deserializer)) {
+      throw std::runtime_error(
+        "Failed to parse message, likely an array with too many elements, adjust parser max "
+        "array policy");
+    }
+  }  // drop lock
+
+  _frameid = getDecodedMessageField<std::string>("frame_id").value_or("");
+}
+
+bool ThrottledMessage::allowedThrough(Nanoseconds currentTime) {
+  // either message has not been seen before or interval has passed
+  std::shared_lock<std::shared_mutex> lock(_topicInfo->frameIdLastRecievedLock);
+  return !_topicInfo->frameIdLastRecieved.count(_frameid) ||
+         currentTime - _topicInfo->frameIdLastRecieved[_frameid] > _topicInfo->throttleInterval;
+}
+
+void ThrottledMessage::updateLastSeen(Nanoseconds currentTime) {
+  std::unique_lock<std::shared_mutex> lock(_topicInfo->frameIdLastRecievedLock);
+  _topicInfo->frameIdLastRecieved[_frameid] = currentTime;
+}
+
+std::optional<TypeSchema> MessageThrottleManager::getTypeSchema(const TypeName& type) {
+  auto channelsAndLock = _server->getChannels();
+  for (const auto& [_, channel] : channelsAndLock.channels) {
+    if (channel.schemaName == type) {
+      return channel.schema;
+    }
+  }
+
+  return std::nullopt;
+}
+
+std::optional<TypeName> MessageThrottleManager::getTypeFromTopic(const TopicName& topic) {
+  auto channelsAndLock = _server->getChannels();
+  for (const auto& [_, channel] : channelsAndLock.channels) {
+    if (channel.topic == topic) {
+      return channel.schemaName;
+    }
+  }
+
+  return std::nullopt;
+}
+
+template <typename Lock>
+std::optional<std::shared_ptr<RosMsgParser::Parser>> MessageThrottleManager::createParser(
+  const TopicName& topic, [[maybe_unused]] Lock& lock) {
+  assert(lock.mutex() == &_topicInfoLock && "Must have unique lock on _topicInfoLock");
+
+  auto optType = getTypeFromTopic(topic);
+  if (!optType) {
+    return std::nullopt;
+  }
+  TypeName type = optType.value();
+
+  auto schemaOpt = getTypeSchema(type);
+  if (!schemaOpt) {
+    return std::nullopt;
+  }
+  TypeSchema schema = schemaOpt.value();
+
+  return std::make_optional(std::make_unique<RosMsgParser::Parser>(topic, type, schema));
+}
+
+bool MessageThrottleManager::shouldThrottleAndUpdate(ThrottledMessage& msg,
+                                                     const Nanoseconds time) {
+  if (!msg.allowedThrough(time)) {
+    return true;
+  }
+
+  msg.updateLastSeen(time);
+  return false;
+}
+
+bool MessageThrottleManager::isUnthrottledTopic(const TopicName& topic) {
+  std::shared_lock<std::shared_mutex> lock(_unthrottledTopicLock);
+  return _unthrottledTopics.count(topic) > 0;
+}
+
+void MessageThrottleManager::addUnthrottledTopic(const TopicName& topic) {
+  std::unique_lock<std::shared_mutex> lock(_unthrottledTopicLock);
+  _unthrottledTopics.emplace(topic);
+}
+
+template <typename Lock>
+std::optional<bool> MessageThrottleManager::tryThrottleIfKnown(
+  const TopicName& topic, const rcl_serialized_message_t& serializedMsg, const Nanoseconds now,
+  [[maybe_unused]] Lock& lock) {
+  assert(lock.mutex() == &_topicInfoLock && "Must have lock on _topicInfoLock");
+  auto topicInfoIt = _throttledTopics.find(topic);
+  if (topicInfoIt == _throttledTopics.end()) {
+    return std::nullopt;
+  }
+
+  auto msg = ThrottledMessage(topicInfoIt->second.get(), serializedMsg);
+  return std::make_optional(shouldThrottleAndUpdate(msg, now));
+}
+
+std::optional<bool> MessageThrottleManager::tryThrottleIfKnown(
+  const TopicName& topic, const rcl_serialized_message_t& serializedMsg, const Nanoseconds now) {
+  std::shared_lock<std::shared_mutex> lock(_topicInfoLock);
+  auto topicInfoIt = _throttledTopics.find(topic);
+  if (topicInfoIt == _throttledTopics.end()) {
+    return std::nullopt;
+  }
+
+  auto msg = ThrottledMessage(topicInfoIt->second.get(), serializedMsg);
+  return std::make_optional(shouldThrottleAndUpdate(msg, now));
+}
+
+bool MessageThrottleManager::shouldThrottle(const TopicName& topic,
+                                            const rcl_serialized_message_t& serializedMsg,
+                                            const Nanoseconds now) {
+  if (auto knownTopic = tryThrottleIfKnown(topic, serializedMsg, now)) {
+    return knownTopic.value();
+  }
+
+  if (isUnthrottledTopic(topic)) {
+    return false;
+  }
+
+  auto optThrottleInterval = getTopicThrottleInterval(topic);
+  // doesn't match any regex patterns
+  if (!optThrottleInterval) {
+    addUnthrottledTopic(topic);
+    return false;
+  }
+  Nanoseconds throttleInterval = optThrottleInterval.value();
+
+  std::unique_lock<std::shared_mutex> lock(_topicInfoLock);
+  // make sure while waiting for lock another thread didn't handle this for the first time
+  if (auto knownTopic = tryThrottleIfKnown(topic, serializedMsg, now, lock)) {
+    return knownTopic.value();
+  }
+
+  auto topicInfo =
+    std::make_unique<ThrottledTopicInfo>(throttleInterval, createParser(topic, lock));
+  auto [newTopicInfoIt, wasInserted] = _throttledTopics.emplace(topic, std::move(topicInfo));
+  assert(wasInserted &&
+         "Tried to replace a topic already in _throttledTopics, should've been caught by initial "
+         "already seen check");
+  auto msg = ThrottledMessage(newTopicInfoIt->second.get(), serializedMsg);
+  return shouldThrottleAndUpdate(msg, now);
+}
+
+std::optional<Nanoseconds> MessageThrottleManager::getTopicThrottleInterval(
+  const TopicName& topic) {
+  // NOTE: assumes throttle patterns and rates arrays are of same length
+  // neither of these arrays should change after object initialization, thus no need for lock
+  for (size_t i = 0; i < _topicThrottlePatterns.size(); i++) {
+    if (std::regex_match(topic, _topicThrottlePatterns[i])) {
+      return static_cast<Nanoseconds>(1 / _topicThrottleRates[i] * NANOSECONDS_IN_SECOND);
+    }
+  }
+
+  return std::nullopt;
+}
+
+}  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -187,6 +187,24 @@ void declareParameters(rclcpp::Node* node) {
     "Avoid requesting parameters from previously unresponsive nodes";
   ignUnresponsiveParamNodes.read_only = true;
   node->declare_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES, true, ignUnresponsiveParamNodes);
+
+  auto topicThrottleRatesDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  topicThrottleRatesDescription.name = TOPIC_THROTTLE_RATES;
+  assetUriAllowlistDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY;
+  topicThrottleRatesDescription.description =
+    "List of rates to throttle corresponding (matching index) patterns by. Represents messages per second";
+  topicThrottleRatesDescription.read_only = true;
+  node->declare_parameter("topic_throttle_rates", std::vector<double>(),
+                          topicThrottleRatesDescription);
+
+  auto topicThrottlePatternsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  topicThrottlePatternsDescription.name = TOPIC_THROTTLE_PATTERNS;
+  assetUriAllowlistDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  topicThrottlePatternsDescription.description =
+    "List of regex patterns to throttle by corresponding rate (matching index)";
+  topicThrottlePatternsDescription.read_only = true;
+  node->declare_parameter("topic_throttle_patterns", std::vector<std::string>(),
+                          topicThrottlePatternsDescription);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -209,8 +209,7 @@ void declareParameters(rclcpp::Node* node) {
 
   auto minQosTopicPatternsDescription = rcl_interfaces::msg::ParameterDescriptor{};
   minQosTopicPatternsDescription.name = PARAM_MIN_QOS_TOPIC_PATTERNS;
-  minQosTopicPatternsDescription.type =
-    rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  minQosTopicPatternsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
   minQosTopicPatternsDescription.description =
     "List of regex patterns to use corresponding min qos depth for (matching index)";
   minQosTopicPatternsDescription.read_only = true;
@@ -219,8 +218,7 @@ void declareParameters(rclcpp::Node* node) {
 
   auto minQosTopicDepthsDescription = rcl_interfaces::msg::ParameterDescriptor{};
   minQosTopicDepthsDescription.name = PARAM_MIN_QOS_TOPIC_DEPTHS;
-  minQosTopicDepthsDescription.type =
-    rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
+  minQosTopicDepthsDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
   minQosTopicDepthsDescription.description =
     "List of depths to use on corresponding min qos pattern (matching index)";
   minQosTopicDepthsDescription.read_only = true;

--- a/ros2_foxglove_bridge/src/param_utils.cpp
+++ b/ros2_foxglove_bridge/src/param_utils.cpp
@@ -189,22 +189,43 @@ void declareParameters(rclcpp::Node* node) {
   node->declare_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES, true, ignUnresponsiveParamNodes);
 
   auto topicThrottleRatesDescription = rcl_interfaces::msg::ParameterDescriptor{};
-  topicThrottleRatesDescription.name = TOPIC_THROTTLE_RATES;
+  topicThrottleRatesDescription.name = PARAM_TOPIC_THROTTLE_RATES;
   assetUriAllowlistDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_DOUBLE_ARRAY;
   topicThrottleRatesDescription.description =
-    "List of rates to throttle corresponding (matching index) patterns by. Represents messages per second";
+    "List of rates to throttle corresponding (matching index) patterns by. Represents messages per "
+    "second";
   topicThrottleRatesDescription.read_only = true;
-  node->declare_parameter("topic_throttle_rates", std::vector<double>(),
+  node->declare_parameter(PARAM_TOPIC_THROTTLE_RATES, std::vector<double>(),
                           topicThrottleRatesDescription);
 
   auto topicThrottlePatternsDescription = rcl_interfaces::msg::ParameterDescriptor{};
-  topicThrottlePatternsDescription.name = TOPIC_THROTTLE_PATTERNS;
+  topicThrottlePatternsDescription.name = PARAM_TOPIC_THROTTLE_PATTERNS;
   assetUriAllowlistDescription.type = rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
   topicThrottlePatternsDescription.description =
     "List of regex patterns to throttle by corresponding rate (matching index)";
   topicThrottlePatternsDescription.read_only = true;
-  node->declare_parameter("topic_throttle_patterns", std::vector<std::string>(),
+  node->declare_parameter(PARAM_TOPIC_THROTTLE_PATTERNS, std::vector<std::string>(),
                           topicThrottlePatternsDescription);
+
+  auto minQosTopicPatternsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  minQosTopicPatternsDescription.name = PARAM_MIN_QOS_TOPIC_PATTERNS;
+  minQosTopicPatternsDescription.type =
+    rcl_interfaces::msg::ParameterType::PARAMETER_STRING_ARRAY;
+  minQosTopicPatternsDescription.description =
+    "List of regex patterns to use corresponding min qos depth for (matching index)";
+  minQosTopicPatternsDescription.read_only = true;
+  node->declare_parameter(PARAM_MIN_QOS_TOPIC_PATTERNS, std::vector<std::string>(),
+                          minQosTopicPatternsDescription);
+
+  auto minQosTopicDepthsDescription = rcl_interfaces::msg::ParameterDescriptor{};
+  minQosTopicDepthsDescription.name = PARAM_MIN_QOS_TOPIC_DEPTHS;
+  minQosTopicDepthsDescription.type =
+    rcl_interfaces::msg::ParameterType::PARAMETER_INTEGER_ARRAY;
+  minQosTopicDepthsDescription.description =
+    "List of depths to use on corresponding min qos pattern (matching index)";
+  minQosTopicDepthsDescription.read_only = true;
+  node->declare_parameter(PARAM_MIN_QOS_TOPIC_DEPTHS, std::vector<int64_t>(),
+                          minQosTopicDepthsDescription);
 }
 
 std::vector<std::regex> parseRegexStrings(rclcpp::Node* node,

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -64,6 +64,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   _topicThrottleRates = this->get_parameter(PARAM_TOPIC_THROTTLE_RATES).as_double_array();
   assert(_topicThrottlePatterns.size() == _topicThrottleRates.size() &&
          "Topic throttle patterns must each have exactly one corresponding throttle rate.");
+  if (!std::all_of(_topicThrottleRates.begin(), _topicThrottleRates.end(), [](auto& x) {
+        return x > 0;
+      })) {
+    throw std::invalid_argument("Topic throttle rates must all be > 0");
+  }
   const auto minQosTopicPatterns =
     this->get_parameter(PARAM_MIN_QOS_TOPIC_PATTERNS).as_string_array();
   _minQosTopicPatterns = parseRegexStrings(this, minQosTopicPatterns);

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -58,11 +58,18 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   _disableLoanMessage = this->get_parameter(PARAM_DISABLE_LOAN_MESSAGE).as_bool();
   const auto ignoreUnresponsiveParamNodes =
     this->get_parameter(PARAM_IGN_UNRESPONSIVE_PARAM_NODES).as_bool();
-  const auto topicThrottlePatterns = this->get_parameter(TOPIC_THROTTLE_PATTERNS).as_string_array();
+  const auto topicThrottlePatterns =
+    this->get_parameter(PARAM_TOPIC_THROTTLE_PATTERNS).as_string_array();
   _topicThrottlePatterns = parseRegexStrings(this, topicThrottlePatterns);
-  _topicThrottleRates = this->get_parameter(TOPIC_THROTTLE_RATES).as_double_array();
+  _topicThrottleRates = this->get_parameter(PARAM_TOPIC_THROTTLE_RATES).as_double_array();
   assert(_topicThrottlePatterns.size() == _topicThrottleRates.size() &&
          "Topic throttle patterns must each have exactly one corresponding throttle rate.");
+  const auto minQosTopicPatterns =
+    this->get_parameter(PARAM_MIN_QOS_TOPIC_PATTERNS).as_string_array();
+  _minQosTopicPatterns = parseRegexStrings(this, minQosTopicPatterns);
+  _minQosTopicDepths = this->get_parameter(PARAM_MIN_QOS_TOPIC_DEPTHS).as_integer_array();
+  assert(_minQosTopicPatterns.size() == _minQosTopicDepths.size() &&
+         "Min qos topic patterns must each have exactly one corresponding min qos depth value.");
 
   const auto logHandler = std::bind(&FoxgloveBridge::logHandler, this, _1, _2);
   // Fetching of assets may be blocking, hence we fetch them in a separate thread.
@@ -500,7 +507,7 @@ void FoxgloveBridge::subscribe(foxglove_ws::ChannelId channelId, ConnectionHandl
     depth = depth + publisherHistoryDepth;
   }
 
-  depth = std::max(depth, _minQosDepth);
+  depth = std::max(depth, getTopicMinQosDepth(topic));
   if (depth > _maxQosDepth) {
     RCLCPP_WARN(this->get_logger(),
                 "Limiting history depth for topic '%s' to %zu (was %zu). You may want to increase "
@@ -1004,6 +1011,17 @@ bool FoxgloveBridge::shouldThrottle(const TopicName& topic,
   }
 
   return _messageThrottler.value().shouldThrottle(topic, serializedMsg, now);
+}
+
+size_t FoxgloveBridge::getTopicMinQosDepth(const TopicName& topic) {
+  for (size_t i = 0; i < _minQosTopicPatterns.size(); i++) {
+    auto pattern = _minQosTopicPatterns[i];
+    if (std::regex_match(topic, pattern)) {
+      return _minQosTopicDepths[i];
+    }
+  }
+
+  return _minQosDepth;
 }
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -5,8 +5,6 @@
 
 #include <foxglove_bridge/ros2_foxglove_bridge.hpp>
 
-#define NANOSECONDS_IN_SECOND 1'000'000'000
-
 namespace foxglove_bridge {
 namespace {
 inline bool isHiddenTopicOrService(const std::string& name) {
@@ -149,6 +147,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
         _server->broadcastTime(static_cast<uint64_t>(timestamp));
       });
   }
+
+  initializeThrottler();
 }
 
 FoxgloveBridge::~FoxgloveBridge() {
@@ -872,142 +872,6 @@ void FoxgloveBridge::logHandler(LogLevel level, char const* msg) {
   }
 }
 
-template <typename T>
-std::optional<T> FoxgloveBridge::getDecodedMessageField(RosMsgParser::FlatMessage& decodedMsg,
-                                                        const std::string& fieldName) {
-  for (auto& field : decodedMsg.value) {
-    std::string fieldPath = field.first.toStdString();
-    if (fieldPath.find(fieldName) != std::string::npos) {
-      return std::make_optional<T>(field.second.extract<T>());
-    }
-  }
-
-  return std::nullopt;
-}
-
-template <>
-std::optional<std::string> FoxgloveBridge::getDecodedMessageField(
-  RosMsgParser::FlatMessage& decodedMsg, const std::string& fieldName) {
-  for (auto& field : decodedMsg.name) {
-    std::string fieldPath = field.first.toStdString();
-    if (fieldPath.find(fieldName) != std::string::npos) {
-      return std::make_optional<std::string>(field.second);
-    }
-  }
-
-  return std::nullopt;
-}
-
-std::optional<TypeSchema> FoxgloveBridge::getTypeSchema(const MessageType& type) {
-  auto channels = _server->getChannels();
-  for (auto [_, channel] : channels) {
-    if (channel.schemaName == type) {
-      return channel.schema;
-    }
-  }
-
-  return std::nullopt;
-}
-
-MessageType FoxgloveBridge::getTypeFromTopic(const TopicName& topic) {
-  for (auto& [_, channel] : _server->getChannels()) {
-    if (topic == channel.topic) {
-      return channel.schemaName;
-    }
-  }
-
-  std::stringstream s;
-  s << "Tried to get type for topic '" << topic << "' which has not been registered";
-  throw std::runtime_error(s.str());
-}
-
-std::shared_ptr<RosMsgParser::Parser> FoxgloveBridge::createParser(const TopicName& topic) {
-  _createMessageParserLock.lock();
-  MessageType type = getTypeFromTopic(topic);
-  auto opt = getTypeSchema(type);
-  if (!opt) {
-    // TODO: return optional
-    throw std::runtime_error("unimplemented");
-  }
-
-  TypeSchema schema = opt.value();
-  std::unique_ptr<RosMsgParser::Parser> parser =
-    std::make_unique<RosMsgParser::Parser>(topic, type, schema);
-  _createMessageParserLock.unlock();
-  return parser;
-}
-
-void FoxgloveBridge::decodeMessage(RosMsgParser::FlatMessage* msgBuf,
-                                   RosMsgParser::ROS2_Deserializer& deserializer,
-                                   const rcl_serialized_message_t& serializedMsg,
-                                   const std::shared_ptr<RosMsgParser::Parser> parser) {
-  auto serializedMsgSpan = nonstd::span(serializedMsg.buffer, serializedMsg.buffer_length);
-  if (!parser.get()->deserialize(serializedMsgSpan, msgBuf, &deserializer)) {
-    throw std::runtime_error(
-      "Failed to parse message, likely an array with too many elements, adjust parser max "
-      "array policy");
-  }
-}
-
-bool FoxgloveBridge::shouldThrottle(const TopicName& topic, const rcl_serialized_message_t& msg,
-                                    const Nanoseconds timestamp) {
-  // TODO: make more parsers?
-  thread_local RosMsgParser::ROS2_Deserializer deserializer;
-  thread_local RosMsgParser::FlatMessage decodedMsg;
-
-  auto it = _throttledTopics.find(topic);
-  if (it != _throttledTopics.end()) {
-    // have seen before so we can skip regex checks
-    ThrottledTopicInfo* info = it->second.get();
-    std::lock_guard<std::mutex> lock(info->parserLock);
-    decodeMessage(&decodedMsg, deserializer, msg, info->parser);
-    std::string frameId = getDecodedMessageField<std::string>(decodedMsg, "frame_id").value_or("");
-    Nanoseconds lastRecieved = info->frameIdLastRecieved[frameId];
-    if (timestamp - lastRecieved < info->throttleInterval) {
-      return true;
-    }
-
-    info->frameIdLastRecieved[frameId] = timestamp;
-    return false;
-  }
-
-  // TODO: find a way to avoid regex checks on topics that we already know we don't need to throttle
-  // topic has not been seen before
-  std::optional<Nanoseconds> opt = getTopicThrottleInterval(topic);
-  if (!opt) {
-    // doesn't match any regex patterns
-    return false;
-  }
-
-  Nanoseconds throttleInterval = opt.value();
-
-  std::shared_ptr<RosMsgParser::Parser> parser = createParser(topic);
-  decodeMessage(&decodedMsg, deserializer, msg, parser);
-  FrameId frameid = getDecodedMessageField<std::string>(decodedMsg, "frame_id").value_or("");
-  std::unordered_map<FrameId, Nanoseconds> frameIdLastRecieved = {{frameid, timestamp}};
-
-  std::unique_ptr<ThrottledTopicInfo> info =
-    std::make_unique<ThrottledTopicInfo>(throttleInterval, parser, frameIdLastRecieved);
-  _throttledTopics.insert({topic, std::move(info)});
-  return false;
-}
-
-std::mutex& waitForParserLock(const TopicName& topic) {
-  (void)topic;
-  throw std::runtime_error("unimplemented");
-}
-
-std::optional<Nanoseconds> FoxgloveBridge::getTopicThrottleInterval(const TopicName& topic) {
-  // NOTE: assumes throttle patterns and rates arrays are of same length
-  for (size_t i = 0; i < _topicThrottlePatterns.size(); i++) {
-    if (std::regex_match(topic, _topicThrottlePatterns[i])) {
-      return (1 / _topicThrottleRates[i]) * NANOSECONDS_IN_SECOND;
-    }
-  }
-
-  return std::nullopt;
-}
-
 void FoxgloveBridge::rosMessageHandler(const foxglove::ChannelId& channelId,
                                        ConnectionHandle clientHandle,
                                        std::shared_ptr<const rclcpp::SerializedMessage> msg,
@@ -1122,6 +986,24 @@ void FoxgloveBridge::fetchAsset(const std::string& uri, uint32_t requestId,
 
 bool FoxgloveBridge::hasCapability(const std::string& capability) {
   return std::find(_capabilities.begin(), _capabilities.end(), capability) != _capabilities.end();
+}
+
+void FoxgloveBridge::initializeThrottler() {
+  if (!_topicThrottlePatterns.size()) {
+    return;
+  }
+
+  _messageThrottler.emplace(_server.get(), _topicThrottleRates, _topicThrottlePatterns);
+}
+
+bool FoxgloveBridge::shouldThrottle(const TopicName& topic,
+                                    const rcl_serialized_message_t& serializedMsg,
+                                    const Nanoseconds now) {
+  if (!_messageThrottler) {
+    return false;
+  }
+
+  return _messageThrottler.value().shouldThrottle(topic, serializedMsg, now);
 }
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -604,6 +604,9 @@ void FoxgloveBridge::unsubscribe(foxglove_ws::ChannelId channelId, ConnectionHan
     RCLCPP_INFO(this->get_logger(), "Unsubscribing from topic \"%s\" (%s) on channel %d",
                 channel.topic.c_str(), channel.schemaName.c_str(), channelId);
     _subscriptions.erase(subscriptionsIt);
+    if (_messageThrottler) {
+      _messageThrottler.value().eraseTopic(channel.topic, channelId);
+    }
   } else {
     RCLCPP_INFO(this->get_logger(),
                 "Removed one subscription from channel %d (%zu subscription(s) left)", channelId,


### PR DESCRIPTION
Message Throttling Implementation for ROS Foxglove Bridge

Introduces per-topic message throttling functionality, allowing users to control the rate at which messages are sent. The implementation provides fine-grained control over message rates using regex patterns to match topic names.

This adds the following params:
- `topic_throttle_rates`: Array of throttling rates (in Hz) corresponding to matching patterns
- `topic_throttle_patterns`: Array of regex patterns to match against topic names

Messages are throttled on a per-topic and per-frame_id basis, ensuring that high-frequency topics don't overwhelm the WebSocket connection while maintaining the full data stream for critical topics. The throttling mechanism is
thread-safe and handles unparsable messages by assuming frame_id's are non-unique.

Only implemented in ROS2 as I have no experience in ROS1
