### PR TITLE
Remove Iron from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ros_distribution: [melodic, noetic, humble, iron, jazzy, kilted, rolling]
+        ros_distribution: [melodic, noetic, humble, jazzy, kilted, rolling]
 
     name: Test (ROS ${{ matrix.ros_distribution }})
     runs-on: ubuntu-latest

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 ROS1_DISTRIBUTIONS := melodic noetic
-ROS2_DISTRIBUTIONS := humble iron jazzy kilted rolling
+ROS2_DISTRIBUTIONS := humble jazzy kilted rolling
 USE_FOXGLOVE_SDK := OFF
 
 define generate_ros1_targets

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ foxglove_bridge
 [![ROS Melodic version](https://img.shields.io/ros/v/melodic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#melodic)
 [![ROS Noetic version](https://img.shields.io/ros/v/noetic/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#noetic)
 [![ROS Humble version](https://img.shields.io/ros/v/humble/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#humble)
-[![ROS Iron version](https://img.shields.io/ros/v/iron/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#iron)
 [![ROS Jazzy version](https://img.shields.io/ros/v/jazzy/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#jazzy)
 [![ROS Kilted version](https://img.shields.io/ros/v/kilted/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#kilted)
 [![ROS Rolling version](https://img.shields.io/ros/v/rolling/foxglove_bridge)](https://index.ros.org/p/foxglove_bridge/github-foxglove-ros-foxglove-bridge/#rolling)


### PR DESCRIPTION
### Changelog
Removed Iron builds from CI since Iron reached EOL in Dec 2024.

### Docs

None

### Description

There was an intermittent test failure (segfault) that is only reproducible in Iron. Since Iron is already EOL, there's no need to bother trying to fix the test.

- Remove from CI build matrix (also removed the required check in repo settings)
- Remove from Makefile
- Remove badge from README (or we could leave it there? 🤷)

Resolves FG-12227