### PR TITLE
Fix memory leak in generic client

### DIFF
--- a/ros2_foxglove_bridge/src/generic_client.cpp
+++ b/ros2_foxglove_bridge/src/generic_client.cpp
@@ -50,7 +50,16 @@ std::shared_ptr<void> allocate_message(const MessageMembers* members) {
   }
   memset(buffer, 0, members->size_of_);
   members->init_function(buffer, rosidl_runtime_cpp::MessageInitialization::ALL);
-  return std::shared_ptr<void>(buffer, free);
+
+  auto deleter = [members](void* ptr) {
+    if (ptr) {
+      // Call the message's destructor to clean up nested allocations
+      members->fini_function(ptr);
+      // Then free the main buffer
+      free(ptr);
+    }
+  };
+  return std::shared_ptr<void>(buffer, deleter);
 }
 
 std::string getTypeIntrospectionSymbolName(const std::string& serviceType) {


### PR DESCRIPTION
### Changelog
<!-- Write a one-sentence summary of the user-impacting change (API, UI/UX, performance, etc) that could appear in a changelog. Write "None" if there is no user-facing change -->
None

### Docs

<!-- Link to a Docs PR, tracking ticket in Linear, OR write "None" if no documentation changes are needed. -->
None

### Description

<!-- Describe the problem, what has changed, and motivation behind those changes. Pretend you are advocating for this change and the reader is skeptical. -->
We have found that with a high volume of service calls the memory usage of the foxglove bridge grows unbounded. Using valgrind with memcheck, the source of some of these definitely lost blocks was found to be the `allocate_message` function in `generic_client`, where a buffer has memory allocated using the `MessageMembers` `_init_function` which is freed using `free`. This seems to mean that if a message type contains pointers, the memory pointed to will never be freed.

To remedy this, we instead call `members->_fini_function` , which the Message-specific clean-up functions (as documented [here](https://docs.ros.org/en/ros2_packages/humble/api/rosidl_typesupport_introspection_cpp/generated/structrosidl__typesupport__introspection__cpp_1_1MessageMembers__s.html) and implemented [here](https://github.com/ros2/rosidl/blob/4edcac1c0aa162d4c231389811c105214c74a439/rosidl_typesupport_introspection_cpp/resource/msg__type_support.cpp.em#L253)

<!-- In addition to unit tests, describe any manual testing you did to validate this change. -->

<table><tr><th>Before</th><th>After</th></tr><tr><td>

<!--before content goes here-->

</td><td>

<!--after content goes here-->

</td></tr></table>

<!-- If necessary, link relevant Linear or Github issues. Use `Fixes: foxglove/repo#1234` to auto-close the Github issue or Fixes: FG-### for Linear isses. -->

