### PR TITLE
Add Connection Count topic

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -184,6 +184,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
     find_package(rclcpp_components REQUIRED)
     find_package(resource_retriever REQUIRED)
     find_package(rosx_introspection REQUIRED)
+    find_package(std_msgs REQUIRED)
 
     if(USE_FOXGLOVE_SDK)
       set(ros2_foxglove_bridge_src_dir ros2_foxglove_bridge_sdk)
@@ -249,6 +250,7 @@ elseif("$ENV{ROS_VERSION}" STREQUAL "2")
       rclcpp_components::component_manager
       resource_retriever::resource_retriever
       rosx_introspection::rosx_introspection
+      ${std_msgs_TARGETS}
     )
 
     rclcpp_components_register_nodes(foxglove_bridge_component "foxglove_bridge::FoxgloveBridge")

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -74,6 +74,7 @@ struct ServerHandlers {
   std::function<void(const ServiceRequest&, ConnectionHandle)> serviceRequestHandler;
   std::function<void(bool)> subscribeConnectionGraphHandler;
   std::function<void(const std::string&, uint32_t, ConnectionHandle)> fetchAssetHandler;
+  std::function<void(uint32_t)> connectionCountChangeHandler;
 };
 
 template <typename ConnectionHandle>

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -153,6 +153,7 @@ public:
 
   uint16_t getPort() override;
   std::string remoteEndpointString(ConnHandle clientHandle) override;
+  uint32_t getConnectionCount();
 
 private:
   struct ClientInfo {
@@ -309,9 +310,16 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
   const auto endpoint = remoteEndpointString(hdl);
   _server.get_alog().write(APP, "Client " + endpoint + " connected via " + con->get_resource());
 
+  uint32_t connectionCount;
   {
     std::unique_lock<std::shared_mutex> lock(_clientsMutex);
     _clients.emplace(hdl, ClientInfo(endpoint, hdl));
+    connectionCount = static_cast<uint32_t>(_clients.size());
+  }
+
+  // Notify about connection count change
+  if (_handlers.connectionCountChangeHandler) {
+    _handlers.connectionCountChangeHandler(connectionCount);
   }
 
   con->send(json({
@@ -356,6 +364,7 @@ inline void Server<ServerConfiguration>::handleConnectionClosed(ConnHandle hdl) 
   std::unordered_set<ClientChannelId> oldAdvertisedChannels;
   std::string clientName;
   bool wasSubscribedToConnectionGraph;
+  uint32_t connectionCount;
   {
     std::unique_lock<std::shared_mutex> lock(_clientsMutex);
     const auto clientIt = _clients.find(hdl);
@@ -373,6 +382,12 @@ inline void Server<ServerConfiguration>::handleConnectionClosed(ConnHandle hdl) 
     oldAdvertisedChannels = std::move(client.advertisedChannels);
     wasSubscribedToConnectionGraph = client.subscribedToConnectionGraph;
     _clients.erase(clientIt);
+    connectionCount = static_cast<uint32_t>(_clients.size());
+  }
+
+  // Notify about connection count change
+  if (_handlers.connectionCountChangeHandler) {
+    _handlers.connectionCountChangeHandler(connectionCount);
   }
 
   // Unadvertise all channels this client advertised
@@ -1034,6 +1049,12 @@ inline uint16_t Server<ServerConfiguration>::getPort() {
     throw std::runtime_error("Server not listening on any port. Has it been started before?");
   }
   return endpoint.port();
+}
+
+template <typename ServerConfiguration>
+inline uint32_t Server<ServerConfiguration>::getConnectionCount() {
+  std::shared_lock<std::shared_mutex> lock(_clientsMutex);
+  return static_cast<uint32_t>(_clients.size());
 }
 
 template <typename ServerConfiguration>

--- a/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
+++ b/ros2_foxglove_bridge/include/foxglove_bridge/ros2_foxglove_bridge.hpp
@@ -9,6 +9,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rosgraph_msgs/msg/clock.hpp>
 #include <rosx_introspection/ros_parser.hpp>
+#include <std_msgs/msg/u_int32.hpp>
 #include <websocketpp/common/connection_hdl.hpp>
 
 #include <foxglove_bridge/callback_queue.hpp>
@@ -79,6 +80,7 @@ private:
   size_t _minQosDepth = DEFAULT_MIN_QOS_DEPTH;
   size_t _maxQosDepth = DEFAULT_MAX_QOS_DEPTH;
   std::shared_ptr<rclcpp::Subscription<rosgraph_msgs::msg::Clock>> _clockSubscription;
+  rclcpp::Publisher<std_msgs::msg::UInt32>::SharedPtr _connectionCountPublisher;
   bool _useSimTime = false;
   std::vector<std::string> _capabilities;
   std::atomic<bool> _subscribeGraphUpdates = false;
@@ -121,6 +123,8 @@ private:
   void fetchAsset(const std::string& assetId, uint32_t requestId, ConnectionHandle clientHandle);
 
   bool hasCapability(const std::string& capability);
+
+  void onConnectionCountChanged(uint32_t connectionCount);
 };
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -89,6 +89,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   hdlrs.serviceRequestHandler = std::bind(&FoxgloveBridge::serviceRequest, this, _1, _2);
   hdlrs.subscribeConnectionGraphHandler =
     std::bind(&FoxgloveBridge::subscribeConnectionGraph, this, _1);
+  hdlrs.connectionCountChangeHandler =
+    std::bind(&FoxgloveBridge::onConnectionCountChanged, this, _1);
 
   if (hasCapability(foxglove_ws::CAPABILITY_PARAMETERS) ||
       hasCapability(foxglove_ws::CAPABILITY_PARAMETERS_SUBSCRIBE)) {
@@ -141,6 +143,11 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
         _server->broadcastTime(static_cast<uint64_t>(timestamp));
       });
   }
+
+  // Create publisher for connection count
+  _connectionCountPublisher = this->create_publisher<std_msgs::msg::UInt32>(
+    "foxglove_connection_count", rclcpp::QoS{rclcpp::KeepLast(1)}.transient_local());
+  _connectionCountPublisher->publish(std_msgs::msg::UInt32()); //publish intial message to latch topic to 0
 }
 
 FoxgloveBridge::~FoxgloveBridge() {
@@ -972,6 +979,12 @@ void FoxgloveBridge::fetchAsset(const std::string& uri, uint32_t requestId,
 
 bool FoxgloveBridge::hasCapability(const std::string& capability) {
   return std::find(_capabilities.begin(), _capabilities.end(), capability) != _capabilities.end();
+}
+
+void FoxgloveBridge::onConnectionCountChanged(uint32_t connectionCount) {
+  auto msg = std_msgs::msg::UInt32();
+  msg.data = connectionCount;
+  _connectionCountPublisher->publish(msg);
 }
 
 }  // namespace foxglove_bridge

--- a/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
+++ b/ros2_foxglove_bridge/src/ros2_foxglove_bridge.cpp
@@ -147,7 +147,8 @@ FoxgloveBridge::FoxgloveBridge(const rclcpp::NodeOptions& options)
   // Create publisher for connection count
   _connectionCountPublisher = this->create_publisher<std_msgs::msg::UInt32>(
     "foxglove_connection_count", rclcpp::QoS{rclcpp::KeepLast(1)}.transient_local());
-  _connectionCountPublisher->publish(std_msgs::msg::UInt32()); //publish intial message to latch topic to 0
+  // publish intial message to latch topic to 0
+  _connectionCountPublisher->publish(std_msgs::msg::UInt32());
 }
 
 FoxgloveBridge::~FoxgloveBridge() {


### PR DESCRIPTION
Implements the Feature Request #38 
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->

-The number of currently connected Foxglove clients is now published under `/foxglove_connection_count` using TransientLocal QoS to minimize the number of actually published messages.

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
The foxglove bridge now publishes a topic itself rather than just passing messages along. 


