### PR TITLE
Add service to rebroadcast serverInfo

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,13 +139,13 @@ if(CATKIN_DEVEL_PREFIX OR catkin_FOUND OR CATKIN_BUILD_BINARY_PACKAGE)
   message(STATUS "Building with catkin")
   set(ROS_BUILD_TYPE "catkin")
 
-  find_package(catkin REQUIRED COMPONENTS nodelet resource_retriever ros_babel_fish rosgraph_msgs roslib roscpp)
+  find_package(catkin REQUIRED COMPONENTS nodelet resource_retriever ros_babel_fish rosgraph_msgs roslib roscpp std_srvs)
   find_package(Boost REQUIRED)
 
   catkin_package(
     INCLUDE_DIRS foxglove_bridge_base/include
     LIBRARIES foxglove_bridge_base foxglove_bridge_nodelet
-    CATKIN_DEPENDS nodelet resource_retriever ros_babel_fish rosgraph_msgs roslib roscpp
+    CATKIN_DEPENDS nodelet resource_retriever ros_babel_fish rosgraph_msgs roslib roscpp std_srvs
     DEPENDS Boost
   )
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,10 @@ Parameters are provided to configure the behavior of the bridge. These parameter
  * __max_update_ms__: The maximum number of milliseconds to wait in between polling `roscore` for new topics, services, or parameters. Defaults to `5000`.
  * __service_type_retrieval_timeout_ms__: Max number of milliseconds for retrieving a services type information. Defaults to `250`.
 
+## Services
+
+ * __~/reset_connection__ (`std_srvs/Trigger`): Sends a new `serverInfo` message to connected clients so Foxglove can reset the connection state.
+
 ## Building from source
 
 ### Fetch source, install dependencies, and build for ROS 1

--- a/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/server_interface.hpp
@@ -82,6 +82,7 @@ public:
   virtual ~ServerInterface() {}
   virtual void start(const std::string& host, uint16_t port) = 0;
   virtual void stop() = 0;
+  virtual void sendServerInfo() = 0;
 
   virtual std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) = 0;
   virtual void removeChannels(const std::vector<ChannelId>& channelIds) = 0;

--- a/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
+++ b/foxglove_bridge_base/include/foxglove_bridge/websocket_server.hpp
@@ -130,6 +130,7 @@ public:
 
   void start(const std::string& host, uint16_t port) override;
   void stop() override;
+  void sendServerInfo() override;
 
   std::vector<ChannelId> addChannels(const std::vector<ChannelWithoutId>& channels) override;
   void removeChannels(const std::vector<ChannelId>& channelIds) override;
@@ -213,6 +214,7 @@ private:
   void handleTextMessage(ConnHandle hdl, MessagePtr msg);
   void handleBinaryMessage(ConnHandle hdl, MessagePtr msg);
 
+  json serverInfoMessage() const;
   void sendJson(ConnHandle hdl, json&& payload);
   void sendJsonRaw(ConnHandle hdl, const std::string& payload);
   void sendBinary(ConnHandle hdl, const uint8_t* payload, size_t payloadSize);
@@ -314,15 +316,7 @@ inline void Server<ServerConfiguration>::handleConnectionOpened(ConnHandle hdl) 
     _clients.emplace(hdl, ClientInfo(endpoint, hdl));
   }
 
-  con->send(json({
-                   {"op", "serverInfo"},
-                   {"name", _name},
-                   {"capabilities", _options.capabilities},
-                   {"supportedEncodings", _options.supportedEncodings},
-                   {"metadata", _options.metadata},
-                   {"sessionId", _options.sessionId},
-                 })
-              .dump());
+  con->send(serverInfoMessage().dump());
 
   std::vector<Channel> channels;
   {
@@ -561,6 +555,28 @@ inline void Server<ServerConfiguration>::start(const std::string& host, uint16_t
   _server.get_alog().write(APP, "WebSocket server listening at " + protocol + "://" +
                                   IPAddressToString(address) + ":" +
                                   std::to_string(endpoint.port()));
+}
+
+template <typename ServerConfiguration>
+inline void Server<ServerConfiguration>::sendServerInfo() {
+  const auto msg = serverInfoMessage().dump();
+  std::shared_lock<std::shared_mutex> lock(_clientsMutex);
+  for (const auto& [hdl, clientInfo] : _clients) {
+    (void)clientInfo;
+    sendJsonRaw(hdl, msg);
+  }
+}
+
+template <typename ServerConfiguration>
+inline json Server<ServerConfiguration>::serverInfoMessage() const {
+  return json({
+    {"op", "serverInfo"},
+    {"name", _name},
+    {"capabilities", _options.capabilities},
+    {"supportedEncodings", _options.supportedEncodings},
+    {"metadata", _options.metadata},
+    {"sessionId", _options.sessionId},
+  });
 }
 
 template <typename ServerConfiguration>

--- a/package.xml
+++ b/package.xml
@@ -15,13 +15,13 @@
     <depend condition="$ROS_VERSION == 1">ros_babel_fish</depend>
     <depend condition="$ROS_VERSION == 1">roscpp</depend>
     <depend condition="$ROS_VERSION == 1">roslib</depend>
+    <depend condition="$ROS_VERSION == 1">std_srvs</depend>
 
     <!-- Test dependencies -->
     <test_depend condition="$ROS_VERSION == 1">gtest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rostest</test_depend>
     <test_depend condition="$ROS_VERSION == 1">rosunit</test_depend>
     <test_depend>std_msgs</test_depend>
-    <test_depend>std_srvs</test_depend>
 
     <!-- Common dependencies -->
     <build_depend>asio</build_depend>

--- a/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
+++ b/ros1_foxglove_bridge/src/ros1_foxglove_bridge_nodelet.cpp
@@ -16,6 +16,7 @@
 #include <ros_babel_fish/babel_fish_message.h>
 #include <ros_babel_fish/generation/providers/integrated_description_provider.h>
 #include <rosgraph_msgs/Clock.h>
+#include <std_srvs/Trigger.h>
 #include <websocketpp/common/connection_hdl.hpp>
 
 #include <foxglove_bridge/foxglove_bridge.hpp>
@@ -180,6 +181,8 @@ public:
       _server->setHandlers(std::move(hdlrs));
 
       _server->start(address, static_cast<uint16_t>(port));
+      _resetConnectionService =
+        nhp.advertiseService("reset_connection", &FoxgloveBridge::resetConnection, this);
 
       xmlrpcServer.bind("paramUpdate", std::bind(&FoxgloveBridge::parameterUpdates, this,
                                                  std::placeholders::_1, std::placeholders::_2));
@@ -926,6 +929,20 @@ private:
     }
   }
 
+  bool resetConnection(std_srvs::Trigger::Request& req, std_srvs::Trigger::Response& res) {
+    (void)req;
+    if (!_server) {
+      res.success = false;
+      res.message = "WebSocket server is not running";
+      return true;
+    }
+
+    _server->sendServerInfo();
+    res.success = true;
+    res.message = "Sent serverInfo to connected clients";
+    return true;
+  }
+
   bool hasCapability(const std::string& capability) {
     return std::find(_capabilities.begin(), _capabilities.end(), capability) != _capabilities.end();
   }
@@ -945,6 +962,7 @@ private:
   std::shared_mutex _publicationsMutex;
   std::shared_mutex _servicesMutex;
   ros::Timer _updateTimer;
+  ros::ServiceServer _resetConnectionService;
   size_t _maxUpdateMs = size_t(DEFAULT_MAX_UPDATE_MS);
   size_t _updateCount = 0;
   ros::Subscriber _clockSubscription;

--- a/ros1_foxglove_bridge/tests/smoke_test.cpp
+++ b/ros1_foxglove_bridge/tests/smoke_test.cpp
@@ -4,9 +4,11 @@
 
 #include <boost/filesystem.hpp>
 #include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
 #include <ros/ros.h>
 #include <std_msgs/builtin_string.h>
 #include <std_srvs/SetBool.h>
+#include <std_srvs/Trigger.h>
 #include <websocketpp/config/asio_client.hpp>
 
 #include <foxglove_bridge/test/test_client.hpp>
@@ -18,6 +20,26 @@ constexpr uint8_t HELLO_WORLD_BINARY[] = {11,  0,  0,   0,   104, 101, 108, 108,
 
 constexpr auto ONE_SECOND = std::chrono::seconds(1);
 constexpr auto DEFAULT_TIMEOUT = std::chrono::seconds(8);
+
+std::future<nlohmann::json> waitForServerInfo(
+  std::shared_ptr<foxglove_ws::ClientInterface> client) {
+  auto promise = std::make_shared<std::promise<nlohmann::json>>();
+  auto future = promise->get_future();
+  auto resolved = std::make_shared<bool>(false);
+
+  client->setTextMessageHandler(
+    [promise = std::move(promise), resolved](const std::string& payload) mutable {
+      const auto msg = nlohmann::json::parse(payload);
+      const auto& op = msg["op"].get<std::string>();
+
+      if (op == "serverInfo" && !*resolved) {
+        *resolved = true;
+        promise->set_value(msg);
+      }
+    });
+
+  return future;
+}
 
 class ParameterTest : public ::testing::Test {
 public:
@@ -66,6 +88,24 @@ private:
 TEST(SmokeTest, testConnection) {
   foxglove_ws::Client<websocketpp::config::asio_client> wsClient;
   EXPECT_EQ(std::future_status::ready, wsClient.connect(URI).wait_for(DEFAULT_TIMEOUT));
+}
+
+TEST(SmokeTest, testResetConnectionServiceSendsServerInfo) {
+  auto wsClient = std::make_shared<foxglove_ws::Client<websocketpp::config::asio_client>>();
+  auto serverInfoFuture = waitForServerInfo(wsClient);
+  ASSERT_EQ(std::future_status::ready, wsClient->connect(URI).wait_for(DEFAULT_TIMEOUT));
+  ASSERT_EQ(std::future_status::ready, serverInfoFuture.wait_for(DEFAULT_TIMEOUT));
+
+  serverInfoFuture = waitForServerInfo(wsClient);
+
+  ros::NodeHandle nh;
+  auto resetClient = nh.serviceClient<std_srvs::Trigger>("/foxglove_bridge/reset_connection");
+  ASSERT_TRUE(resetClient.waitForExistence(ros::Duration(1.0)));
+
+  std_srvs::Trigger srv;
+  ASSERT_TRUE(resetClient.call(srv));
+  ASSERT_TRUE(srv.response.success);
+  EXPECT_EQ(std::future_status::ready, serverInfoFuture.wait_for(DEFAULT_TIMEOUT));
 }
 
 TEST(SmokeTest, testSubscription) {


### PR DESCRIPTION
Refs #286

### Changelog

Add a ROS Trigger service to rebroadcast `serverInfo` to connected Foxglove clients.

### Docs

None

### Description

Foxglove clients receive a `serverInfo` message when they first connect, but there was no ROS-side way to ask the bridge to send that message again later.

This adds a `std_srvs/Trigger` service that rebroadcasts `serverInfo` to all currently connected WebSocket clients. It gives users a lightweight way to reset the Foxglove client state without restarting the bridge or forcing clients to reconnect.

Manual testing: called the new trigger service while a Foxglove client was connected and verified that the client received a fresh `serverInfo` message.

<table><tr><th>Before</th><th>After</th></tr><tr><td>

`serverInfo` was only sent when a WebSocket client first connected.

</td><td>

Users can call the new ROS service to rebroadcast `serverInfo` to currently connected clients.

</td></tr></table>

Fixes: foxglove/ros-foxglove-bridge#286


